### PR TITLE
fix: prevent path traversal in resolve_genome_paths

### DIFF
--- a/crates/fastvep-web/src/handlers.rs
+++ b/crates/fastvep-web/src/handlers.rs
@@ -314,6 +314,14 @@ fn resolve_genome_paths(
     data_dir: &std::path::Path,
     name: &str,
 ) -> Result<(PathBuf, Option<PathBuf>), AppError> {
+    // Sanitize: reject any name containing path separators or traversal sequences
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(AppError::BadRequest(format!(
+            "Genome '{}' not found in data directory",
+            name
+        )));
+    }
+
     // Check if it's a subdirectory
     let subdir = data_dir.join(name);
     if subdir.is_dir() {


### PR DESCRIPTION
The name field in /api/load-genome was passed directly to data_dir.join(name) without sanitization, allowing callers to reference directories outside data_dir via sequences like '../../../etc'.

The two distinct error messages returned by the server also leaked filesystem information (directory oracle).

Fix: reject any name containing '/', '\', or '..' before path joining.