### PR TITLE
feat(classification): gnomAD v4 AN minimum + multi-disorder scaffold

### DIFF
--- a/analysis/acmg_benchmark/METHODS.md
+++ b/analysis/acmg_benchmark/METHODS.md
@@ -31,7 +31,7 @@ Of the 28 ACMG-AMP criteria, 18 are fully automatable from variant-level data an
 
 | Criterion | Strength | Description | Data Source |
 |-----------|----------|-------------|-------------|
-| BA1 | Standalone | Common variant (AF > 5%) | gnomAD max population allele frequency |
+| BA1 | Standalone | Common variant (AF > 5%) | gnomAD max population allele frequency, with AN ≥ 2000 minimum (gnomAD v4 / SVI March 2024) |
 | BS1 | Strong | Greater than expected frequency | gnomAD allele frequency (AF > 0.01) |
 | BS2 | Strong | Observed in healthy adults | gnomAD homozygote count + OMIM inheritance |
 | BP1 | Supporting | Missense in truncation-disease gene | gnomAD gene constraints (pLI + misZ) |

--- a/crates/fastvep-classification/src/config.rs
+++ b/crates/fastvep-classification/src/config.rs
@@ -140,6 +140,15 @@ pub struct AcmgConfig {
     #[serde(default = "default_ba1_exceptions")]
     pub ba1_exceptions: Vec<Ba1Exception>,
 
+    /// Minimum allele number (AN) required for BA1 / BS1 to fire (gnomAD v4
+    /// guidance, ClinGen SVI March 2024). With v4's massive expansion (807k
+    /// exomes, 76k genomes), the overall AN should be ≥ 2000 before a
+    /// frequency-based call is reliable. When the AN drops below this
+    /// threshold, BA1/BS1 are marked NotEvaluated rather than firing on
+    /// noisy frequency estimates. Default 2000.
+    #[serde(default = "default_min_an")]
+    pub min_an_for_frequency_criteria: u64,
+
     // ── Gene-specific overrides ──
     #[serde(default)]
     pub gene_overrides: HashMap<String, GeneOverride>,
@@ -177,6 +186,24 @@ pub struct GeneOverride {
     /// Criteria strength overrides (code -> new strength)
     #[serde(default)]
     pub strength_overrides: HashMap<String, EvidenceStrength>,
+    /// Per-disorder thresholds for genes associated with multiple disorders
+    /// (ClinGen SVI guidance July 2025). The classifier consumes whichever
+    /// disorder context is active for the call; in the absence of explicit
+    /// disorder selection, this scaffold is currently informational only —
+    /// the active disorder selection mechanism is part of a follow-up PR.
+    #[serde(default)]
+    pub disorders: HashMap<String, DisorderOverride>,
+}
+
+/// Per-disorder override values within a multi-disorder gene.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DisorderOverride {
+    /// Inheritance for this disorder ("AD", "AR", or "AD_AR").
+    pub inheritance: Option<String>,
+    /// Override BS1 AF threshold for this disorder.
+    pub bs1_af_threshold: Option<f64>,
+    /// Override PM2 AF threshold for this disorder.
+    pub pm2_af_threshold: Option<f64>,
 }
 
 impl Default for AcmgConfig {
@@ -207,6 +234,7 @@ impl Default for AcmgConfig {
             use_pp5_bp6: false,
             ba1_exceptions: default_ba1_exceptions(),
             use_clinvar_stars_as_ps4_proxy: false,
+            min_an_for_frequency_criteria: 2000,
             gene_overrides: HashMap::new(),
             trio: None,
         }
@@ -277,6 +305,7 @@ fn default_misz() -> f64 { 3.09 }
 fn default_pm1_window() -> u64 { 5 }
 fn default_pm1_threshold() -> u32 { 3 }
 fn default_true() -> bool { true }
+fn default_min_an() -> u64 { 2000 }
 
 /// Default BA1 exception list (Ghosh et al. 2018, Hum Mutat — 9 variants).
 fn default_ba1_exceptions() -> Vec<Ba1Exception> {
@@ -321,6 +350,7 @@ mod tests {
                 pm2_af_threshold: None,
                 disabled_criteria: vec![],
                 strength_overrides: HashMap::new(),
+                disorders: HashMap::new(),
             },
         );
         assert_eq!(cfg.effective_bs1_threshold(Some("BRCA1")), 0.001);

--- a/crates/fastvep-classification/src/criteria/benign_standalone.rs
+++ b/crates/fastvep-classification/src/criteria/benign_standalone.rs
@@ -56,6 +56,36 @@ pub fn evaluate_ba1(
     }
 
     let (met, summary) = if let Some(ref gnomad) = input.gnomad {
+        // ClinGen SVI gnomAD v4 guidance (March 2024): require minimum AN
+        // before frequency-based criteria fire — protects against noisy AF
+        // estimates in poorly-covered populations.
+        let an_ok = gnomad
+            .all_an
+            .map_or(true, |an| an >= config.min_an_for_frequency_criteria);
+        if !an_ok {
+            details.insert(
+                "an_below_minimum".into(),
+                serde_json::json!(gnomad.all_an),
+            );
+            details.insert(
+                "min_an_for_frequency_criteria".into(),
+                serde_json::json!(config.min_an_for_frequency_criteria),
+            );
+            return EvidenceCriterion {
+                code: "BA1".to_string(),
+                direction: EvidenceDirection::Benign,
+                strength: EvidenceStrength::Standalone,
+                default_strength: EvidenceStrength::Standalone,
+                met: false,
+                evaluated: false,
+                summary: format!(
+                    "BA1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
+                    gnomad.all_an.unwrap_or(0),
+                    config.min_an_for_frequency_criteria
+                ),
+                details: serde_json::Value::Object(details),
+            };
+        }
         let max_af = gnomad.max_pop_af();
         if let Some(af) = max_af {
             details.insert("max_pop_af".into(), serde_json::json!(af));
@@ -320,6 +350,52 @@ mod tests {
         };
         let result = evaluate_ba1(&input, &AcmgConfig::default());
         assert!(result.met);
+    }
+
+    #[test]
+    fn test_ba1_low_an_not_evaluated() {
+        // PR10 (gnomAD v4 guidance): AN below 2000 → NotEvaluated, not Benign,
+        // even at high AF — the frequency estimate is unreliable.
+        let input = ClassificationInput {
+            consequences: vec![],
+            impact: fastvep_core::Impact::Modifier,
+            gene_symbol: None,
+            is_canonical: false,
+            amino_acids: None,
+            protein_position: None,
+            gnomad: Some(GnomadData {
+                all_af: Some(0.10),
+                all_an: Some(500), // way below 2000
+                ..Default::default()
+            }),
+            clinvar: None,
+            revel: None,
+            splice_ai: None,
+            dbnsfp: None,
+            phylop: None,
+            gerp: None,
+            gene_constraints: None,
+            omim: None,
+            clinvar_protein: None,
+            hgvs_c: None,
+            predicted_nmd: None,
+            protein_truncation_pct: None,
+            is_last_exon: None,
+            in_critical_region: None,
+            alt_start_codon_distance: None,
+            same_splice_position_pathogenic: None,
+            in_repeat_region: None,
+            at_exon_edge: None,
+            intronic_offset: None,
+            proband_genotype: None,
+            mother_genotype: None,
+            father_genotype: None,
+            companion_variants: vec![],
+        };
+        let result = evaluate_ba1(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        assert!(!result.evaluated);
+        assert!(result.summary.contains("below minimum"));
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/benign_strong.rs
+++ b/crates/fastvep-classification/src/criteria/benign_strong.rs
@@ -26,6 +26,35 @@ fn evaluate_bs1(
     details.insert("af_threshold".into(), serde_json::json!(threshold));
 
     let (met, summary) = if let Some(ref gnomad) = input.gnomad {
+        // ClinGen SVI gnomAD v4 guidance (March 2024): require minimum AN
+        // before BS1 fires, same as BA1.
+        let an_ok = gnomad
+            .all_an
+            .map_or(true, |an| an >= config.min_an_for_frequency_criteria);
+        if !an_ok {
+            details.insert(
+                "an_below_minimum".into(),
+                serde_json::json!(gnomad.all_an),
+            );
+            details.insert(
+                "min_an_for_frequency_criteria".into(),
+                serde_json::json!(config.min_an_for_frequency_criteria),
+            );
+            return EvidenceCriterion {
+                code: "BS1".to_string(),
+                direction: EvidenceDirection::Benign,
+                strength: EvidenceStrength::Strong,
+                default_strength: EvidenceStrength::Strong,
+                met: false,
+                evaluated: false,
+                summary: format!(
+                    "BS1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
+                    gnomad.all_an.unwrap_or(0),
+                    config.min_an_for_frequency_criteria
+                ),
+                details: serde_json::Value::Object(details),
+            };
+        }
         let af = gnomad.all_af.unwrap_or(0.0);
         details.insert("gnomad_allAf".into(), serde_json::json!(af));
 

--- a/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
@@ -859,6 +859,7 @@ mod tests {
                 pm2_af_threshold: Some(0.001),
                 disabled_criteria: vec![],
                 strength_overrides: Default::default(),
+                disorders: Default::default(),
             },
         );
         let mut input = make_input(


### PR DESCRIPTION
## Summary

PR10 of the ACMG/AMP alignment series. Two ClinGen SVI infrastructure refinements.

Branches off `master`. Independent of PR1–PR9.

### gnomAD v4 AN minimum (SVI March 2024)

BA1 and BS1 now require `gnomAD all_an ≥ min_an_for_frequency_criteria` (default **2000**) before they can fire. Below the threshold the criterion is marked NotEvaluated rather than firing on noisy frequency estimates. Configurable per-VCEP via TOML.

### Multi-disorder scaffold (SVI July 2025)

`GeneOverride` extended with `disorders: HashMap<String, DisorderOverride>`, where each entry can carry per-disorder inheritance / BS1 threshold / PM2 threshold. The scaffold is currently informational; the active-disorder selection mechanism is a follow-up. This PR puts the data model in place so VCEP configs can be authored against it ahead of wiring.

## Tests

76/76 pass (was 75; +1):
- BA1 with `all_an = 500` → NotEvaluated (was firing erroneously before).

## References

- ClinGen Guidance to VCEPs Regarding gnomAD v4 (March 2024).
- ClinGen Guidance Classifying Variants in Genes Associated with Multiple Disorders (July 2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
