### PR TITLE
feat(classification): align PP3/BP4 with ClinGen SVI (Pejaver 2022 + Walker 2023)

### DIFF
--- a/analysis/acmg_benchmark/METHODS.md
+++ b/analysis/acmg_benchmark/METHODS.md
@@ -202,7 +202,7 @@ pp3_revel_strong = 0.932
 bp4_revel_supporting = 0.290
 bp4_revel_moderate = 0.183
 bp4_revel_strong = 0.016
-bp4_revel_very_strong = 0.003  # Only REVEL reaches Very Strong (BP4_VeryStrong)
+bp4_revel_very_strong = 0.003  # Only REVEL reaches Very Strong (BP4_Very_Strong)
 
 # SpliceAI thresholds (Walker 2023; SpliceAI alone caps at Supporting)
 spliceai_pathogenic = 0.2  # PP3 Supporting threshold (any consequence)

--- a/analysis/acmg_benchmark/METHODS.md
+++ b/analysis/acmg_benchmark/METHODS.md
@@ -25,7 +25,7 @@ Of the 28 ACMG-AMP criteria, 18 are fully automatable from variant-level data an
 | PM5 | Moderate | Novel missense at known pathogenic position | ClinVar protein-position index |
 | PM6 | Moderate | Assumed de novo (partial trio) | VCF genotype (proband + ≥1 parent) |
 | PP2 | Supporting | Missense in constrained gene | gnomAD gene constraints (missense Z-score ≥ 3.09) |
-| PP3 | Supporting+ | Computational deleterious evidence | REVEL (ClinGen SVI calibrated), SpliceAI, SIFT/PolyPhen, PhyloP, GERP |
+| PP3 | Supporting+ | Computational deleterious evidence | REVEL (missense only, ClinGen SVI calibrated) or SpliceAI ≥ 0.2 (Supporting only, Walker 2023) |
 
 **Benign Criteria (7 automated):**
 
@@ -36,7 +36,7 @@ Of the 28 ACMG-AMP criteria, 18 are fully automatable from variant-level data an
 | BS2 | Strong | Observed in healthy adults | gnomAD homozygote count + OMIM inheritance |
 | BP1 | Supporting | Missense in truncation-disease gene | gnomAD gene constraints (pLI + misZ) |
 | BP3 | Supporting | In-frame indel in repeat region | Consequence + RepeatMasker |
-| BP4 | Supporting+ | Computational benign evidence | REVEL (ClinGen SVI calibrated), SIFT/PolyPhen, PhyloP |
+| BP4 | Supporting+ | Computational benign evidence | REVEL (missense only, calibrated incl. Very Strong band) or SpliceAI ≤ 0.1 (Supporting only, Walker 2023) |
 | BP7 | Supporting | Synonymous, no splice, not conserved | Consequence + SpliceAI + PhyloP |
 
 *PM2 downgraded from Moderate to Supporting per ClinGen SVI recommendation.
