### PR TITLE
fix(classification): address Copilot review feedback from PR1-PR10 series

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -850,12 +850,13 @@ fn enrich_compound_het(
 ) {
     use std::collections::HashMap;
 
-    // Collect per-gene variant info: (variant_index, gene_symbol, is_clinvar_pathogenic, proband_het, is_phased, hgvsc, allele_indices for phase)
+    // Collect per-gene variant info: (variant_index, gene_symbol, ClinVar P/LP flags, proband_het, is_phased, hgvsc, allele_indices for phase)
     struct VariantGeneInfo {
         vf_idx: usize,
         tv_idx: usize,
         aa_idx: usize,
         is_clinvar_pathogenic: bool,
+        is_clinvar_likely_pathogenic: bool,
         proband_het: bool,
         is_phased: bool,
         /// Proband's allele indices for phase comparison
@@ -893,13 +894,30 @@ fn enrich_compound_het(
                         })
                     });
 
-                // Also check the supplementary annotations directly for ClinVar pathogenic
-                let clinvar_pathogenic_from_sa = aa.supplementary.iter().any(|(key, json)| {
-                    key == "clinvar"
-                        && (json.contains("Pathogenic") || json.contains("pathogenic"))
-                        && !json.contains("Conflicting")
-                        && !json.contains("conflicting")
-                });
+                // Classify ClinVar supplementary as Pathogenic / Likely pathogenic
+                // separately so PM3 v1.0 can score them at their proper point
+                // values. A bare substring match on "pathogenic" matches both
+                // "Pathogenic" and "Likely pathogenic" — this would over-score
+                // LP companions as P. Strip "Likely pathogenic" first, then
+                // see if any "pathogenic" remains: that residual signals true P.
+                let (clinvar_p_from_sa, clinvar_lp_from_sa) = aa
+                    .supplementary
+                    .iter()
+                    .filter(|(key, json)| {
+                        key == "clinvar"
+                            && !json.contains("Conflicting")
+                            && !json.contains("conflicting")
+                    })
+                    .map(|(_, json)| {
+                        let lower = json.to_lowercase();
+                        let has_lp = lower.contains("likely pathogenic");
+                        let stripped = lower.replace("likely pathogenic", "");
+                        let has_p = stripped.contains("pathogenic");
+                        (has_p, has_lp && !has_p)
+                    })
+                    .fold((false, false), |(p_acc, lp_acc), (p, lp)| {
+                        (p_acc || p, lp_acc || lp)
+                    });
 
                 let proband_het = proband_gt.as_ref().map_or(false, |g| g.is_het);
                 let is_phased = proband_gt.as_ref().map_or(false, |g| g.is_phased);
