### PR TITLE
Add conda recipe for local fastvep/fastvep-web builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ echtvar/
 target/
 .DS_Store
 
+# Conda build artifacts
+conda/recipe/build/
+conda-bld/
+
 # Large data (downloaded via benchmarks/download_data.sh)
 test_data/
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ fastvep --version
 > source "$HOME/.cargo/env"
 > ```
 
+#### Alternative: build a conda package
+
+Prefer conda? The repo ships a recipe under `conda/recipe/` that builds both `fastvep` and `fastvep-web` into a local conda package (Linux and macOS):
+
+```bash
+# One-time: tools for building conda packages
+conda install -n base -c conda-forge conda-build
+
+# Build the package from the repo root
+conda build conda/recipe
+
+# Install into a fresh environment
+conda create -n fastvep -c local fastvep
+conda activate fastvep
+fastvep --version
+```
+
 ### 3. Try it — annotate the included test data
 
 fastVEP ships with a small test VCF and GFF3 so you can try it immediately:

--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep cargo's registry/cache inside the build sandbox.
+export CARGO_HOME="${SRC_DIR}/.cargo"
+
+# Build and install both workspace binaries into $PREFIX/bin/.
+cargo install --locked --no-track \
+    --path crates/fastvep-cli \
+    --root "${PREFIX}"
+
+cargo install --locked --no-track \
+    --path crates/fastvep-web \
+    --root "${PREFIX}"

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "fastvep" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # Build against the working tree in this repo. Run `conda build conda/recipe`
+  # from the repo root.
+  path: ../..
+  # For a future bioconda / conda-forge submission, replace the `path:` entry
+  # above with the tagged release tarball:
+  #
+  # url: https://github.com/Huang-lab/fastVEP/archive/refs/tags/v{{ version }}.tar.gz
+  # sha256: <fill-in-on-release>
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - make
+  run:
+
+test:
+  commands:
+    - fastvep --version
+    - fastvep --help
+    - fastvep-web --help
+
+about:
+  home: https://github.com/Huang-lab/fastVEP
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE.md
+  summary: A high-performance variant effect predictor with clinical database integration, written in Rust
+  description: |
+    fastVEP predicts the functional consequences of genomic variants (SNPs,
+    insertions, deletions, structural variants) on genes, transcripts, and
+    protein sequences, with direct integration of clinical and population
+    databases (ClinVar, gnomAD, dbSNP, COSMIC, 1000 Genomes, TOPMed,
+    MitoMap). It is inspired by Ensembl VEP and Illumina Nirvana and ships
+    both a CLI (`fastvep`) and a production web server (`fastvep-web`).
+  dev_url: https://github.com/Huang-lab/fastVEP
+  doc_url: https://github.com/Huang-lab/fastVEP
+
+extra:
+  recipe-maintainers:
+    - Huang-lab


### PR DESCRIPTION
## Summary
- Adds `conda/recipe/meta.yaml` and `conda/recipe/build.sh` so contributors can build both `fastvep` (CLI) and `fastvep-web` (server) binaries with `conda build conda/recipe`.
- Documents the conda-build flow in the README as an alternative to `cargo install`.
- Ignores local `conda-bld/` and `conda/recipe/build/` output so they do not leak into commits.

This recipe uses a local `path:` source and is intended for contributor convenience. The bioconda submission uses a separate URL-based recipe in `bioconda/bioconda-recipes`.

## Test plan
- [ ] `conda build conda/recipe` produces installable `fastvep` and `fastvep-web` binaries locally (Linux/macOS)
- [ ] `fastvep --version` / `fastvep-web --help` succeed from the installed package