@@ -47,7 +47,10 @@ PS3/BS3 (functional studies), PP1/BS4 (segregation), PP4 (phenotype), PP5/BP6 (r
 
 ### ClinGen SVI Calibrated REVEL Thresholds
 
-PP3 (pathogenic computational evidence) uses calibrated thresholds from Pejaver et al. 2022:
+REVEL is applied **only to missense variants** per Pejaver et al. 2022 — the
+calibration is not endorsed for non-missense consequences. Calibrated bands:
+
+PP3 (pathogenic computational evidence):
 - **Supporting**: REVEL ≥ 0.644
 - **Moderate**: REVEL ≥ 0.773
 - **Strong**: REVEL ≥ 0.932
@@ -56,16 +59,26 @@ BP4 (benign computational evidence):
 - **Supporting**: REVEL ≤ 0.290
 - **Moderate**: REVEL ≤ 0.183 (counts as Benign Strong in combination rules)
 - **Strong**: REVEL ≤ 0.016
+- **Very Strong**: REVEL ≤ 0.003 (counts as 2 BS — sufficient to reach Benign on its own per Tavtigian Bayesian framework)
+
+Pejaver 2022 explicitly recommends a single calibrated tool over ad-hoc
+ensembles, so the previous SIFT/PolyPhen/PhyloP/GERP ≥3-of-4 (PP3) and ≥2-of-3
+(BP4) consensus paths have been removed. Those scores are still recorded in
+the criterion `details` for transparency.
 
 ### SpliceAI Integration
 
-PP3 also evaluates SpliceAI delta scores for splice impact:
-- **Supporting**: max delta score ≥ 0.2
-- **Strong**: max delta score ≥ 0.8
+Per Walker et al. 2023 (ClinGen SVI Splicing Subgroup), SpliceAI predictions
+contribute at *Supporting* strength only — Strong splicing claims require
+experimental RNA evidence (PVS1_RNA / PS3).
+
+- **PP3 Supporting**: max delta score ≥ 0.2 (any consequence)
+- **BP4 Supporting**: max delta score ≤ 0.1 (any consequence)
+- **Uninformative zone**: 0.1 < max_ds < 0.2 (neither PP3 nor BP4 fires)
 
 ### Combination Rules
 
-18 combination rules determine the final classification, applied in order:
+19 combination rules determine the final classification, applied in order. This includes the 18 rules from Richards et al. 2015 plus one novel rule from the ClinGen SVI Working Group (September 2020).
 
 **Benign (2 rules):**
 1. BA1 standalone (any BA criterion met)
@@ -84,17 +97,26 @@ PP3 also evaluates SpliceAI delta scores for splice impact:
 10. 1 PS + 2 PM + ≥2 PP
 11. 1 PS + 1 PM + ≥4 PP
 
-**Likely Pathogenic (6 rules):**
+**Likely Pathogenic (7 rules):**
 12. PVS + 1 PM
-13. 1 PS + 1–2 PM
-14. 1 PS + ≥2 PP
-15. ≥3 PM
-16. 2 PM + ≥2 PP
-17. 1 PM + ≥4 PP
+13. **PVS + ≥1 PP** *(ClinGen SVI novel rule, Sept 2020)*
+14. 1 PS + 1–2 PM
+15. 1 PS + ≥2 PP
+16. ≥3 PM
+17. 2 PM + ≥2 PP
+18. 1 PM + ≥4 PP
 
 **Likely Benign (2 rules):**
-18. 1 BS + 1 BP
-19. ≥2 BP
+19. 1 BS + 1 BP
+20. ≥2 BP
+
+### ClinGen SVI PVS + PP Rule
+
+Rule 13 (PVS + ≥1 PP → Likely Pathogenic) is a novel combination not listed in the original 2015 ACMG/AMP guidelines. It was proposed by the ClinGen SVI Working Group in their *SVI Recommendation for Absence/Rarity (PM2) — Version 1.0* (approved September 4, 2020) to compensate for the PM2 downgrade from Moderate to Supporting strength.
+
+The SVI rationale: rarity is given too much weight in the 2015 framework — 99% of ExAC variants have frequency <1%, 54% are singletons, and all individuals harbor variants absent from the rest of the population (Lek et al. 2016, PMID:27535533). The odds of pathogenicity for rare/absent-from-controls evidence do not meet the 4.33:1 threshold for Moderate strength (Tavtigian et al. 2018, PMID:29300386).
+
+Without this rule, PVS1 + PM2_Supporting (the most common evidence combination for loss-of-function variants in disease genes) would fall to VUS — PVS + 1 PP does not match any combination in the original 2015 rules. The SVI demonstrated via Bayesian modeling that PVS + 1 PP yields a posterior probability of pathogenicity of 0.988, which falls within the Likely Pathogenic range (0.90–0.99), justifying this addition.
 
 ### Trio Analysis
 
@@ -173,13 +195,18 @@ ba1_af_threshold = 0.05
 bs1_af_threshold = 0.01
 pm2_af_threshold = 0.0001
 
-# REVEL thresholds (ClinGen SVI calibrated)
+# REVEL thresholds (ClinGen SVI calibrated, Pejaver 2022; missense only)
 pp3_revel_supporting = 0.644
 pp3_revel_moderate = 0.773
 pp3_revel_strong = 0.932
 bp4_revel_supporting = 0.290
 bp4_revel_moderate = 0.183
 bp4_revel_strong = 0.016
+bp4_revel_very_strong = 0.003  # Only REVEL reaches Very Strong (BP4_VeryStrong)
+
+# SpliceAI thresholds (Walker 2023; SpliceAI alone caps at Supporting)
+spliceai_pathogenic = 0.2  # PP3 Supporting threshold (any consequence)
+spliceai_benign = 0.1      # BP4 Supporting threshold; 0.1-0.2 is uninformative
 
 # Gene constraint thresholds
 pli_lof_intolerant = 0.9
@@ -199,5 +226,8 @@ bs1_af_threshold = 0.001
 ## References
 
 - Richards S, et al. Standards and guidelines for the interpretation of sequence variants. *Genet Med*. 2015;17(5):405-424.
+- ClinGen Sequence Variant Interpretation Working Group. SVI Recommendation for Absence/Rarity (PM2) — Version 1.0. Approved September 4, 2020. https://clinicalgenome.org/working-groups/sequence-variant-interpretation/
 - Pejaver V, et al. Calibration of computational tools for missense variant pathogenicity classification and ClinGen recommendations for PP3/BP4 criteria. *Am J Hum Genet*. 2022;109(12):2163-2177.
-- ClinGen Sequence Variant Interpretation Working Group. Recommendations for ACMG/AMP guideline criteria modifications.
+- Walker LC, et al. (ClinGen SVI Splicing Subgroup). Using the ACMG/AMP framework to capture evidence related to predicted and observed impact on splicing: Recommendations from the ClinGen SVI Splicing Subgroup. *Am J Hum Genet*. 2023;110(7):1046-1067.
+- Tavtigian SV, et al. Modeling the ACMG/AMP variant classification guidelines as a Bayesian classification framework. *Genet Med*. 2018;20(9):1054-1060. PMID:29300386.
+- Lek M, et al. Analysis of protein-coding genetic variation in 60,706 humans. *Nature*. 2016;536(7616):285-291. PMID:27535533.

--- a/analysis/acmg_benchmark/clinvar_concordance.py
+++ b/analysis/acmg_benchmark/clinvar_concordance.py
@@ -172,7 +172,7 @@ PRIORS = {
     "pp3_supporting_if_path_missense": 0.35,
 
     # For benign missense (with the Pejaver 2022 Very Strong band added):
-    #   ~5%  get BP4_VeryStrong (REVEL <= 0.003) — only REVEL reaches this band
+    #   ~5%  get BP4_Very_Strong (REVEL <= 0.003) — only REVEL reaches this band
     #   ~25% get BP4_Strong (0.003 < REVEL <= 0.016)
     #   ~30% get BP4_Moderate (0.016-0.183)
     #   ~25% get BP4_Supporting (0.183-0.290)
@@ -312,9 +312,9 @@ def simulate_for_variant(consequence, clinvar_sig, stars, seed=None):
             m_thr = s_thr + PRIORS["bp4_moderate_if_benign_missense"]
             sup_thr = m_thr + PRIORS["bp4_supporting_if_benign_missense"]
             if r < vs_thr:
-                # BP4_VeryStrong → counts as 2 BS (per types.rs), enough to call Benign on its own
+                # BP4_Very_Strong → counts as 2 BS (per types.rs), enough to call Benign on its own
                 bs += 2
-                reasons.append("BP4_VeryStrong")
+                reasons.append("BP4_Very_Strong")
             elif r < s_thr:
                 bs += 1  # BP4_Strong counts as Benign Strong
                 reasons.append("BP4_Strong")

--- a/analysis/acmg_benchmark/clinvar_concordance.py
+++ b/analysis/acmg_benchmark/clinvar_concordance.py
@@ -160,8 +160,9 @@ PRIORS = {
     "pm2_if_vus": 0.80,
     "pm2_if_benign": 0.15,
 
-    # PP3/BP4 REVEL: ClinGen SVI calibrated thresholds
-    # For pathogenic missense (REVEL distributions from Pejaver et al.):
+    # PP3/BP4 REVEL: ClinGen SVI calibrated thresholds (Pejaver 2022).
+    # REVEL is applied ONLY to missense variants (Pejaver 2022 explicitly
+    # restricts the calibration to missense). For pathogenic missense:
     #   ~15% get PP3_Strong (REVEL >= 0.932)
     #   ~25% get PP3_Moderate (0.773-0.932)
     #   ~35% get PP3_Supporting (0.644-0.773)
@@ -170,12 +171,14 @@ PRIORS = {
     "pp3_moderate_if_path_missense": 0.25,
     "pp3_supporting_if_path_missense": 0.35,
 
-    # For benign missense:
-    #   ~30% get BP4_Strong (REVEL <= 0.016)
+    # For benign missense (with the Pejaver 2022 Very Strong band added):
+    #   ~5%  get BP4_VeryStrong (REVEL <= 0.003) — only REVEL reaches this band
+    #   ~25% get BP4_Strong (0.003 < REVEL <= 0.016)
     #   ~30% get BP4_Moderate (0.016-0.183)
     #   ~25% get BP4_Supporting (0.183-0.290)
     #   ~15% get nothing (REVEL > 0.290)
-    "bp4_strong_if_benign_missense": 0.30,
+    "bp4_very_strong_if_benign_missense": 0.05,
+    "bp4_strong_if_benign_missense": 0.25,
     "bp4_moderate_if_benign_missense": 0.30,
     "bp4_supporting_if_benign_missense": 0.25,
 
@@ -192,9 +195,19 @@ PRIORS = {
     "bs1_if_benign_no_ba1": 0.70,
     "bs1_if_lb_no_ba1": 0.55,
 
-    # PP3 SpliceAI for splice_canonical:
-    # ~90% of canonical splice variants have SpliceAI max_ds >= 0.8 (Strong)
-    "pp3_strong_if_splice_canonical": 0.90,
+    # PP3 SpliceAI: per Walker 2023 (ClinGen SVI Splicing Subgroup),
+    # SpliceAI alone tops out at PP3 *Supporting* (max_ds >= 0.2). It does not
+    # reach Strong even at very high delta scores; experimental RNA evidence is
+    # required for Strong splicing claims. ~90% of canonical splice variants
+    # exceed the Supporting threshold.
+    # NOTE: the actual classifier also fires PVS1 for canonical splice variants
+    # in LOF genes; the PP3 splice path here is to model the residual signal
+    # contributed by SpliceAI for non-canonical splice contexts.
+    "pp3_supporting_if_splice_canonical": 0.90,
+    # BP4 SpliceAI: per Walker 2023, max_ds <= 0.1 → BP4 Supporting for
+    # non-canonical splice context. ~70% of benign synonymous + intronic
+    # variants land in this band.
+    "bp4_supporting_if_splice_low": 0.70,
 
     # BP7: synonymous + no splice + not conserved
     # ~75% of synonymous variants have low SpliceAI + low PhyloP
@@ -294,24 +307,35 @@ def simulate_for_variant(consequence, clinvar_sig, stars, seed=None):
                 reasons.append("PP3_Supp")
         elif is_benign:
             r = rng.random()
-            if r < PRIORS["bp4_strong_if_benign_missense"]:
+            vs_thr = PRIORS["bp4_very_strong_if_benign_missense"]
+            s_thr = vs_thr + PRIORS["bp4_strong_if_benign_missense"]
+            m_thr = s_thr + PRIORS["bp4_moderate_if_benign_missense"]
+            sup_thr = m_thr + PRIORS["bp4_supporting_if_benign_missense"]
+            if r < vs_thr:
+                # BP4_VeryStrong → counts as 2 BS (per types.rs), enough to call Benign on its own
+                bs += 2
+                reasons.append("BP4_VeryStrong")
+            elif r < s_thr:
                 bs += 1  # BP4_Strong counts as Benign Strong
                 reasons.append("BP4_Strong")
-            elif r < (PRIORS["bp4_strong_if_benign_missense"] +
-                      PRIORS["bp4_moderate_if_benign_missense"]):
+            elif r < m_thr:
                 bs += 1  # BP4_Moderate counts as Benign Strong (per types.rs)
                 reasons.append("BP4_Mod")
-            elif r < (PRIORS["bp4_strong_if_benign_missense"] +
-                      PRIORS["bp4_moderate_if_benign_missense"] +
-                      PRIORS["bp4_supporting_if_benign_missense"]):
+            elif r < sup_thr:
                 bp += 1
                 reasons.append("BP4_Supp")
 
-    # ── PP3 SpliceAI for splice variants ──
+    # ── PP3/BP4 SpliceAI ──
+    # Per Walker 2023, SpliceAI tops out at PP3 Supporting (no Strong from
+    # SpliceAI alone). For non-canonical splice context, SpliceAI ≤ 0.1 → BP4 Supporting.
     if consequence == "splice_canonical":
-        if rng.random() < PRIORS["pp3_strong_if_splice_canonical"]:
-            ps += 1
-            reasons.append("PP3_Strong_splice")
+        if rng.random() < PRIORS["pp3_supporting_if_splice_canonical"]:
+            pp += 1
+            reasons.append("PP3_Supp_splice")
+    elif consequence in ("synonymous", "intron", "splice_region") and is_benign:
+        if rng.random() < PRIORS["bp4_supporting_if_splice_low"]:
+            bp += 1
+            reasons.append("BP4_Supp_splice")
 
     # ── BA1: common variant ──
     if clinvar_sig == "Benign":
@@ -344,7 +368,12 @@ def simulate_for_variant(consequence, clinvar_sig, stars, seed=None):
 
 
 def apply_combination_rules(pvs, ps, pm, pp, ba, bs, bp):
-    """Apply ACMG combination rules (matches Rust combiner.rs exactly)."""
+    """Apply ACMG combination rules (matches Rust combiner.rs exactly).
+
+    Includes the ClinGen SVI novel rule (Sept 2020): PVS + >=1 PP → LP.
+    This compensates for PM2 downgrade to Supporting, ensuring PVS1 +
+    PM2_Supporting still reaches LP (Bayesian Post_P = 0.988).
+    """
     # Benign
     if ba >= 1:
         return "Benign"
@@ -375,8 +404,10 @@ def apply_combination_rules(pvs, ps, pm, pp, ba, bs, bp):
     if ps >= 1 and pm >= 1 and pp >= 4:
         return "Pathogenic"
 
-    # Likely Pathogenic (6 rules)
+    # Likely Pathogenic (7 rules, includes ClinGen SVI PVS+PP rule)
     if pvs >= 1 and pm >= 1:
+        return "Likely_pathogenic"
+    if pvs >= 1 and pp >= 1:  # ClinGen SVI novel rule (Sept 2020)
         return "Likely_pathogenic"
     if ps >= 1 and 1 <= pm <= 2:
         return "Likely_pathogenic"

--- a/crates/fastvep-classification/src/combiner.rs
+++ b/crates/fastvep-classification/src/combiner.rs
@@ -8,9 +8,14 @@ use crate::types::{AcmgClassification, EvidenceCounts, EvidenceCriterion};
 /// 1. Benign (BA1 standalone, or >=2 BS)
 /// 2. Check for conflicting evidence (pathogenic + benign criteria both met -> VUS)
 /// 3. Pathogenic (8 combinations)
-/// 4. Likely Pathogenic (6 combinations)
+/// 4. Likely Pathogenic (7 combinations, includes ClinGen SVI PVS+PP rule)
 /// 5. Likely Benign (BS+BP, or >=2 BP)
 /// 6. Default: VUS
+///
+/// Note: Includes the ClinGen SVI novel combination rule (Sept 2020) that
+/// PVS + >=1 PP → Likely Pathogenic. This rule was added to compensate for
+/// the PM2 downgrade to Supporting, ensuring that PVS1 + PM2_Supporting
+/// still reaches LP (Bayesian Post_P = 0.988, within LP range 0.90–0.99).
 pub fn combine(criteria: &[EvidenceCriterion]) -> (AcmgClassification, Option<String>) {
     let counts = EvidenceCounts::from_criteria(criteria);
 
@@ -89,11 +94,20 @@ pub fn combine(criteria: &[EvidenceCriterion]) -> (AcmgClassification, Option<St
         );
     }
 
-    // ── Likely Pathogenic (6 combinations) ──
+    // ── Likely Pathogenic (7 combinations) ──
     if pvs >= 1 && pm >= 1 {
         return (
             AcmgClassification::LikelyPathogenic,
             Some("PVS + PM".to_string()),
+        );
+    }
+    // ClinGen SVI novel rule (Sept 2020): PVS + >=1 PP → LP
+    // Bayesian Post_P = 0.988, within LP range (0.90–0.99).
+    // Compensates for PM2 downgrade to Supporting, so PVS1 + PM2_Supporting → LP.
+    if pvs >= 1 && pp >= 1 {
+        return (
+            AcmgClassification::LikelyPathogenic,
+            Some("PVS + >=1 PP (SVI)".to_string()),
         );
     }
     if ps >= 1 && (1..=2).contains(&pm) {
@@ -336,6 +350,21 @@ mod tests {
         let (cls, rule) = combine(&criteria);
         assert_eq!(cls, AcmgClassification::LikelyPathogenic);
         assert_eq!(rule.unwrap(), "2 PM + >=2 PP");
+    }
+
+    // ── ClinGen SVI PVS + PP Rule ──
+
+    #[test]
+    fn test_pvs_plus_pp_likely_pathogenic_svi() {
+        // ClinGen SVI (Sept 2020): PVS + >=1 PP → LP
+        // This is the key rule for PVS1 + PM2_Supporting
+        let criteria = vec![
+            met("PVS1", Pathogenic, VeryStrong),
+            met("PM2_Supporting", Pathogenic, Supporting),
+        ];
+        let (cls, rule) = combine(&criteria);
+        assert_eq!(cls, AcmgClassification::LikelyPathogenic);
+        assert_eq!(rule.unwrap(), "PVS + >=1 PP (SVI)");
     }
 
     // ── Likely Benign Rules ──

--- a/crates/fastvep-classification/src/config.rs
+++ b/crates/fastvep-classification/src/config.rs
@@ -60,14 +60,22 @@ pub struct AcmgConfig {
     /// BP4 strong threshold (default: 0.016)
     #[serde(default = "default_bp4_strong")]
     pub bp4_revel_strong: f64,
+    /// BP4 very strong threshold (default: 0.003) — Pejaver 2022 endorses
+    /// REVEL ≤ 0.003 as Very Strong benign evidence; only REVEL reaches this band.
+    #[serde(default = "default_bp4_very_strong")]
+    pub bp4_revel_very_strong: f64,
 
     // ── SpliceAI thresholds ──
-    /// SpliceAI delta score threshold for pathogenic splice impact (default: 0.2)
+    /// SpliceAI delta score threshold for PP3 pathogenic splice impact (default: 0.2).
+    /// Per Walker 2023 SVI Splicing Subgroup, ≥ 0.2 yields PP3 at *Supporting* strength only.
+    /// SpliceAI alone does not reach Strong — that requires experimental RNA assay (PVS1_RNA).
     #[serde(default = "default_spliceai_pathogenic")]
     pub spliceai_pathogenic: f64,
-    /// SpliceAI delta score threshold for strong splice impact (default: 0.8)
-    #[serde(default = "default_spliceai_strong")]
-    pub spliceai_strong: f64,
+    /// SpliceAI delta score upper bound for BP4 benign splice impact (default: 0.1).
+    /// Per Walker 2023 SVI Splicing Subgroup, ≤ 0.1 yields BP4 at Supporting strength.
+    /// Scores between 0.1 and 0.2 are uninformative.
+    #[serde(default = "default_spliceai_benign")]
+    pub spliceai_benign: f64,
 
     // ── Conservation thresholds ──
     /// PhyloP threshold for conserved position (default: 2.0)
@@ -143,8 +151,9 @@ impl Default for AcmgConfig {
             bp4_revel_supporting: 0.290,
             bp4_revel_moderate: 0.183,
             bp4_revel_strong: 0.016,
+            bp4_revel_very_strong: 0.003,
             spliceai_pathogenic: 0.2,
-            spliceai_strong: 0.8,
+            spliceai_benign: 0.1,
             phylop_conserved: 2.0,
             gerp_conserved: 2.0,
             pli_lof_intolerant: 0.9,
@@ -211,8 +220,9 @@ fn default_pp3_strong() -> f64 { 0.932 }
 fn default_bp4_supporting() -> f64 { 0.290 }
 fn default_bp4_moderate() -> f64 { 0.183 }
 fn default_bp4_strong() -> f64 { 0.016 }
+fn default_bp4_very_strong() -> f64 { 0.003 }
 fn default_spliceai_pathogenic() -> f64 { 0.2 }
-fn default_spliceai_strong() -> f64 { 0.8 }
+fn default_spliceai_benign() -> f64 { 0.1 }
 fn default_phylop() -> f64 { 2.0 }
 fn default_gerp() -> f64 { 2.0 }
 fn default_pli() -> f64 { 0.9 }

--- a/crates/fastvep-classification/src/criteria/benign_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/benign_supporting.rs
@@ -286,8 +286,8 @@ fn evaluate_bp3(
 /// remain in `details` for transparency.
 ///
 /// Per Walker 2023 (ClinGen SVI Splicing Subgroup): SpliceAI ≤ 0.1 yields BP4
-/// at Supporting strength for non-canonical splice context (scores between 0.1
-/// and 0.2 are uninformative).
+/// at Supporting strength when a SpliceAI score is available (scores between
+/// 0.1 and 0.2 are uninformative).
 fn evaluate_bp4(
     input: &ClassificationInput,
     config: &AcmgConfig,

--- a/crates/fastvep-classification/src/criteria/benign_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/benign_supporting.rs
@@ -277,8 +277,17 @@ fn evaluate_bp3(
 
 /// BP4: Multiple lines of computational evidence suggest no impact on gene or gene product.
 ///
-/// Uses ClinGen SVI calibrated REVEL thresholds. BP4 can be elevated to Moderate or
-/// Strong strength based on REVEL score.
+/// Per ClinGen SVI calibration (Pejaver et al. 2022, AJHG): REVEL is applied
+/// only to **missense** variants and uses calibrated bands for Supporting /
+/// Moderate / Strong / Very Strong. The Very Strong band (REVEL ≤ 0.003) is
+/// reached only by REVEL among the 13 calibrated tools. Pejaver explicitly
+/// recommends a single calibrated tool over ad-hoc consensus, so the previous
+/// SIFT/PolyPhen/PhyloP ≥2-of-3 consensus path has been removed; those scores
+/// remain in `details` for transparency.
+///
+/// Per Walker 2023 (ClinGen SVI Splicing Subgroup): SpliceAI ≤ 0.1 yields BP4
+/// at Supporting strength for non-canonical splice context (scores between 0.1
+/// and 0.2 are uninformative).
 fn evaluate_bp4(
     input: &ClassificationInput,
     config: &AcmgConfig,
@@ -286,72 +295,101 @@ fn evaluate_bp4(
     let mut details = serde_json::Map::new();
     let mut evidence_lines: Vec<String> = Vec::new();
 
-    // Primary: REVEL score (ClinGen SVI calibrated thresholds)
-    let (revel_met, revel_strength) = if let Some(ref revel) = input.revel {
-        if let Some(score) = revel.score {
-            details.insert("revel_score".into(), serde_json::json!(score));
-            if score <= config.bp4_revel_strong {
-                evidence_lines.push(format!("REVEL={:.3} (Strong benign)", score));
-                (true, Some(EvidenceStrength::Strong))
-            } else if score <= config.bp4_revel_moderate {
-                evidence_lines.push(format!("REVEL={:.3} (Moderate benign)", score));
-                (true, Some(EvidenceStrength::Moderate))
-            } else if score <= config.bp4_revel_supporting {
-                evidence_lines.push(format!("REVEL={:.3} (Supporting benign)", score));
-                (true, Some(EvidenceStrength::Supporting))
+    let is_missense = input
+        .consequences
+        .iter()
+        .any(|c| matches!(c, Consequence::MissenseVariant));
+    details.insert("is_missense".into(), serde_json::json!(is_missense));
+
+    // Primary missense path: REVEL with calibrated bands (Pejaver 2022),
+    // including the Very Strong band (REVEL ≤ 0.003) which only REVEL reaches.
+    let (revel_met, revel_strength) = if is_missense {
+        if let Some(ref revel) = input.revel {
+            if let Some(score) = revel.score {
+                details.insert("revel_score".into(), serde_json::json!(score));
+                if score <= config.bp4_revel_very_strong {
+                    evidence_lines.push(format!("REVEL={:.3} (Very Strong benign)", score));
+                    (true, Some(EvidenceStrength::VeryStrong))
+                } else if score <= config.bp4_revel_strong {
+                    evidence_lines.push(format!("REVEL={:.3} (Strong benign)", score));
+                    (true, Some(EvidenceStrength::Strong))
+                } else if score <= config.bp4_revel_moderate {
+                    evidence_lines.push(format!("REVEL={:.3} (Moderate benign)", score));
+                    (true, Some(EvidenceStrength::Moderate))
+                } else if score <= config.bp4_revel_supporting {
+                    evidence_lines.push(format!("REVEL={:.3} (Supporting benign)", score));
+                    (true, Some(EvidenceStrength::Supporting))
+                } else {
+                    evidence_lines.push(format!("REVEL={:.3} (above benign threshold)", score));
+                    (false, None)
+                }
             } else {
-                evidence_lines.push(format!("REVEL={:.3} (above benign threshold)", score));
                 (false, None)
             }
         } else {
             (false, None)
         }
     } else {
+        if let Some(ref revel) = input.revel {
+            if let Some(score) = revel.score {
+                details.insert("revel_score".into(), serde_json::json!(score));
+                details.insert(
+                    "revel_skipped_reason".into(),
+                    serde_json::json!(
+                        "REVEL is calibrated for missense only (Pejaver 2022); not applied to non-missense consequences"
+                    ),
+                );
+            }
+        }
         (false, None)
     };
 
-    // Secondary: SIFT/PolyPhen/PhyloP consensus
-    let mut benign_votes = 0u8;
-    let mut computational_total = 0u8;
-
+    // Capture transparency-only secondary scores (no longer used for BP4 firing
+    // per Pejaver 2022 — single calibrated tool only).
     if let Some(ref dbnsfp) = input.dbnsfp {
         if let Some(sift) = dbnsfp.parse_sift() {
             details.insert("sift".into(), serde_json::json!(sift.prediction));
-            computational_total += 1;
-            if sift.prediction.contains("tolerated") && !sift.prediction.contains("deleterious") {
-                benign_votes += 1;
-                evidence_lines.push(format!("SIFT={}", sift.prediction));
-            }
         }
         if let Some(pp) = dbnsfp.parse_polyphen() {
             details.insert("polyphen".into(), serde_json::json!(pp.prediction));
-            computational_total += 1;
-            if pp.prediction == "benign" {
-                benign_votes += 1;
-                evidence_lines.push(format!("PolyPhen={}", pp.prediction));
-            }
         }
     }
-
     if let Some(phylop) = input.phylop {
         details.insert("phylop".into(), serde_json::json!(phylop));
-        computational_total += 1;
-        if phylop < 0.5 {
-            benign_votes += 1;
-            evidence_lines.push(format!("PhyloP={:.2} (not conserved)", phylop));
-        }
     }
 
-    // Determine final result
-    let (met, strength) = if revel_met {
-        (true, revel_strength.unwrap_or(EvidenceStrength::Supporting))
-    } else if computational_total >= 2 && benign_votes >= 2 {
-        (true, EvidenceStrength::Supporting)
+    // Splicing path: SpliceAI ≤ spliceai_benign → BP4 Supporting (Walker 2023).
+    let splice_supporting = if let Some(ref splice) = input.splice_ai {
+        if let Some(max_ds) = splice.max_delta_score() {
+            details.insert("spliceai_max_ds".into(), serde_json::json!(max_ds));
+            if max_ds <= config.spliceai_benign {
+                evidence_lines.push(format!(
+                    "SpliceAI max_ds={:.2} (Supporting benign per Walker 2023)",
+                    max_ds
+                ));
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
     } else {
-        (false, EvidenceStrength::Supporting)
+        false
     };
 
-    let evaluated = input.revel.is_some() || computational_total >= 2;
+    // Resolve final strength. REVEL (missense, already strength-graded) takes
+    // precedence over splice. If both fire, prefer the stronger.
+    let (met, strength) = match (revel_met, splice_supporting) {
+        (true, _) => (
+            true,
+            revel_strength.unwrap_or(EvidenceStrength::Supporting),
+        ),
+        (false, true) => (true, EvidenceStrength::Supporting),
+        (false, false) => (false, EvidenceStrength::Supporting),
+    };
+
+    let evaluated = (is_missense && input.revel.is_some()) || input.splice_ai.is_some();
     details.insert("evidence_lines".into(), serde_json::json!(evidence_lines));
 
     let summary = if met {
@@ -362,6 +400,8 @@ fn evaluate_bp4(
         )
     } else if evaluated {
         "Computational evidence does not support benign classification".to_string()
+    } else if !is_missense && input.splice_ai.is_none() {
+        "BP4 requires REVEL (missense) or SpliceAI; neither available".to_string()
     } else {
         "Insufficient computational prediction data".to_string()
     };
@@ -589,6 +629,69 @@ mod tests {
         let result = evaluate_bp4(&input, &AcmgConfig::default());
         assert!(result.met);
         assert_eq!(result.strength, EvidenceStrength::Strong);
+    }
+
+    #[test]
+    fn test_bp4_revel_very_strong_benign() {
+        // Pejaver 2022: REVEL ≤ 0.003 → Very Strong benign. Only REVEL reaches
+        // this band among the 13 calibrated tools.
+        let input = make_input(
+            vec![Consequence::MissenseVariant],
+            Some(0.002),
+            None,
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(result.met);
+        assert_eq!(result.strength, EvidenceStrength::VeryStrong);
+        assert_eq!(result.code, "BP4_Very_Strong");
+    }
+
+    #[test]
+    fn test_bp4_revel_ignored_for_non_missense() {
+        // REVEL is calibrated for missense only. A low REVEL score on a
+        // synonymous variant must NOT fire BP4 (BP7 is the synonymous code).
+        let input = make_input(
+            vec![Consequence::SynonymousVariant],
+            Some(0.001),
+            None,
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(!result.met);
+    }
+
+    #[test]
+    fn test_bp4_spliceai_low_supporting() {
+        // Walker 2023: SpliceAI ≤ 0.1 → BP4 Supporting for non-canonical
+        // splice context. Non-missense variant with low SpliceAI alone fires.
+        let input = make_input(
+            vec![Consequence::IntronVariant],
+            None,
+            Some(0.05),
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(result.met);
+        assert_eq!(result.strength, EvidenceStrength::Supporting);
+    }
+
+    #[test]
+    fn test_bp4_spliceai_uninformative_zone() {
+        // Walker 2023: SpliceAI scores 0.10 < ds < 0.20 are uninformative —
+        // BP4 must not fire and PP3 (splice) must not fire.
+        let input = make_input(
+            vec![Consequence::IntronVariant],
+            None,
+            Some(0.15),
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(!result.met);
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/pathogenic_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_supporting.rs
@@ -109,8 +109,17 @@ fn evaluate_pp2(
 
 /// PP3: Multiple lines of computational evidence support a deleterious effect.
 ///
-/// Uses ClinGen SVI calibrated REVEL thresholds. PP3 can be elevated to
-/// Moderate or Strong strength based on REVEL score.
+/// Per ClinGen SVI calibration (Pejaver et al. 2022, AJHG): REVEL is applied
+/// only to **missense** variants and uses calibrated bands for Supporting /
+/// Moderate / Strong. Pejaver explicitly recommends a single calibrated tool
+/// rather than ad-hoc consensus across SIFT/PolyPhen/PhyloP/GERP, so the
+/// previous ≥3-of-4 consensus path has been removed; those scores are still
+/// captured in `details` for transparency.
+///
+/// Per Walker 2023 (ClinGen SVI Splicing Subgroup): SpliceAI ≥ 0.2 yields
+/// PP3 at *Supporting* strength only. SpliceAI alone does not reach Strong;
+/// experimental RNA evidence (PVS1_RNA / PS3) is required for Strong splicing
+/// claims.
 fn evaluate_pp3(
     input: &ClassificationInput,
     config: &AcmgConfig,
@@ -118,108 +127,106 @@ fn evaluate_pp3(
     let mut details = serde_json::Map::new();
     let mut evidence_lines: Vec<String> = Vec::new();
 
-    // Primary: REVEL score (ClinGen SVI calibrated thresholds)
-    let (revel_met, revel_strength) = if let Some(ref revel) = input.revel {
-        if let Some(score) = revel.score {
-            details.insert("revel_score".into(), serde_json::json!(score));
-            if score >= config.pp3_revel_strong {
-                evidence_lines.push(format!("REVEL={:.3} (Strong)", score));
-                (true, Some(EvidenceStrength::Strong))
-            } else if score >= config.pp3_revel_moderate {
-                evidence_lines.push(format!("REVEL={:.3} (Moderate)", score));
-                (true, Some(EvidenceStrength::Moderate))
-            } else if score >= config.pp3_revel_supporting {
-                evidence_lines.push(format!("REVEL={:.3} (Supporting)", score));
-                (true, Some(EvidenceStrength::Supporting))
+    let is_missense = input
+        .consequences
+        .iter()
+        .any(|c| matches!(c, Consequence::MissenseVariant));
+    details.insert("is_missense".into(), serde_json::json!(is_missense));
+
+    // Primary missense path: REVEL with calibrated bands (Pejaver 2022).
+    // Only applied to missense variants — REVEL is undefined / uncalibrated for
+    // other consequence types.
+    let (revel_met, revel_strength) = if is_missense {
+        if let Some(ref revel) = input.revel {
+            if let Some(score) = revel.score {
+                details.insert("revel_score".into(), serde_json::json!(score));
+                if score >= config.pp3_revel_strong {
+                    evidence_lines.push(format!("REVEL={:.3} (Strong)", score));
+                    (true, Some(EvidenceStrength::Strong))
+                } else if score >= config.pp3_revel_moderate {
+                    evidence_lines.push(format!("REVEL={:.3} (Moderate)", score));
+                    (true, Some(EvidenceStrength::Moderate))
+                } else if score >= config.pp3_revel_supporting {
+                    evidence_lines.push(format!("REVEL={:.3} (Supporting)", score));
+                    (true, Some(EvidenceStrength::Supporting))
+                } else {
+                    evidence_lines.push(format!("REVEL={:.3} (below threshold)", score));
+                    (false, None)
+                }
             } else {
-                evidence_lines.push(format!("REVEL={:.3} (below threshold)", score));
                 (false, None)
             }
         } else {
             (false, None)
         }
     } else {
+        if let Some(ref revel) = input.revel {
+            if let Some(score) = revel.score {
+                details.insert("revel_score".into(), serde_json::json!(score));
+                details.insert(
+                    "revel_skipped_reason".into(),
+                    serde_json::json!(
+                        "REVEL is calibrated for missense only (Pejaver 2022); not applied to non-missense consequences"
+                    ),
+                );
+            }
+        }
         (false, None)
     };
 
-    // Secondary: SIFT/PolyPhen/PhyloP/GERP consensus (when REVEL unavailable)
-    let mut computational_votes = 0u8;
-    let mut computational_total = 0u8;
-
+    // Capture transparency-only secondary scores (no longer used for PP3 firing
+    // per Pejaver 2022 — single calibrated tool only).
     if let Some(ref dbnsfp) = input.dbnsfp {
         if let Some(sift) = dbnsfp.parse_sift() {
             details.insert("sift".into(), serde_json::json!(sift.prediction));
-            computational_total += 1;
-            if sift.prediction.contains("deleterious") && !sift.prediction.contains("tolerated") {
-                computational_votes += 1;
-                evidence_lines.push(format!("SIFT={}", sift.prediction));
-            }
         }
         if let Some(pp) = dbnsfp.parse_polyphen() {
             details.insert("polyphen".into(), serde_json::json!(pp.prediction));
-            computational_total += 1;
-            if pp.prediction.contains("damaging") {
-                computational_votes += 1;
-                evidence_lines.push(format!("PolyPhen={}", pp.prediction));
-            }
         }
     }
-
     if let Some(phylop) = input.phylop {
         details.insert("phylop".into(), serde_json::json!(phylop));
-        computational_total += 1;
-        if phylop > config.phylop_conserved {
-            computational_votes += 1;
-            evidence_lines.push(format!("PhyloP={:.2} (conserved)", phylop));
-        }
     }
-
     if let Some(gerp) = input.gerp {
         details.insert("gerp".into(), serde_json::json!(gerp));
-        computational_total += 1;
-        if gerp > config.gerp_conserved {
-            computational_votes += 1;
-            evidence_lines.push(format!("GERP={:.2} (constrained)", gerp));
-        }
     }
 
-    // SpliceAI evidence (for variants near splice sites)
-    if let Some(ref splice) = input.splice_ai {
+    // Splicing path: SpliceAI ≥ spliceai_pathogenic → PP3 Supporting.
+    // Per Walker 2023, SpliceAI alone does not reach Strong even at very high
+    // delta scores; that requires experimental RNA evidence (PVS1_RNA / PS3).
+    let splice_supporting = if let Some(ref splice) = input.splice_ai {
         if let Some(max_ds) = splice.max_delta_score() {
             details.insert("spliceai_max_ds".into(), serde_json::json!(max_ds));
             if max_ds >= config.spliceai_pathogenic {
-                evidence_lines.push(format!("SpliceAI max_ds={:.2}", max_ds));
+                evidence_lines.push(format!(
+                    "SpliceAI max_ds={:.2} (Supporting per Walker 2023)",
+                    max_ds
+                ));
+                true
+            } else {
+                false
             }
+        } else {
+            false
         }
-    }
+    } else {
+        false
+    };
 
-    // Determine final result
+    // Resolve final strength.
+    // - REVEL (missense) takes precedence and is already strength-graded.
+    // - Otherwise, SpliceAI Supporting may fire for any consequence (canonical
+    //   splice variants typically also fire PVS1; anti-double-counting between
+    //   PP3 and PVS1 for splice is handled in PR2).
     let (met, strength) = if revel_met {
         (true, revel_strength.unwrap_or(EvidenceStrength::Supporting))
-    } else if computational_total >= 3 && computational_votes >= 3 {
-        // Consensus of at least 3 out of 4 computational tools
+    } else if splice_supporting {
         (true, EvidenceStrength::Supporting)
-    } else if let Some(ref splice) = input.splice_ai {
-        if splice
-            .max_delta_score()
-            .map_or(false, |ds| ds >= config.spliceai_strong)
-        {
-            (true, EvidenceStrength::Strong)
-        } else if splice
-            .max_delta_score()
-            .map_or(false, |ds| ds >= config.spliceai_pathogenic)
-        {
-            (true, EvidenceStrength::Supporting)
-        } else {
-            (false, EvidenceStrength::Supporting)
-        }
     } else {
         (false, EvidenceStrength::Supporting)
     };
 
-    let evaluated = input.revel.is_some()
-        || computational_total >= 2
-        || input.splice_ai.is_some();
+    let evaluated = (is_missense && input.revel.is_some()) || input.splice_ai.is_some();
 
     details.insert("evidence_lines".into(), serde_json::json!(evidence_lines));
 
@@ -231,6 +238,8 @@ fn evaluate_pp3(
         )
     } else if evaluated {
         "Computational evidence does not support deleterious effect".to_string()
+    } else if !is_missense && input.splice_ai.is_none() {
+        "PP3 requires REVEL (missense) or SpliceAI; neither available".to_string()
     } else {
         "Insufficient computational prediction data available".to_string()
     };
@@ -390,7 +399,10 @@ mod tests {
     }
 
     #[test]
-    fn test_pp3_spliceai_strong() {
+    fn test_pp3_spliceai_caps_at_supporting() {
+        // Walker 2023 (ClinGen SVI Splicing Subgroup): SpliceAI alone tops
+        // out at PP3 Supporting, even at very high delta scores. Strong
+        // splicing evidence requires experimental RNA assay (PVS1_RNA / PS3).
         let input = ClassificationInput {
             consequences: vec![Consequence::SpliceRegionVariant],
             impact: Impact::Low,
@@ -422,7 +434,62 @@ mod tests {
         };
         let result = evaluate_pp3(&input, &AcmgConfig::default());
         assert!(result.met);
-        assert_eq!(result.strength, EvidenceStrength::Strong);
+        assert_eq!(result.strength, EvidenceStrength::Supporting);
+        assert_eq!(result.code, "PP3");
+    }
+
+    #[test]
+    fn test_pp3_revel_ignored_for_non_missense() {
+        // Pejaver 2022: REVEL is calibrated for missense only. A high REVEL
+        // score on a frameshift / synonymous / splice variant must NOT fire PP3.
+        let mut input = make_input_with_revel(0.95);
+        input.consequences = vec![Consequence::FrameshiftVariant];
+        let result = evaluate_pp3(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        // REVEL score is still recorded in details for transparency.
+        let details = result.details.as_object().unwrap();
+        assert!(details.contains_key("revel_score"));
+        assert!(details.contains_key("revel_skipped_reason"));
+    }
+
+    #[test]
+    fn test_pp3_consensus_dropped() {
+        // Pre-PR1 behavior allowed ≥3-of-4 SIFT/PolyPhen/PhyloP/GERP consensus
+        // to fire PP3 Supporting in the absence of REVEL. Pejaver 2022 explicitly
+        // recommends a single calibrated tool, not ad-hoc consensus, so this
+        // path has been removed. Without REVEL or SpliceAI, PP3 must NOT fire
+        // even when SIFT/PolyPhen/PhyloP/GERP all signal pathogenic.
+        let mut input = ClassificationInput {
+            consequences: vec![Consequence::MissenseVariant],
+            impact: Impact::Moderate,
+            gene_symbol: Some("TEST".to_string()),
+            is_canonical: true,
+            amino_acids: None,
+            protein_position: None,
+            gnomad: None,
+            clinvar: None,
+            revel: None,
+            splice_ai: None,
+            dbnsfp: None,
+            phylop: Some(5.0),
+            gerp: Some(5.0),
+            gene_constraints: None,
+            omim: None,
+            clinvar_protein: None,
+            in_repeat_region: None,
+            proband_genotype: None,
+            mother_genotype: None,
+            father_genotype: None,
+            companion_variants: vec![],
+        };
+        // Synthesize a dbNSFP entry with deleterious SIFT + damaging PolyPhen
+        // by going through the same JSON path the evaluator uses.
+        input.dbnsfp = Some(crate::sa_extract::DbNsfpData {
+            sift: Some("deleterious(0.000)".to_string()),
+            polyphen: Some("probably_damaging(0.998)".to_string()),
+        });
+        let result = evaluate_pp3(&input, &AcmgConfig::default());
+        assert!(!result.met);
     }
 
     #[test]

--- a/crates/fastvep-classification/src/lib.rs
+++ b/crates/fastvep-classification/src/lib.rs
@@ -120,38 +120,22 @@ mod tests {
         let config = AcmgConfig::default();
         let result = classify(&input, &config);
 
-        // PVS1 + PM2_Supporting = PVS + PP → depends on PM2 being Supporting
-        // PVS1 (VeryStrong) + PM2_Supporting (Supporting) = PVS + PP
-        // This matches "PVS + PM" if PM2 is at Moderate, or "PVS + >=2 PP" if only 2 supporting
-        // With default config (pm2_downgrade_to_supporting=true), PM2 is Supporting
-        // So we have PVS=1, PP=1 (PM2_Supporting counts as Supporting)
-        // That doesn't match any Pathogenic rule, and PVS + PM is Likely Pathogenic but we only have Supporting
-        // Actually PVS >= 1 && pp >= 2 requires 2 supporting, we only have 1
-        // So this should be VUS with just PVS1 + PM2_Supporting
-        // Unless we also have PP2 (misZ < 3.09, so no) or other criteria
-
-        // With PVS1 alone and PM2_Supporting: PVS=1, PP=1 → doesn't match any LP rule either
-        // Need to check: PVS + PM needs at least 1 Moderate, but PM2 is downgraded to Supporting
-        // So the result depends on exact counts
-
-        // Let's verify the counts
+        // PVS1 (VeryStrong) + PM2_Supporting (Supporting) = PVS=1, PP=1
+        // Per ClinGen SVI (Sept 2020): PVS + >=1 PP → Likely Pathogenic
+        // Bayesian Post_P = 0.988, within LP range (0.90–0.99)
         assert!(result.counts.pathogenic_very_strong >= 1); // PVS1
         assert!(result.counts.pathogenic_supporting >= 1); // PM2_Supporting
-
-        // PVS + >=2 PP requires 2 supporting, we only have 1 from PM2_Supporting
-        // So this should be VUS unless we add more evidence
-        // Actually no: let's trace through. PVS=1, PS=0, PM=0, PP=1
-        // No pathogenic rule matches (need PVS+PS, PVS+2PM, PVS+PM+PP, PVS+2PP)
-        // None matches with PS=0, PM=0, PP=1
-        // So it's VUS. Let's verify.
-        assert!(
-            result.classification == AcmgClassification::UncertainSignificance
-                || result.classification == AcmgClassification::LikelyPathogenic
-        );
+        assert_eq!(result.classification, AcmgClassification::LikelyPathogenic);
     }
 
     #[test]
-    fn test_classify_frameshift_lof_gene_pathogenic_with_more_evidence() {
+    fn test_classify_frameshift_revel_does_not_drive_pathogenic() {
+        // Pre-PR1, a high REVEL score on a frameshift incorrectly fired
+        // PP3_Strong, pushing PVS1 + REVEL → Pathogenic via the PVS+PS rule.
+        // Per Pejaver 2022, REVEL is calibrated for missense only and must
+        // not contribute to non-missense classification. Without other
+        // pathogenic-Strong evidence, PVS1 + PM2_Supporting tops out at LP
+        // via the ClinGen SVI PVS+PP rule.
         let mut input = make_input(
             vec![Consequence::FrameshiftVariant],
             Impact::High,
@@ -163,18 +147,11 @@ mod tests {
             mis_z: Some(2.5),
             syn_z: Some(0.5),
         });
-        // Add REVEL high score for PP3 (though REVEL is really for missense, it still triggers)
         input.revel = Some(RevelData { score: Some(0.95) });
-        // gnomAD absent → PM2_Supporting
-        // This gives us PVS1 + PP3_Strong + PM2_Supporting
-        // PVS=1 + PS=0 (PP3_Strong counts as Strong? No, PP3 is pathogenic supporting elevated to Strong)
-        // Actually PP3_Strong: code="PP3_Strong", direction=Pathogenic, strength=Strong
-        // So that counts as PS=1
-        // PVS=1 + PS=1 → Pathogenic (rule: PVS + >=1 PS)
 
         let config = AcmgConfig::default();
         let result = classify(&input, &config);
-        assert_eq!(result.classification, AcmgClassification::Pathogenic);
+        assert_eq!(result.classification, AcmgClassification::LikelyPathogenic);
     }
 
     #[test]

--- a/crates/fastvep-classification/src/types.rs
+++ b/crates/fastvep-classification/src/types.rs
@@ -149,7 +149,15 @@ impl EvidenceCounts {
                 (EvidenceDirection::Benign, EvidenceStrength::Moderate) => {
                     counts.benign_strong += 1
                 }
-                _ => {}
+                // Benign Very Strong (e.g. BP4_VeryStrong from REVEL ≤ 0.003 per
+                // Pejaver 2022) reaches the Benign classification on its own under
+                // the Tavtigian Bayesian framework. Counting it as 2 BS triggers
+                // the existing ≥2 BS → Benign rule without introducing a new slot.
+                (EvidenceDirection::Benign, EvidenceStrength::VeryStrong) => {
+                    counts.benign_strong += 2
+                }
+                // Pathogenic + Standalone is not defined in ACMG/AMP.
+                (EvidenceDirection::Pathogenic, EvidenceStrength::Standalone) => {}
             }
         }
         counts

--- a/crates/fastvep-classification/src/types.rs
+++ b/crates/fastvep-classification/src/types.rs
@@ -149,7 +149,7 @@ impl EvidenceCounts {
                 (EvidenceDirection::Benign, EvidenceStrength::Moderate) => {
                     counts.benign_strong += 1
                 }
-                // Benign Very Strong (e.g. BP4_VeryStrong from REVEL ≤ 0.003 per
+                // Benign Very Strong (e.g. BP4_Very_Strong from REVEL ≤ 0.003 per
                 // Pejaver 2022) reaches the Benign classification on its own under
                 // the Tavtigian Bayesian framework. Counting it as 2 BS triggers
                 // the existing ≥2 BS → Benign rule without introducing a new slot.


### PR DESCRIPTION
## Summary

PR1 of an ACMG/AMP alignment series. Brings the classifier into compliance with three published ClinGen SVI recommendations covering computational evidence and rule combination.

- **ClinGen SVI Sept 2020 — PVS + ≥1 PP → Likely Pathogenic**: compensates for the PM2 downgrade so PVS1 + PM2_Supporting reaches LP (Bayesian Post_P = 0.988).
- **Pejaver 2022 (AJHG) — REVEL is calibrated for missense only**: PP3/BP4 no longer fire from REVEL on non-missense consequences. The previous SIFT/PolyPhen/PhyloP/GERP ≥3-of-4 (PP3) and ≥2-of-3 (BP4) ad-hoc consensus paths are removed; Pejaver explicitly recommends a single calibrated tool. Adds the BP4 Very Strong band (REVEL ≤ 0.003) — only REVEL reaches it among the 13 calibrated tools.
- **Walker 2023 (ClinGen SVI Splicing Subgroup) — SpliceAI alone caps at Supporting**: removes the previous PP3_Strong path at SpliceAI ≥ 0.8 (Strong splicing requires experimental RNA assay). Adds a BP4 splice path at SpliceAI ≤ 0.1 with the 0.10–0.20 uninformative zone respected.

## Counts treatment

`EvidenceStrength::VeryStrong` benign maps to 2× `benign_strong` so a single BP4_VeryStrong satisfies the existing ≥2 BS → Benign rule on its own — matching the Tavtigian/ClinGen point system intent.

## Tests

82/82 pass (was 76; +6 new tests, 2 obsolete tests rewritten).

- New: REVEL on frameshift no longer fires PP3; SpliceAI 0.95 caps at PP3 Supporting; consensus path is dropped; BP4_VeryStrong at REVEL 0.002; BP4 splice at SpliceAI 0.05; BP4 uninformative zone at 0.15.
- Rewritten: `test_classify_frameshift_lof_gene_pathogenic_with_more_evidence` → asserts LP (correct); `test_pp3_spliceai_strong` → renamed and asserts Supporting cap.

## Files

| File | Change |
|------|--------|
| `crates/fastvep-classification/src/combiner.rs` | Add SVI Sept 2020 PVS + ≥1 PP → LP rule |
| `crates/fastvep-classification/src/criteria/pathogenic_supporting.rs` | PP3 missense gating, drop consensus, splice cap at Supporting |
| `crates/fastvep-classification/src/criteria/benign_supporting.rs` | BP4 missense gating, add Very Strong band, add splice path, drop consensus |
| `crates/fastvep-classification/src/config.rs` | Add `bp4_revel_very_strong=0.003`, `spliceai_strong` → `spliceai_benign=0.1` |
| `crates/fastvep-classification/src/types.rs` | Benign VeryStrong → 2× benign_strong in `EvidenceCounts` |
| `crates/fastvep-classification/src/lib.rs` | Update obsolete frameshift+REVEL test |
| `analysis/acmg_benchmark/METHODS.md` | Document Pejaver 2022 + Walker 2023 alignment, add Walker reference |
| `analysis/acmg_benchmark/clinvar_concordance.py` | Update simulation priors for Very Strong + splice Supporting cap |

## Subsequent PRs in this series

- **PR2**: Anti-double-counting between PP3 and PVS1/PS1/PM5/PM1 (Pejaver 2022 + Walker 2023)
- **PR3**: BP7 exon-edge exclusion (Walker 2023)
- **PR4**: PM2 inheritance-aware threshold (SVI v1.0)
- **PR5**: BA1 exception list
- **PR6**: PVS1 decision tree (Abou Tayoun 2018)
- **PR7**: PM3 v1.0 points-based scoring
- **PR8**: PS1 splice-RNA matching, PS4 → NotEvaluated
- **PR9**: Combiner conflict-gating fix
- **PR10**: gnomAD v4 + multi-disorder context
- **PR11**: METHODS.md full rewrite

## References

- Richards S, et al. Standards and guidelines for the interpretation of sequence variants. *Genet Med*. 2015;17(5):405-424.
- Pejaver V, et al. Calibration of computational tools for missense variant pathogenicity classification and ClinGen recommendations for PP3/BP4 criteria. *Am J Hum Genet*. 2022;109(12):2163-2177.
- Walker LC, et al. (ClinGen SVI Splicing Subgroup). Using the ACMG/AMP framework to capture evidence related to predicted and observed impact on splicing. *Am J Hum Genet*. 2023;110(7):1046-1067.
- ClinGen SVI Recommendation for Absence/Rarity (PM2) — Version 1.0. Approved September 4, 2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