@@ -937,7 +955,8 @@ fn enrich_compound_het(
                         vf_idx,
                         tv_idx,
                         aa_idx,
-                        is_clinvar_pathogenic: is_clinvar_pathogenic || clinvar_pathogenic_from_sa,
+                        is_clinvar_pathogenic: is_clinvar_pathogenic || clinvar_p_from_sa,
+                        is_clinvar_likely_pathogenic: clinvar_lp_from_sa,
                         proband_het,
                         is_phased,
                         proband_alleles,
@@ -991,7 +1010,7 @@ fn enrich_compound_het(
 
                     fastvep_classification::CompanionVariant {
                         is_clinvar_pathogenic: other.is_clinvar_pathogenic,
-                        is_clinvar_likely_pathogenic: false,
+                        is_clinvar_likely_pathogenic: other.is_clinvar_likely_pathogenic,
                         is_in_trans,
                         proband_het: other.proband_het,
                         hgvsc: other.hgvsc.clone(),

--- a/crates/fastvep-classification/src/criteria/benign_standalone.rs
+++ b/crates/fastvep-classification/src/criteria/benign_standalone.rs
@@ -58,33 +58,43 @@ pub fn evaluate_ba1(
     let (met, summary) = if let Some(ref gnomad) = input.gnomad {
         // ClinGen SVI gnomAD v4 guidance (March 2024): require minimum AN
         // before frequency-based criteria fire — protects against noisy AF
-        // estimates in poorly-covered populations.
-        let an_ok = gnomad
-            .all_an
-            .map_or(true, |an| an >= config.min_an_for_frequency_criteria);
-        if !an_ok {
-            details.insert(
-                "an_below_minimum".into(),
-                serde_json::json!(gnomad.all_an),
-            );
-            details.insert(
-                "min_an_for_frequency_criteria".into(),
-                serde_json::json!(config.min_an_for_frequency_criteria),
-            );
-            return EvidenceCriterion {
-                code: "BA1".to_string(),
-                direction: EvidenceDirection::Benign,
-                strength: EvidenceStrength::Standalone,
-                default_strength: EvidenceStrength::Standalone,
-                met: false,
-                evaluated: false,
-                summary: format!(
-                    "BA1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
-                    gnomad.all_an.unwrap_or(0),
-                    config.min_an_for_frequency_criteria
-                ),
-                details: serde_json::Value::Object(details),
-            };
+        // estimates in poorly-covered populations. Treat missing AN the
+        // same as below-minimum: the SVI guidance is a *requirement*, not
+        // an opt-in check, so we cannot fire BA1 without confirming AN.
+        match gnomad.all_an {
+            Some(an) if an >= config.min_an_for_frequency_criteria => {}
+            other => {
+                details.insert(
+                    "min_an_for_frequency_criteria".into(),
+                    serde_json::json!(config.min_an_for_frequency_criteria),
+                );
+                let summary = match other {
+                    Some(an) => {
+                        details.insert("an_below_minimum".into(), serde_json::json!(an));
+                        format!(
+                            "BA1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
+                            an, config.min_an_for_frequency_criteria
+                        )
+                    }
+                    None => {
+                        details.insert("an_missing".into(), serde_json::json!(true));
+                        format!(
+                            "BA1 not evaluated: gnomAD AN unavailable; minimum {} required (gnomAD v4 guidance)",
+                            config.min_an_for_frequency_criteria
+                        )
+                    }
+                };
+                return EvidenceCriterion {
+                    code: "BA1".to_string(),
+                    direction: EvidenceDirection::Benign,
+                    strength: EvidenceStrength::Standalone,
+                    default_strength: EvidenceStrength::Standalone,
+                    met: false,
+                    evaluated: false,
+                    summary,
+                    details: serde_json::Value::Object(details),
+                };
+            }
         }
         let max_af = gnomad.max_pop_af();
         if let Some(af) = max_af {
@@ -155,6 +165,7 @@ mod tests {
             gnomad: Some(GnomadData {
                 all_af: Some(0.10),
                 afr_af: Some(0.15),
+                all_an: Some(100_000),
                 ..Default::default()
             }),
             clinvar: None,
@@ -323,7 +334,7 @@ mod tests {
             is_canonical: true,
             amino_acids: None,
             protein_position: None,
-            gnomad: Some(GnomadData { all_af: Some(0.10), ..Default::default() }),
+            gnomad: Some(GnomadData { all_af: Some(0.10), all_an: Some(100_000), ..Default::default() }),
             clinvar: None,
             revel: None,
             splice_ai: None,
@@ -410,6 +421,7 @@ mod tests {
             gnomad: Some(GnomadData {
                 all_af: Some(0.02),
                 eas_af: Some(0.06), // Only EAS above 5%
+                all_an: Some(100_000),
                 ..Default::default()
             }),
             clinvar: None,

--- a/crates/fastvep-classification/src/criteria/benign_strong.rs
+++ b/crates/fastvep-classification/src/criteria/benign_strong.rs
@@ -27,33 +27,42 @@ fn evaluate_bs1(
 
     let (met, summary) = if let Some(ref gnomad) = input.gnomad {
         // ClinGen SVI gnomAD v4 guidance (March 2024): require minimum AN
-        // before BS1 fires, same as BA1.
-        let an_ok = gnomad
-            .all_an
-            .map_or(true, |an| an >= config.min_an_for_frequency_criteria);
-        if !an_ok {
-            details.insert(
-                "an_below_minimum".into(),
-                serde_json::json!(gnomad.all_an),
-            );
-            details.insert(
-                "min_an_for_frequency_criteria".into(),
-                serde_json::json!(config.min_an_for_frequency_criteria),
-            );
-            return EvidenceCriterion {
-                code: "BS1".to_string(),
-                direction: EvidenceDirection::Benign,
-                strength: EvidenceStrength::Strong,
-                default_strength: EvidenceStrength::Strong,
-                met: false,
-                evaluated: false,
-                summary: format!(
-                    "BS1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
-                    gnomad.all_an.unwrap_or(0),
-                    config.min_an_for_frequency_criteria
-                ),
-                details: serde_json::Value::Object(details),
-            };
+        // before BS1 fires, same as BA1. Treat missing AN as NotEvaluated
+        // (the SVI guidance is a requirement, not an opt-in).
+        match gnomad.all_an {
+            Some(an) if an >= config.min_an_for_frequency_criteria => {}
+            other => {
+                details.insert(
+                    "min_an_for_frequency_criteria".into(),
+                    serde_json::json!(config.min_an_for_frequency_criteria),
+                );
+                let summary = match other {
+                    Some(an) => {
+                        details.insert("an_below_minimum".into(), serde_json::json!(an));
+                        format!(
+                            "BS1 not evaluated: gnomAD AN={} below minimum {} (gnomAD v4 guidance)",
+                            an, config.min_an_for_frequency_criteria
+                        )
+                    }
+                    None => {
+                        details.insert("an_missing".into(), serde_json::json!(true));
+                        format!(
+                            "BS1 not evaluated: gnomAD AN unavailable; minimum {} required (gnomAD v4 guidance)",
+                            config.min_an_for_frequency_criteria
+                        )
+                    }
+                };
+                return EvidenceCriterion {
+                    code: "BS1".to_string(),
+                    direction: EvidenceDirection::Benign,
+                    strength: EvidenceStrength::Strong,
+                    default_strength: EvidenceStrength::Strong,
+                    met: false,
+                    evaluated: false,
+                    summary,
+                    details: serde_json::Value::Object(details),
+                };
+            }
         }
         let af = gnomad.all_af.unwrap_or(0.0);
         details.insert("gnomad_allAf".into(), serde_json::json!(af));
@@ -255,6 +264,7 @@ mod tests {
     fn test_bs1_above_threshold() {
         let input = make_input(Some(GnomadData {
             all_af: Some(0.02),
+            all_an: Some(100_000),
             ..Default::default()
         }));
         let result = evaluate_bs1(&input, &AcmgConfig::default());
@@ -265,6 +275,7 @@ mod tests {
     fn test_bs1_below_threshold() {
         let input = make_input(Some(GnomadData {
             all_af: Some(0.001),
+            all_an: Some(100_000),
             ..Default::default()
         }));
         let result = evaluate_bs1(&input, &AcmgConfig::default());
@@ -276,10 +287,39 @@ mod tests {
         let input = make_input(Some(GnomadData {
             all_af: Some(0.10),
             afr_af: Some(0.10),
+            all_an: Some(100_000),
             ..Default::default()
         }));
         let result = evaluate_bs1(&input, &AcmgConfig::default());
         assert!(!result.met); // BA1 would fire, so BS1 should not
+    }
+
+    #[test]
+    fn test_bs1_low_an_not_evaluated() {
+        // gnomAD v4 guidance: AN below 2000 → NotEvaluated, even at high AF.
+        let input = make_input(Some(GnomadData {
+            all_af: Some(0.02),
+            all_an: Some(500),
+            ..Default::default()
+        }));
+        let result = evaluate_bs1(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        assert!(!result.evaluated);
+        assert!(result.summary.contains("below minimum"));
+    }
+
+    #[test]
+    fn test_bs1_missing_an_not_evaluated() {
+        // gnomAD record present but AN is None → NotEvaluated, never fires.
+        let input = make_input(Some(GnomadData {
+            all_af: Some(0.02),
+            all_an: None,
+            ..Default::default()
+        }));
+        let result = evaluate_bs1(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        assert!(!result.evaluated);
+        assert!(result.summary.contains("AN unavailable"));
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
@@ -166,39 +166,74 @@ fn evaluate_pm2(
     details.insert("is_recessive".into(), serde_json::json!(is_recessive));
     details.insert("is_dominant".into(), serde_json::json!(is_dominant));
 
-    let (met, summary) = if let Some(ref gnomad) = input.gnomad {
-        let af = gnomad.all_af.unwrap_or(0.0);
-        let ac = gnomad.all_ac.unwrap_or(0);
-        details.insert("gnomad_allAf".into(), serde_json::json!(af));
-        details.insert("gnomad_allAc".into(), serde_json::json!(ac));
+    let (met, evaluated, summary) = if let Some(ref gnomad) = input.gnomad {
+        details.insert("gnomad_allAf".into(), serde_json::json!(gnomad.all_af));
+        details.insert("gnomad_allAc".into(), serde_json::json!(gnomad.all_ac));
 
-        // For strict absence (threshold = 0.0), require AC = 0 AND AF = 0.
-        // For non-zero thresholds (e.g. AR 0.00007), allow AF ≤ threshold.
-        let met = if threshold == 0.0 {
-            ac == 0 && af == 0.0
+        // For strict absence (threshold = 0.0), require AC and AF to both be
+        // PRESENT and equal to zero — treating missing fields as zero would
+        // call PM2 on incomplete gnomAD records. For non-zero thresholds
+        // (e.g. AR 0.00007), require AF present and ≤ threshold.
+        if threshold == 0.0 {
+            match (gnomad.all_ac, gnomad.all_af) {
+                (Some(0), Some(af)) if af == 0.0 => (
+                    true,
+                    true,
+                    format!(
+                        "Absent in gnomAD (AC=0, AF=0, inheritance={})",
+                        inheritance_basis
+                    ),
+                ),
+                (Some(ac), Some(af)) => (
+                    false,
+                    true,
+                    format!(
+                        "Not absent in gnomAD (AF={:.6}, AC={}, inheritance={})",
+                        af, ac, inheritance_basis
+                    ),
+                ),
+                _ => (
+                    false,
+                    false,
+                    format!(
+                        "PM2 not evaluated: gnomAD record present but AC/AF missing (inheritance={})",
+                        inheritance_basis
+                    ),
+                ),
+            }
         } else {
-            af <= threshold
-        };
-        let summary = if met {
-            format!(
-                "{} in gnomAD (AF={:.6}, AC={}, threshold={:.6}, inheritance={})",
-                if threshold == 0.0 { "Absent" } else { "Rare" },
-                af,
-                ac,
-                threshold,
-                inheritance_basis
-            )
-        } else {
-            format!(
-                "Not rare enough in gnomAD (AF={:.6}, AC={}, threshold={:.6}, inheritance={})",
-                af, ac, threshold, inheritance_basis
-            )
-        };
-        (met, summary)
+            match gnomad.all_af {
+                Some(af) if af <= threshold => (
+                    true,
+                    true,
+                    format!(
+                        "Rare in gnomAD (AF={:.6}, threshold={:.6}, inheritance={})",
+                        af, threshold, inheritance_basis
+                    ),
+                ),
+                Some(af) => (
+                    false,
+                    true,
+                    format!(
+                        "Not rare enough in gnomAD (AF={:.6}, threshold={:.6}, inheritance={})",
+                        af, threshold, inheritance_basis
+                    ),
+                ),
+                None => (
+                    false,
+                    false,
+                    format!(
+                        "PM2 not evaluated: gnomAD record present but AF missing (inheritance={})",
+                        inheritance_basis
+                    ),
+                ),
+            }
+        }
     } else {
         // Absent from gnomAD entirely (no record at all).
         details.insert("gnomad_allAf".into(), serde_json::Value::Null);
         (
+            true,
             true,
             format!(
                 "Absent from gnomAD (no record) — meets PM2 under {} rule",
@@ -213,7 +248,7 @@ fn evaluate_pm2(
         strength,
         default_strength: EvidenceStrength::Moderate,
         met,
-        evaluated: true,
+        evaluated,
         summary,
         details: serde_json::Value::Object(details),
     }

--- a/crates/fastvep-classification/src/criteria/pathogenic_strong.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_strong.rs
@@ -49,18 +49,49 @@ fn evaluate_ps1(
     );
 
     // Walker 2023 splice-RNA path.
-    if is_canonical_splice && input.same_splice_position_pathogenic == Some(true) {
-        details.insert("ps1_path".into(), serde_json::json!("splice_rna_match"));
-        return EvidenceCriterion {
-            code: "PS1".to_string(),
-            direction: EvidenceDirection::Pathogenic,
-            strength: EvidenceStrength::Strong,
-            default_strength: EvidenceStrength::Strong,
-            met: true,
-            evaluated: true,
-            summary: "Canonical ±1/2 splice variant predicted to produce the same RNA outcome as a known pathogenic splice variant (Walker 2023)".to_string(),
-            details: serde_json::Value::Object(details),
-        };
+    if is_canonical_splice {
+        match input.same_splice_position_pathogenic {
+            Some(true) => {
+                details.insert("ps1_path".into(), serde_json::json!("splice_rna_match"));
+                return EvidenceCriterion {
+                    code: "PS1".to_string(),
+                    direction: EvidenceDirection::Pathogenic,
+                    strength: EvidenceStrength::Strong,
+                    default_strength: EvidenceStrength::Strong,
+                    met: true,
+                    evaluated: true,
+                    summary: "Canonical ±1/2 splice variant predicted to produce the same RNA outcome as a known pathogenic splice variant (Walker 2023)".to_string(),
+                    details: serde_json::Value::Object(details),
+                };
+            }
+            Some(false) => {
+                return EvidenceCriterion {
+                    code: "PS1".to_string(),
+                    direction: EvidenceDirection::Pathogenic,
+                    strength: EvidenceStrength::Strong,
+                    default_strength: EvidenceStrength::Strong,
+                    met: false,
+                    evaluated: true,
+                    summary: "Canonical splice variant; no known same-position pathogenic splice match (Walker 2023 PS1 splice path does not fire)".to_string(),
+                    details: serde_json::Value::Object(details),
+                };
+            }
+            None => {
+                // Splice catalog data isn't available — distinguish "no data"
+                // from "no match" so downstream consumers don't treat this as
+                // an evaluated negative call.
+                return EvidenceCriterion {
+                    code: "PS1".to_string(),
+                    direction: EvidenceDirection::Pathogenic,
+                    strength: EvidenceStrength::Strong,
+                    default_strength: EvidenceStrength::Strong,
+                    met: false,
+                    evaluated: false,
+                    summary: "Canonical splice variant; PS1 splice catalog (same_splice_position_pathogenic) not populated by pipeline".to_string(),
+                    details: serde_json::Value::Object(details),
+                };
+            }
+        }
     }
 
     if !is_missense {
@@ -71,11 +102,7 @@ fn evaluate_ps1(
             default_strength: EvidenceStrength::Strong,
             met: false,
             evaluated: true,
-            summary: if is_canonical_splice {
-                "Canonical splice variant; no same-position pathogenic splice match available for PS1".to_string()
-            } else {
-                "Not a missense or canonical splice variant".to_string()
-            },
+            summary: "Not a missense or canonical splice variant".to_string(),
             details: serde_json::Value::Object(details),
         };
     }

--- a/crates/fastvep-classification/src/criteria/pvs1.rs
+++ b/crates/fastvep-classification/src/criteria/pvs1.rs
@@ -95,20 +95,42 @@ enum NullKind {
 
 impl NullKind {
     fn detect(cs: &[Consequence]) -> Option<Self> {
+        // Scan all consequences and pick the most severe null kind so the
+        // result doesn't depend on input ordering (e.g. when both
+        // splice_donor_variant and frameshift_variant appear, splice wins
+        // deterministically). Severity rank below matches Ensembl VEP's
+        // null-variant ordering.
+        let mut best: Option<Self> = None;
         for c in cs {
-            match c {
-                Consequence::StopGained | Consequence::FrameshiftVariant => {
-                    return Some(Self::NonsenseOrFrameshift)
-                }
+            let kind = match c {
+                Consequence::TranscriptAblation => Some(Self::WholeGeneDeletion),
                 Consequence::SpliceAcceptorVariant | Consequence::SpliceDonorVariant => {
-                    return Some(Self::CanonicalSplice)
+                    Some(Self::CanonicalSplice)
                 }
-                Consequence::StartLost => return Some(Self::StartLost),
-                Consequence::TranscriptAblation => return Some(Self::WholeGeneDeletion),
-                _ => {}
+                Consequence::StopGained | Consequence::FrameshiftVariant => {
+                    Some(Self::NonsenseOrFrameshift)
+                }
+                Consequence::StartLost => Some(Self::StartLost),
+                _ => None,
+            };
+            if let Some(k) = kind {
+                best = Some(match best {
+                    None => k,
+                    Some(prev) if k.severity_rank() > prev.severity_rank() => k,
+                    Some(prev) => prev,
+                });
             }
         }
-        None
+        best
+    }
+
+    fn severity_rank(&self) -> u8 {
+        match self {
+            Self::WholeGeneDeletion => 4,
+            Self::CanonicalSplice => 3,
+            Self::NonsenseOrFrameshift => 2,
+            Self::StartLost => 1,
+        }
     }
 
     fn label(&self) -> &'static str {
@@ -161,9 +183,8 @@ fn grade_nonsense_frameshift(
                 ),
             ),
             _ => (
-                EvidenceStrength::Strong,
-                "NMD-escape; insufficient signal to grade further → PVS1_Strong (conservative)"
-                    .to_string(),
+                EvidenceStrength::VeryStrong,
+                "NMD-escape; grading signals incomplete → PVS1 (legacy fallback)".to_string(),
             ),
         }
     } else {
@@ -208,23 +229,33 @@ fn grade_start_lost(
 ) -> (EvidenceStrength, String) {
     if let Some(d) = input.alt_start_codon_distance {
         details.insert("alt_start_codon_distance".into(), serde_json::json!(d));
-        if d.unsigned_abs() <= 100 && input.in_critical_region == Some(true) {
-            return (
-                EvidenceStrength::Moderate,
-                format!(
-                    "Start-lost with downstream Met {} codons away and pathogenic variant upstream → PVS1_Moderate",
-                    d
-                ),
-            );
-        }
-        if d.unsigned_abs() > 100 {
-            return (
-                EvidenceStrength::Supporting,
-                format!(
-                    "Start-lost; alternative downstream Met is {} codons away → PVS1_Supporting",
-                    d
-                ),
-            );
+        // alt_start_codon_distance is the downstream distance in codons; the
+        // pipeline produces a non-negative value. A negative value is
+        // out-of-contract — treat it as "no usable signal" rather than
+        // silently abs() it (which would let upstream / invalid distances
+        // qualify the variant for PVS1_Moderate or _Supporting).
+        if d < 0 {
+            details.insert("alt_start_codon_distance_invalid".into(), serde_json::json!(true));
+        } else {
+            let d_codons = d as u64;
+            if d_codons <= 100 && input.in_critical_region == Some(true) {
+                return (
+                    EvidenceStrength::Moderate,
+                    format!(
+                        "Start-lost with downstream Met {} codons away and pathogenic variant upstream → PVS1_Moderate",
+                        d_codons
+                    ),
+                );
+            }
+            if d_codons > 100 {
+                return (
+                    EvidenceStrength::Supporting,
+                    format!(
+                        "Start-lost; alternative downstream Met is {} codons away → PVS1_Supporting",
+                        d_codons
+                    ),
+                );
+            }
         }
     }
     (

--- a/crates/fastvep-classification/src/lib.rs
+++ b/crates/fastvep-classification/src/lib.rs
@@ -103,6 +103,7 @@ mod tests {
         input.gnomad = Some(GnomadData {
             all_af: Some(0.10),
             afr_af: Some(0.15),
+            all_an: Some(100_000),
             ..Default::default()
         });
         let result = classify(&input, &AcmgConfig::default());

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1102,6 +1102,7 @@ fn enrich_compound_het_batch(
         tv_idx: usize,
         aa_idx: usize,
         is_clinvar_pathogenic: bool,
+        is_clinvar_likely_pathogenic: bool,
         proband_het: bool,
         is_phased: bool,
         proband_alleles: Vec<Option<u32>>,
@@ -1121,12 +1122,29 @@ fn enrich_compound_het_batch(
             };
 
             for (aa_idx, aa) in tv.allele_annotations.iter().enumerate() {
-                let clinvar_pathogenic_from_sa = aa.supplementary.iter().any(|(key, json)| {
-                    key == "clinvar"
-                        && (json.contains("Pathogenic") || json.contains("pathogenic"))
-                        && !json.contains("Conflicting")
-                        && !json.contains("conflicting")
-                });
+                // Classify ClinVar supplementary as Pathogenic / Likely pathogenic
+                // separately so PM3 v1.0 scores them at their proper point values.
+                // Strip "Likely pathogenic" before checking for "pathogenic"
+                // residual to avoid the substring-match bug that double-counts
+                // LP as P.
+                let (clinvar_p_from_sa, clinvar_lp_from_sa) = aa
+                    .supplementary
+                    .iter()
+                    .filter(|(key, json)| {
+                        key == "clinvar"
+                            && !json.contains("Conflicting")
+                            && !json.contains("conflicting")
+                    })
+                    .map(|(_, json)| {
+                        let lower = json.to_lowercase();
+                        let has_lp = lower.contains("likely pathogenic");
+                        let stripped = lower.replace("likely pathogenic", "");
+                        let has_p = stripped.contains("pathogenic");
+                        (has_p, has_lp && !has_p)
+                    })
+                    .fold((false, false), |(p_acc, lp_acc), (p, lp)| {
+                        (p_acc || p, lp_acc || lp)
+                    });
 
                 let proband_het = proband_gt.as_ref().map_or(false, |g| g.is_het);
                 let is_phased = proband_gt.as_ref().map_or(false, |g| g.is_phased);
@@ -1164,7 +1182,8 @@ fn enrich_compound_het_batch(
                         vf_idx,
                         tv_idx,
                         aa_idx,
-                        is_clinvar_pathogenic: clinvar_pathogenic_from_sa,
+                        is_clinvar_pathogenic: clinvar_p_from_sa,
+                        is_clinvar_likely_pathogenic: clinvar_lp_from_sa,
                         proband_het,
                         is_phased,
                         proband_alleles,
@@ -1210,10 +1229,7 @@ fn enrich_compound_het_batch(
 
                     fastvep_classification::CompanionVariant {
                         is_clinvar_pathogenic: other.is_clinvar_pathogenic,
-                        // The pipeline does not yet distinguish LP from P;
-                        // future change will populate this from a richer
-                        // ClinVar classification field.
-                        is_clinvar_likely_pathogenic: false,
+                        is_clinvar_likely_pathogenic: other.is_clinvar_likely_pathogenic,
                         is_in_trans,
                         proband_het: other.proband_het,
                         hgvsc: other.hgvsc.clone(),


### PR DESCRIPTION
## Summary

Bundles seven targeted fixes for issues surfaced by Copilot review on the ClinGen SVI alignment series (PR #6–#15). Each fix has a clearly correct answer; deferred items requiring new pipeline data sources (PS1 splice catalog, full PVS1 plumbing) are not addressed here.

## Fixes

### PM2 — strict-absence with missing fields
`pathogenic_moderate.rs` previously did `all_af.unwrap_or(0.0)` and `all_ac.unwrap_or(0)`, so a gnomAD record missing AC/AF would fire PM2 incorrectly. Now requires both fields PRESENT and zero for strict absence; missing fields → NotEvaluated.

### PVS1 — deterministic consequence ordering
`NullKind::detect` returned on the first match in the consequences vector — splice vs frameshift could yield different PVS1 grading depending on input order. Now scans all consequences and picks the most severe (TranscriptAblation > Splice > Nonsense/Frameshift > StartLost).

### PVS1 — NMD-escape fallback
NMD-escape with missing critical/pct signals returned `Strong` with a "conservative" summary, contradicting the docstring's "fallback to legacy VeryStrong" claim. Now returns VeryStrong + a clear "grading signals incomplete; legacy fallback" summary.

### PVS1 — alt_start_codon_distance signed handling
The `i64` distance was passed through `unsigned_abs()`, silently letting upstream/invalid distances qualify the variant for `PVS1_Moderate`/`_Supporting`. Now negative values are recorded as `alt_start_codon_distance_invalid` in details and the start-loss path falls through without grading.

### PM3 — LP over-counting (most consequential)
`is_clinvar_pathogenic` was computed via substring match on `"pathogenic"`, which also matches `"Likely pathogenic"`; combined with `is_clinvar_likely_pathogenic` hardcoded to `false`, every LP in-trans companion was scored at the P point value (1.0 instead of 0.5). Now strips `"likely pathogenic"` first and checks for residual `"pathogenic"` to detect true P; LP gets correctly populated. Applied to both `fastvep-cli/src/pipeline.rs` and `fastvep-annotate/src/lib.rs`.

### PS1 — splice path evaluated flag
For canonical splice variants, `same_splice_position_pathogenic == None` (data unavailable) was conflated with `Some(false)` (no match found) — both returned `evaluated: true`. Now distinguishes:
- `Some(true)` → met
- `Some(false)` → evaluated, not met (no match)
- `None` → not evaluated (data unavailable)

### BA1/BS1 — missing AN treated as NotEvaluated
`map_or(true, ...)` on `gnomad.all_an` allowed BA1/BS1 to fire when AN was missing — contradicting the SVI March-2024 "AN ≥ 2000 required" intent. Now treats missing AN the same as below-minimum: NotEvaluated. Added BS1 low-AN and missing-AN tests; updated BA1/BS1 test fixtures to set `all_an` explicitly.

## Tests

128/128 lib tests pass (was 126; +2 BS1 AN-gate tests).
333 total workspace lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)