### PR TITLE
Add supplementary annotation columns to tab output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ fastVEP supports direct integration with clinical and population databases throu
 | **PrimateAI** | Allele-specific | Primate-based pathogenicity | `--source primateai` |
 | **dbNSFP** | Allele-specific | SIFT/PolyPhen predictions | `--source dbnsfp` |
 
+For the per-source VCF `FV_*` / tab column / JSON-key schema (pipe formats,
+escaping rules, identifiers), see
+[`docs/SUPPLEMENTARY_ANNOTATIONS.md`](docs/SUPPLEMENTARY_ANNOTATIONS.md).
+
 ## Command Reference
 
 ### `fastvep annotate`

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -312,14 +312,20 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
             }
         }
         "tab" => {
-            writeln!(
-                writer,
-                "## fastVEP output"
-            )?;
-            writeln!(
-                writer,
-                "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tIMPACT\tDISTANCE\tSTRAND\tFLAGS"
-            )?;
+            writeln!(writer, "## fastVEP output")?;
+            for line in output::tab_supplementary_header_lines(&sa_json_keys, &gene_json_keys) {
+                writeln!(writer, "{}", line)?;
+            }
+            let extra_columns =
+                output::tab_supplementary_column_names(&sa_json_keys, &gene_json_keys);
+            let mut header = String::from(
+                "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tIMPACT\tDISTANCE\tSTRAND\tFLAGS",
+            );
+            for col in &extra_columns {
+                header.push('\t');
+                header.push_str(col);
+            }
+            writeln!(writer, "{}", header)?;
         }
         "json" => {
             writeln!(writer, "[")?;
@@ -1043,7 +1049,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
             match config.output_format.as_str() {
                 "vcf" => write_vcf_line(&mut writer, vf)?,
                 "tab" => {
-                    for line in output::format_tab_line(vf) {
+                    for line in output::format_tab_line(vf, &sa_json_keys, &gene_json_keys) {
                         writeln!(writer, "{}", line)?;
                     }
                 }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -292,6 +292,10 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
     let owned_vcf_info_ids = output::vcf_owned_info_ids(&sa_json_keys, &gene_json_keys);
     let generated_vcf_headers =
         output::vcf_info_header_lines(&sa_json_keys, &gene_json_keys, output::DEFAULT_CSQ_FIELDS);
+    // Precompute the loaded-source lookup once so the per-row tab writer
+    // doesn't redo an O(specs × keys) membership scan for every variant.
+    let supplementary_specs =
+        output::LoadedSupplementarySpecs::new(&sa_json_keys, &gene_json_keys);
 
     // Write headers based on output format
     match config.output_format.as_str() {
@@ -313,11 +317,10 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
         }
         "tab" => {
             writeln!(writer, "## fastVEP output")?;
-            for line in output::tab_supplementary_header_lines(&sa_json_keys, &gene_json_keys) {
+            for line in output::tab_supplementary_header_lines(&supplementary_specs) {
                 writeln!(writer, "{}", line)?;
             }
-            let extra_columns =
-                output::tab_supplementary_column_names(&sa_json_keys, &gene_json_keys);
+            let extra_columns = output::tab_supplementary_column_names(&supplementary_specs);
             let mut header = String::from(
                 "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tIMPACT\tDISTANCE\tSTRAND\tFLAGS",
             );
@@ -1049,7 +1052,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
             match config.output_format.as_str() {
                 "vcf" => write_vcf_line(&mut writer, vf)?,
                 "tab" => {
-                    for line in output::format_tab_line(vf, &sa_json_keys, &gene_json_keys) {
+                    for line in output::format_tab_line(vf, &supplementary_specs) {
                         writeln!(writer, "{}", line)?;
                     }
                 }

--- a/crates/fastvep-cli/tests/sa_build_oga.rs
+++ b/crates/fastvep-cli/tests/sa_build_oga.rs
@@ -471,3 +471,124 @@ fn annotate_vcf_emits_fastsa_projection_for_gnomad() {
     );
     assert!(!annotated.contains("FV_GNOMAD={"), "{annotated}");
 }
+
+#[test]
+fn annotate_tab_emits_fastsa_columns_for_clinvar_and_gnomad() {
+    // Regression test for issue #30: tab output silently dropped every
+    // supplementary annotation source. After fix, each loaded source must
+    // produce one extra tab column with the same pipe-delimited value used
+    // for the VCF `FV_*` INFO field.
+    let tmp = tempfile::tempdir().unwrap();
+    let clinvar_source = tmp.path().join("clinvar-mini.vcf");
+    let gnomad_source = tmp.path().join("gnomad-mini.vcf");
+    let input_vcf = tmp.path().join("input.vcf");
+    let gff3 = tmp.path().join("mini.gff3");
+    let clinvar_base = tmp.path().join("clinvar-mini");
+    let gnomad_base = tmp.path().join("gnomad-mini");
+    let output_tab = tmp.path().join("annotated.tab");
+    let transcript_cache = tmp.path().join("mini.fastvep.cache");
+
+    let clinvar_fixture = "\
+##fileformat=VCFv4.1
+##INFO=<ID=CLNSIG,Number=.,Type=String>
+##INFO=<ID=CLNREVSTAT,Number=.,Type=String>
+##INFO=<ID=CLNDN,Number=.,Type=String>
+##INFO=<ID=CLNVC,Number=.,Type=String>
+##INFO=<ID=CLNVCSO,Number=.,Type=String>
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t25000\trs1\tA\tG\t.\t.\tCLNSIG=Pathogenic;CLNREVSTAT=criteria_provided,_multiple_submitters,_no_conflicts;CLNDN=Breast_cancer;CLNVC=SNV;CLNVCSO=SO:0001483
+";
+    fs::write(&clinvar_source, clinvar_fixture).unwrap();
+    fs::write(&gnomad_source, GNOMAD_SOURCE_VCF).unwrap();
+    fs::write(&input_vcf, INPUT_NO_SPLICEAI_INFO_VCF).unwrap();
+    fs::write(&gff3, MINI_GFF3).unwrap();
+
+    run_sa_build(
+        "clinvar",
+        clinvar_source.to_str().unwrap(),
+        clinvar_base.to_str().unwrap(),
+        "GRCh38",
+    )
+    .unwrap();
+    run_sa_build(
+        "gnomad",
+        gnomad_source.to_str().unwrap(),
+        gnomad_base.to_str().unwrap(),
+        "GRCh38",
+    )
+    .unwrap();
+
+    run_annotate(AnnotateConfig {
+        input: input_vcf.to_string_lossy().into_owned(),
+        output: output_tab.to_string_lossy().into_owned(),
+        gff3: Some(gff3.to_string_lossy().into_owned()),
+        fasta: None,
+        output_format: "tab".into(),
+        pick: false,
+        hgvs: false,
+        distance: 0,
+        cache_dir: None,
+        transcript_cache: Some(transcript_cache.to_string_lossy().into_owned()),
+        sa_dir: Some(tmp.path().to_string_lossy().into_owned()),
+        acmg: false,
+        acmg_config: None,
+        proband: None,
+        mother: None,
+        father: None,
+    })
+    .unwrap();
+
+    let annotated = fs::read_to_string(output_tab).unwrap();
+
+    // Tab schema header must document the pipe format for every loaded source.
+    assert!(
+        annotated.contains("## COLUMN=<ID=FV_CLINVAR,Description=\"fastVEP ClinVar annotations. Format: ALLELE|SIGNIFICANCE|REVIEW_STATUS|PHENOTYPES|VARIANT_CLASS|SO_ACCESSION\">"),
+        "tab output must declare FV_CLINVAR schema:\n{}",
+        annotated
+    );
+    assert!(
+        annotated.contains("## COLUMN=<ID=FV_GNOMAD,Description="),
+        "tab output must declare FV_GNOMAD schema:\n{}",
+        annotated
+    );
+
+    // The column header line must end with the FV_* columns.
+    let column_header = annotated
+        .lines()
+        .find(|l| l.starts_with("#Uploaded_variation"))
+        .expect("missing tab column header");
+    assert!(
+        column_header.ends_with("\tFV_CLINVAR\tFV_GNOMAD"),
+        "extra columns must append after FLAGS in spec order: {}",
+        column_header
+    );
+
+    // At least one data row carries a populated FV_CLINVAR value at position 25000.
+    let data_rows: Vec<&str> = annotated
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .collect();
+    assert!(!data_rows.is_empty(), "tab output must contain data rows");
+    let pos25k = data_rows
+        .iter()
+        .find(|r| r.contains("1:25000\t"))
+        .expect("expected an annotated row for chr1:25000");
+    let cols: Vec<&str> = pos25k.split('\t').collect();
+    assert_eq!(cols.len(), 17 + 2);
+    assert_eq!(
+        cols[17], "G|Pathogenic|criteria_provided%2C_multiple_submitters%2C_no_conflicts|Breast_cancer|SNV|SO%3A0001483",
+        "FV_CLINVAR tab column must match the VCF pipe schema: {}",
+        pos25k
+    );
+    // The fixture only populates a subset of gnomAD fields; absent positions
+    // render as empty between pipes (matches VCF behavior).
+    assert_eq!(
+        cols[18], "G|0.00012|12|100000|0|0.00021||||||0.00009|||",
+        "FV_GNOMAD tab column must match the VCF pipe schema: {}",
+        pos25k
+    );
+
+    // Sanity: no raw JSON leaked into the tab file.
+    assert!(!annotated.contains('{'), "tab output must not contain raw JSON:\n{}", annotated);
+    assert!(!annotated.contains('}'), "tab output must not contain raw JSON:\n{}", annotated);
+}

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -549,6 +549,108 @@ pub fn vcf_info_header_id(line: &str) -> Option<&str> {
     Some(&rest[..end])
 }
 
+/// Return the supplementary projection column names (info IDs) for tab output,
+/// in the same order as `vcf_info_header_lines` emits them. SpliceAI is
+/// included first when it's loaded, followed by every loaded
+/// `VCF_PROJECTION_SPECS` entry.
+pub fn tab_supplementary_column_names(
+    sa_keys: &[String],
+    gene_keys: &[String],
+) -> Vec<&'static str> {
+    let mut names = Vec::new();
+    if sa_keys.iter().any(|key| key == "spliceAI") {
+        names.push("SpliceAI");
+    }
+    for spec in VCF_PROJECTION_SPECS {
+        let loaded = match spec.kind {
+            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
+                gene_keys.iter().any(|key| key == spec.json_key)
+            }
+            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
+                sa_keys.iter().any(|key| key == spec.json_key)
+            }
+        };
+        if loaded {
+            names.push(spec.info_id);
+        }
+    }
+    names
+}
+
+/// Format `##` header comment lines describing the tab pipe-format for each
+/// loaded supplementary source. Mirrors `vcf_info_header_lines` content so the
+/// tab and VCF outputs document the same schema.
+pub fn tab_supplementary_header_lines(
+    sa_keys: &[String],
+    gene_keys: &[String],
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    if sa_keys.iter().any(|key| key == "spliceAI") {
+        lines.push(format!(
+            "## COLUMN=<ID=SpliceAI,Description=\"{}\">",
+            "SpliceAI annotations. Format: ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL"
+        ));
+    }
+    for spec in VCF_PROJECTION_SPECS {
+        let loaded = match spec.kind {
+            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
+                gene_keys.iter().any(|key| key == spec.json_key)
+            }
+            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
+                sa_keys.iter().any(|key| key == spec.json_key)
+            }
+        };
+        if loaded {
+            lines.push(format!(
+                "## COLUMN=<ID={},Description=\"{}\">",
+                spec.info_id, spec.description
+            ));
+        }
+    }
+    lines
+}
+
+/// Render the per-allele supplementary projection columns for a single tab
+/// row, in the same order as `tab_supplementary_column_names`. Missing values
+/// render as `-` so the column count is fixed.
+pub fn format_supplementary_tab_columns_for_allele(
+    vf: &VariationFeature,
+    tv: &TranscriptVariation,
+    aa: &AlleleAnnotation,
+    sa_keys: &[String],
+    gene_keys: &[String],
+) -> Vec<String> {
+    let mut cols = Vec::new();
+    if sa_keys.iter().any(|key| key == "spliceAI") {
+        let value = format_spliceai_for_allele(vf, aa).unwrap_or_else(|| "-".to_string());
+        cols.push(value);
+    }
+    for spec in VCF_PROJECTION_SPECS {
+        let loaded = match spec.kind {
+            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
+                gene_keys.iter().any(|key| key == spec.json_key)
+            }
+            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
+                sa_keys.iter().any(|key| key == spec.json_key)
+            }
+        };
+        if !loaded {
+            continue;
+        }
+        let value = match spec.kind {
+            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
+                format_allele_projection_for_aa(vf, aa, spec)
+            }
+            VcfProjectionKind::GeneObject => format_gene_projection_for_tv(vf, tv, spec),
+            VcfProjectionKind::ClinvarProtein => {
+                format_clinvar_protein_projection_for_tv(vf, tv, spec)
+            }
+        };
+        cols.push(value.unwrap_or_else(|| "-".to_string()));
+    }
+    cols
+}
+
 /// Format all supplementary VCF INFO projections for an annotated variant.
 pub fn format_supplementary_vcf_info(vf: &VariationFeature) -> Vec<(String, String)> {
     let mut projected = Vec::new();
@@ -719,6 +821,120 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
     if values.is_empty() { None } else { Some(values.join(",")) }
 }
 
+fn format_spliceai_for_allele(vf: &VariationFeature, aa: &AlleleAnnotation) -> Option<String> {
+    let allele = uploaded_allele_for_annotation(vf, &aa.allele);
+    let mut values: Vec<String> = Vec::new();
+    for (key, json_str) in &aa.supplementary {
+        if key != "spliceAI" {
+            continue;
+        }
+        if let Some(value) = format_spliceai_entry(&allele, json_str) {
+            if !values.contains(&value) {
+                values.push(value);
+            }
+        }
+    }
+    if values.is_empty() { None } else { Some(values.join(",")) }
+}
+
+fn format_allele_projection_for_aa(
+    vf: &VariationFeature,
+    aa: &AlleleAnnotation,
+    spec: &VcfProjectionSpec,
+) -> Option<String> {
+    let allele = uploaded_allele_for_annotation(vf, &aa.allele);
+    let mut values: Vec<String> = Vec::new();
+    for (key, json_str) in &aa.supplementary {
+        if key != spec.json_key {
+            continue;
+        }
+        let parsed = serde_json::from_str::<Value>(json_str)
+            .unwrap_or_else(|_| Value::String(json_str.clone()));
+        let entries = match spec.kind {
+            VcfProjectionKind::AlleleScalar => {
+                vec![format!("{}|{}", escape_vcf_subfield(&allele), json_value_to_vcf(&parsed))]
+            }
+            _ => format_object_projection_entries(&allele, &parsed, spec.fields),
+        };
+        for value in entries {
+            if !values.contains(&value) {
+                values.push(value);
+            }
+        }
+    }
+    if values.is_empty() { None } else { Some(values.join(",")) }
+}
+
+fn format_gene_projection_for_tv(
+    vf: &VariationFeature,
+    tv: &TranscriptVariation,
+    spec: &VcfProjectionSpec,
+) -> Option<String> {
+    let want = tv.gene_symbol.as_deref().unwrap_or(&tv.gene_id);
+    let mut values: Vec<String> = Vec::new();
+    for ga in &vf.gene_annotations {
+        if ga.json_key != spec.json_key || ga.gene_symbol != want {
+            continue;
+        }
+        let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
+            continue;
+        };
+        let mut parts = Vec::with_capacity(spec.fields.len() + 1);
+        parts.push(escape_vcf_subfield(&ga.gene_symbol));
+        if let Some(obj) = parsed.as_object() {
+            for (_, json_key) in spec.fields {
+                parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+            }
+        }
+        let value = parts.join("|");
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+    if values.is_empty() { None } else { Some(values.join(",")) }
+}
+
+fn format_clinvar_protein_projection_for_tv(
+    vf: &VariationFeature,
+    tv: &TranscriptVariation,
+    spec: &VcfProjectionSpec,
+) -> Option<String> {
+    let want = tv.gene_symbol.as_deref().unwrap_or(&tv.gene_id);
+    let mut values: Vec<String> = Vec::new();
+    for ga in &vf.gene_annotations {
+        if ga.json_key != spec.json_key || ga.gene_symbol != want {
+            continue;
+        }
+        let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
+            continue;
+        };
+        let variants = parsed
+            .get("proteinVariants")
+            .and_then(|v| v.as_array())
+            .map(|vars| {
+                vars.iter()
+                    .filter_map(|v| {
+                        let pos = v.get("pos").map(json_leaf_to_string)?;
+                        let ref_aa = v.get("refAa").map(json_leaf_to_string)?;
+                        let alt_aa = v.get("altAa").map(json_leaf_to_string)?;
+                        let sig = v.get("sig").map(json_leaf_to_string).unwrap_or_default();
+                        Some(escape_vcf_subfield(&format!("{pos}:{ref_aa}>{alt_aa}:{sig}")))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("&")
+            })
+            .unwrap_or_default();
+        if variants.is_empty() {
+            continue;
+        }
+        let value = format!("{}|{}", escape_vcf_subfield(&ga.gene_symbol), variants);
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+    if values.is_empty() { None } else { Some(values.join(",")) }
+}
+
 fn format_clinvar_protein_projection(
     vf: &VariationFeature,
     spec: &VcfProjectionSpec,
@@ -847,7 +1063,17 @@ fn uploaded_allele_for_annotation(vf: &VariationFeature, allele: &Allele) -> Str
 }
 
 /// Format a VariationFeature as a tab-delimited VEP output line.
-pub fn format_tab_line(vf: &VariationFeature) -> Vec<String> {
+///
+/// `sa_keys` and `gene_keys` enumerate the supplementary annotation sources
+/// loaded for this run. For each loaded source, one extra tab column is
+/// appended carrying the same pipe-delimited value emitted into the VCF
+/// `FV_*` INFO field (`SpliceAI=` for the SpliceAI source). The column order
+/// matches `tab_supplementary_column_names`. Missing values render as `-`.
+pub fn format_tab_line(
+    vf: &VariationFeature,
+    sa_keys: &[String],
+    gene_keys: &[String],
+) -> Vec<String> {
     let mut lines = Vec::new();
 
     let location = if vf.position.start == vf.position.end {
@@ -864,6 +1090,8 @@ pub fn format_tab_line(vf: &VariationFeature) -> Vec<String> {
         .clone()
         .unwrap_or_else(|| format!("{}_{}", location, vf.allele_string));
 
+    let supplementary_loaded = !sa_keys.is_empty() || !gene_keys.is_empty();
+
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
             let consequence_str = aa
@@ -878,47 +1106,77 @@ pub fn format_tab_line(vf: &VariationFeature) -> Vec<String> {
             let strand_str = format!("{}", tv.strand.as_int());
             let flags_str = if tv.canonical { "canonical" } else { "-" };
 
-            let line = format!(
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                uploaded_variation,
-                location,
-                aa.allele,
-                tv.gene_id,
-                tv.transcript_id,
-                "Transcript",
-                consequence_str,
-                format_position_range(aa.cdna_position),
-                format_position_range(aa.cds_position),
-                format_position_range(aa.protein_position),
+            let mut parts: Vec<String> = Vec::with_capacity(17);
+            parts.push(uploaded_variation.clone());
+            parts.push(location.clone());
+            parts.push(aa.allele.to_string());
+            parts.push(tv.gene_id.to_string());
+            parts.push(tv.transcript_id.to_string());
+            parts.push("Transcript".to_string());
+            parts.push(consequence_str);
+            parts.push(format_position_range(aa.cdna_position));
+            parts.push(format_position_range(aa.cds_position));
+            parts.push(format_position_range(aa.protein_position));
+            parts.push(
                 aa.amino_acids
                     .as_ref()
                     .map(|(r, a)| format!("{}/{}", r, a))
                     .unwrap_or("-".to_string()),
+            );
+            parts.push(
                 aa.codons
                     .as_ref()
                     .map(|(r, a)| format!("{}/{}", r, a))
                     .unwrap_or("-".to_string()),
-                if aa.existing_variation.is_empty() { "-".to_string() } else { aa.existing_variation.join(",") },
-                impact_str,
-                distance_str,
-                strand_str,
-                flags_str,
             );
-            lines.push(line);
+            parts.push(if aa.existing_variation.is_empty() {
+                "-".to_string()
+            } else {
+                aa.existing_variation.join(",")
+            });
+            parts.push(impact_str);
+            parts.push(distance_str);
+            parts.push(strand_str);
+            parts.push(flags_str.to_string());
+
+            if supplementary_loaded {
+                parts.extend(format_supplementary_tab_columns_for_allele(
+                    vf, tv, aa, sa_keys, gene_keys,
+                ));
+            }
+
+            lines.push(parts.join("\t"));
         }
     }
 
     // If no transcript annotations, still output the variant with intergenic
     if vf.transcript_variations.is_empty() {
         for alt in &vf.alt_alleles {
-            let line = format!(
-                "{}\t{}\t{}\t-\t-\t-\t{}\t-\t-\t-\t-\t-\t-",
-                uploaded_variation,
-                location,
-                alt,
-                Consequence::IntergenicVariant.so_term(),
-            );
-            lines.push(line);
+            let mut parts: Vec<String> = vec![
+                uploaded_variation.clone(),
+                location.clone(),
+                alt.to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                Consequence::IntergenicVariant.so_term().to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+            ];
+            if supplementary_loaded {
+                let column_count =
+                    tab_supplementary_column_names(sa_keys, gene_keys).len();
+                parts.extend(std::iter::repeat("-".to_string()).take(column_count));
+            }
+            lines.push(parts.join("\t"));
         }
     }
 
@@ -1417,6 +1675,182 @@ mod tests {
         assert!(!info.contains("CSQ=old"));
         assert!(!info.contains("SpliceAI=old"));
         assert!(!info.contains("FV_CLINVAR=old"));
+    }
+
+    fn all_supplementary_sa_keys() -> Vec<String> {
+        vec![
+            "clinvar".into(),
+            "gnomad".into(),
+            "dbsnp".into(),
+            "cosmic".into(),
+            "oneKg".into(),
+            "topmed".into(),
+            "mitomap".into(),
+            "phylop".into(),
+            "gerp".into(),
+            "dann".into(),
+            "revel".into(),
+            "primateAI".into(),
+            "dbnsfp".into(),
+            "spliceAI".into(),
+        ]
+    }
+
+    fn all_supplementary_gene_keys() -> Vec<String> {
+        vec!["omim".into(), "gnomad_genes".into(), "clinvar_protein".into()]
+    }
+
+    #[test]
+    fn tab_supplementary_column_names_match_vcf_header_order() {
+        let sa_keys = all_supplementary_sa_keys();
+        let gene_keys = all_supplementary_gene_keys();
+        let cols = tab_supplementary_column_names(&sa_keys, &gene_keys);
+        // SpliceAI is emitted first to mirror the VCF header ordering, then
+        // every loaded VCF_PROJECTION_SPECS entry in declaration order.
+        assert_eq!(cols.first().copied(), Some("SpliceAI"));
+        for expected in [
+            "FV_CLINVAR",
+            "FV_GNOMAD",
+            "FV_DBSNP",
+            "FV_COSMIC",
+            "FV_1KG",
+            "FV_TOPMED",
+            "FV_MITOMAP",
+            "FV_PHYLOP",
+            "FV_GERP",
+            "FV_DANN",
+            "FV_REVEL",
+            "FV_PRIMATEAI",
+            "FV_DBNSFP",
+            "FV_OMIM",
+            "FV_GNOMAD_GENE",
+            "FV_CLINVAR_PROTEIN",
+        ] {
+            assert!(cols.contains(&expected), "missing column {expected}: {cols:?}");
+        }
+    }
+
+    #[test]
+    fn tab_supplementary_header_lines_document_pipe_format() {
+        let sa_keys = vec!["clinvar".into()];
+        let gene_keys: Vec<String> = vec![];
+        let lines = tab_supplementary_header_lines(&sa_keys, &gene_keys);
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("## COLUMN=<ID=FV_CLINVAR,Description=\"fastVEP ClinVar annotations. Format: ALLELE|SIGNIFICANCE|REVIEW_STATUS|PHENOTYPES|VARIANT_CLASS|SO_ACCESSION\">"),
+            "header lines should document FV_CLINVAR pipe format: {joined}"
+        );
+    }
+
+    #[test]
+    fn tab_line_emits_supplementary_columns_for_loaded_sources() {
+        let vf = projection_test_variant();
+        let sa_keys = all_supplementary_sa_keys();
+        let gene_keys = all_supplementary_gene_keys();
+        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        assert_eq!(lines.len(), 1, "test variant has exactly one TV×AA row");
+        let row = &lines[0];
+        let cols: Vec<&str> = row.split('\t').collect();
+
+        let extra_cols = tab_supplementary_column_names(&sa_keys, &gene_keys);
+        assert_eq!(
+            cols.len(),
+            17 + extra_cols.len(),
+            "tab row should carry 17 base columns plus one per loaded source"
+        );
+
+        // Pipe values must match the VCF projection exactly — they share the
+        // same renderer.
+        let vcf_projections: std::collections::HashMap<String, String> =
+            format_supplementary_vcf_info(&vf)
+                .into_iter()
+                .collect();
+
+        for (i, info_id) in extra_cols.iter().enumerate() {
+            let tab_value = cols[17 + i];
+            let expected = vcf_projections.get(*info_id).cloned().unwrap_or_else(|| "-".into());
+            assert_eq!(
+                tab_value, expected,
+                "tab column {info_id} should equal VCF INFO value"
+            );
+        }
+
+        // No JSON braces or quotes leaked into tab output.
+        assert!(!row.contains('{'), "tab row must not contain JSON: {row}");
+        assert!(!row.contains('}'), "tab row must not contain JSON: {row}");
+        assert!(!row.contains('"'), "tab row must not contain JSON quotes: {row}");
+    }
+
+    #[test]
+    fn tab_line_emits_dashes_when_no_supplementary_loaded_but_columns_requested() {
+        let mut vf = projection_test_variant();
+        // Drop all supplementary content from the test fixture.
+        for tv in &mut vf.transcript_variations {
+            for aa in &mut tv.allele_annotations {
+                aa.supplementary.clear();
+            }
+        }
+        vf.gene_annotations.clear();
+
+        let sa_keys = vec!["clinvar".into(), "dbnsfp".into()];
+        let gene_keys: Vec<String> = vec![];
+        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        let cols: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(cols.len(), 17 + 2);
+        assert_eq!(cols[17], "-", "FV_CLINVAR column should be '-' when absent");
+        assert_eq!(cols[18], "-", "FV_DBNSFP column should be '-' when absent");
+    }
+
+    #[test]
+    fn tab_line_has_no_extra_columns_when_no_sa_loaded() {
+        let vf = projection_test_variant();
+        let sa_keys: Vec<String> = vec![];
+        let gene_keys: Vec<String> = vec![];
+        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        let cols: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(
+            cols.len(),
+            17,
+            "without any loaded SA sources, the tab row keeps the original 17-column shape"
+        );
+    }
+
+    #[test]
+    fn supplementary_annotations_doc_lists_every_projection_spec() {
+        // The user-facing `docs/SUPPLEMENTARY_ANNOTATIONS.md` is the single
+        // place we point users at for the FV_* schema. If a new
+        // VCF_PROJECTION_SPECS entry is added without a matching doc entry,
+        // downstream parsers won't know its pipe format. This test fails CI
+        // in that case so the doc cannot drift from the code.
+        let doc = include_str!("../../../docs/SUPPLEMENTARY_ANNOTATIONS.md");
+        for spec in VCF_PROJECTION_SPECS {
+            assert!(
+                doc.contains(spec.info_id),
+                "docs/SUPPLEMENTARY_ANNOTATIONS.md is missing INFO ID {}",
+                spec.info_id
+            );
+            // Each spec's Description ends with "Format: <pipe layout>".
+            // Verify the pipe layout itself appears verbatim in the doc so
+            // grep-style downstream consumers can pull the schema from
+            // either source. (The "fastVEP X annotations. Format: " prose
+            // intentionally does not need to appear verbatim.)
+            let format = spec
+                .description
+                .split_once("Format: ")
+                .map(|(_, layout)| layout)
+                .unwrap_or(spec.description);
+            assert!(
+                doc.contains(format),
+                "docs/SUPPLEMENTARY_ANNOTATIONS.md is missing pipe format for {}: expected `{}`",
+                spec.info_id,
+                format
+            );
+        }
+        let spliceai_format = "ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL";
+        assert!(
+            doc.contains(spliceai_format),
+            "docs/SUPPLEMENTARY_ANNOTATIONS.md must document the SpliceAI pipe format"
+        );
     }
 
     #[test]

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -300,9 +300,17 @@ pub fn csq_header_line(fields: &[&str]) -> String {
     )
 }
 
+/// Description string shared by SpliceAI's VCF `##INFO=` header and the
+/// tab `## COLUMN=<...>` prologue so both formats document the same schema.
+pub const SPLICEAI_DESCRIPTION: &str =
+    "SpliceAI annotations. Format: ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL";
+
 /// Generate the VCF INFO header line for SpliceAI annotations emitted from fastSA.
-pub fn spliceai_header_line() -> &'static str {
-    "##INFO=<ID=SpliceAI,Number=.,Type=String,Description=\"SpliceAI annotations. Format: ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL\">"
+pub fn spliceai_header_line() -> String {
+    format!(
+        "##INFO=<ID=SpliceAI,Number=.,Type=String,Description=\"{}\">",
+        SPLICEAI_DESCRIPTION
+    )
 }
 
 #[derive(Clone, Copy)]
@@ -521,7 +529,7 @@ pub fn vcf_info_header_lines(
 ) -> Vec<String> {
     let mut headers = vec![csq_header_line(csq_fields)];
     if sa_keys.iter().any(|key| key == "spliceAI") {
-        headers.push(spliceai_header_line().to_string());
+        headers.push(spliceai_header_line());
     }
     for spec in VCF_PROJECTION_SPECS {
         let loaded = match spec.kind {
@@ -549,94 +557,106 @@ pub fn vcf_info_header_id(line: &str) -> Option<&str> {
     Some(&rest[..end])
 }
 
-/// Return the supplementary projection column names (info IDs) for tab output,
-/// in the same order as `vcf_info_header_lines` emits them. SpliceAI is
-/// included first when it's loaded, followed by every loaded
+/// Precomputed "which supplementary projections are loaded" view, derived
+/// once from the loaded SA / gene-annotation keys. Reused by the tab output
+/// helpers so each row avoids a fresh O(specs × keys) scan.
+pub struct LoadedSupplementarySpecs {
+    /// Whether the SpliceAI fastSA source is loaded; emitted as its own
+    /// un-namespaced INFO ID / tab column.
+    spliceai: bool,
+    /// Parallel to `VCF_PROJECTION_SPECS`: `true` when that spec's source is
+    /// loaded for this run.
+    per_spec: Vec<bool>,
+}
+
+impl LoadedSupplementarySpecs {
+    /// Build the lookup from the SA-provider and gene-provider JSON keys
+    /// computed by the annotation pipeline.
+    pub fn new(sa_keys: &[String], gene_keys: &[String]) -> Self {
+        let spliceai = sa_keys.iter().any(|key| key == "spliceAI");
+        let per_spec = VCF_PROJECTION_SPECS
+            .iter()
+            .map(|spec| match spec.kind {
+                VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
+                    gene_keys.iter().any(|key| key == spec.json_key)
+                }
+                VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
+                    sa_keys.iter().any(|key| key == spec.json_key)
+                }
+            })
+            .collect();
+        Self { spliceai, per_spec }
+    }
+
+    /// Number of extra tab columns this lookup will produce (including
+    /// SpliceAI). O(1) — just `popcount` over the precomputed flags.
+    pub fn column_count(&self) -> usize {
+        self.spliceai as usize + self.per_spec.iter().filter(|b| **b).count()
+    }
+
+    /// True when no supplementary source is loaded; callers can skip the
+    /// per-row work entirely in that case.
+    pub fn is_empty(&self) -> bool {
+        !self.spliceai && self.per_spec.iter().all(|b| !*b)
+    }
+
+    fn loaded_specs(&self) -> impl Iterator<Item = &'static VcfProjectionSpec> + '_ {
+        VCF_PROJECTION_SPECS
+            .iter()
+            .zip(self.per_spec.iter())
+            .filter_map(|(spec, loaded)| if *loaded { Some(spec) } else { None })
+    }
+}
+
+/// Return the supplementary projection column names (info IDs) for tab
+/// output, in the same order as `vcf_info_header_lines` emits them. SpliceAI
+/// is included first when it's loaded, followed by every loaded
 /// `VCF_PROJECTION_SPECS` entry.
-pub fn tab_supplementary_column_names(
-    sa_keys: &[String],
-    gene_keys: &[String],
-) -> Vec<&'static str> {
-    let mut names = Vec::new();
-    if sa_keys.iter().any(|key| key == "spliceAI") {
+pub fn tab_supplementary_column_names(specs: &LoadedSupplementarySpecs) -> Vec<&'static str> {
+    let mut names = Vec::with_capacity(specs.column_count());
+    if specs.spliceai {
         names.push("SpliceAI");
     }
-    for spec in VCF_PROJECTION_SPECS {
-        let loaded = match spec.kind {
-            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
-                gene_keys.iter().any(|key| key == spec.json_key)
-            }
-            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
-                sa_keys.iter().any(|key| key == spec.json_key)
-            }
-        };
-        if loaded {
-            names.push(spec.info_id);
-        }
+    for spec in specs.loaded_specs() {
+        names.push(spec.info_id);
     }
     names
 }
 
 /// Format `##` header comment lines describing the tab pipe-format for each
-/// loaded supplementary source. Mirrors `vcf_info_header_lines` content so the
-/// tab and VCF outputs document the same schema.
-pub fn tab_supplementary_header_lines(
-    sa_keys: &[String],
-    gene_keys: &[String],
-) -> Vec<String> {
-    let mut lines = Vec::new();
-    if sa_keys.iter().any(|key| key == "spliceAI") {
+/// loaded supplementary source. Mirrors `vcf_info_header_lines` content so
+/// the tab and VCF outputs document the same schema.
+pub fn tab_supplementary_header_lines(specs: &LoadedSupplementarySpecs) -> Vec<String> {
+    let mut lines = Vec::with_capacity(specs.column_count());
+    if specs.spliceai {
         lines.push(format!(
             "## COLUMN=<ID=SpliceAI,Description=\"{}\">",
-            "SpliceAI annotations. Format: ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL"
+            SPLICEAI_DESCRIPTION
         ));
     }
-    for spec in VCF_PROJECTION_SPECS {
-        let loaded = match spec.kind {
-            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
-                gene_keys.iter().any(|key| key == spec.json_key)
-            }
-            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
-                sa_keys.iter().any(|key| key == spec.json_key)
-            }
-        };
-        if loaded {
-            lines.push(format!(
-                "## COLUMN=<ID={},Description=\"{}\">",
-                spec.info_id, spec.description
-            ));
-        }
+    for spec in specs.loaded_specs() {
+        lines.push(format!(
+            "## COLUMN=<ID={},Description=\"{}\">",
+            spec.info_id, spec.description
+        ));
     }
     lines
 }
 
 /// Render the per-allele supplementary projection columns for a single tab
-/// row, in the same order as `tab_supplementary_column_names`. Missing values
-/// render as `-` so the column count is fixed.
+/// row, in the same order as `tab_supplementary_column_names`. Missing
+/// values render as `-` so the column count is fixed.
 pub fn format_supplementary_tab_columns_for_allele(
     vf: &VariationFeature,
     tv: &TranscriptVariation,
     aa: &AlleleAnnotation,
-    sa_keys: &[String],
-    gene_keys: &[String],
+    specs: &LoadedSupplementarySpecs,
 ) -> Vec<String> {
-    let mut cols = Vec::new();
-    if sa_keys.iter().any(|key| key == "spliceAI") {
-        let value = format_spliceai_for_allele(vf, aa).unwrap_or_else(|| "-".to_string());
-        cols.push(value);
+    let mut cols = Vec::with_capacity(specs.column_count());
+    if specs.spliceai {
+        cols.push(format_spliceai_for_allele(vf, aa).unwrap_or_else(|| "-".to_string()));
     }
-    for spec in VCF_PROJECTION_SPECS {
-        let loaded = match spec.kind {
-            VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
-                gene_keys.iter().any(|key| key == spec.json_key)
-            }
-            VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
-                sa_keys.iter().any(|key| key == spec.json_key)
-            }
-        };
-        if !loaded {
-            continue;
-        }
+    for spec in specs.loaded_specs() {
         let value = match spec.kind {
             VcfProjectionKind::AlleleObject | VcfProjectionKind::AlleleScalar => {
                 format_allele_projection_for_aa(vf, aa, spec)
@@ -707,29 +727,24 @@ pub fn format_vcf_info_fields(original_info: &str, vf: &VariationFeature, csq: &
 }
 
 fn format_spliceai_projection(vf: &VariationFeature) -> Option<String> {
-    let mut values = Vec::new();
-
+    let mut values: Vec<String> = Vec::new();
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
-            let allele = uploaded_allele_for_annotation(vf, &aa.allele);
-            for (key, json_str) in &aa.supplementary {
-                if key != "spliceAI" {
-                    continue;
-                }
-                if let Some(value) = format_spliceai_entry(&allele, json_str) {
-                    if !values.contains(&value) {
-                        values.push(value);
-                    }
+            let Some(joined) = format_spliceai_for_allele(vf, aa) else {
+                continue;
+            };
+            // The per-aa helper already comma-joins multiple entries for one
+            // allele; split them back out so variant-level dedupe stays
+            // entry-by-entry rather than across whole allele payloads.
+            for value in joined.split(',') {
+                let owned = value.to_string();
+                if !values.contains(&owned) {
+                    values.push(owned);
                 }
             }
         }
     }
-
-    if values.is_empty() {
-        None
-    } else {
-        Some(values.join(","))
-    }
+    if values.is_empty() { None } else { Some(values.join(",")) }
 }
 
 fn format_spliceai_entry(allele: &str, json_str: &str) -> Option<String> {
@@ -769,27 +784,16 @@ fn escape_spliceai_field(value: &str) -> String {
 }
 
 fn format_allele_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Option<String> {
-    let mut values = Vec::new();
+    let mut values: Vec<String> = Vec::new();
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
-            let allele = uploaded_allele_for_annotation(vf, &aa.allele);
-            for (key, json_str) in &aa.supplementary {
-                if key != spec.json_key {
-                    continue;
-                }
-                let parsed = serde_json::from_str::<Value>(json_str).unwrap_or_else(|_| {
-                    Value::String(json_str.clone())
-                });
-                let entries = match spec.kind {
-                    VcfProjectionKind::AlleleScalar => {
-                        vec![format!("{}|{}", escape_vcf_subfield(&allele), json_value_to_vcf(&parsed))]
-                    }
-                    _ => format_object_projection_entries(&allele, &parsed, spec.fields),
-                };
-                for value in entries {
-                    if !values.contains(&value) {
-                        values.push(value);
-                    }
+            let Some(joined) = format_allele_projection_for_aa(vf, aa, spec) else {
+                continue;
+            };
+            for value in joined.split(',') {
+                let owned = value.to_string();
+                if !values.contains(&owned) {
+                    values.push(owned);
                 }
             }
         }
@@ -870,11 +874,20 @@ fn format_gene_projection_for_tv(
     tv: &TranscriptVariation,
     spec: &VcfProjectionSpec,
 ) -> Option<String> {
-    let want = tv.gene_symbol.as_deref().unwrap_or(&tv.gene_id);
+    // Gene annotations are keyed by HGNC symbol. When the transcript has a
+    // known symbol, filter to that gene; otherwise emit every matching
+    // annotation for this variant — same dedupe semantics the VCF emitter
+    // uses — so tab rows for transcripts with no symbol don't lose data.
+    let symbol_filter = tv.gene_symbol.as_deref();
     let mut values: Vec<String> = Vec::new();
     for ga in &vf.gene_annotations {
-        if ga.json_key != spec.json_key || ga.gene_symbol != want {
+        if ga.json_key != spec.json_key {
             continue;
+        }
+        if let Some(want) = symbol_filter {
+            if ga.gene_symbol != want {
+                continue;
+            }
         }
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
@@ -899,11 +912,18 @@ fn format_clinvar_protein_projection_for_tv(
     tv: &TranscriptVariation,
     spec: &VcfProjectionSpec,
 ) -> Option<String> {
-    let want = tv.gene_symbol.as_deref().unwrap_or(&tv.gene_id);
+    // See `format_gene_projection_for_tv`: fall back to variant-level
+    // dedupe when the transcript has no associated gene symbol.
+    let symbol_filter = tv.gene_symbol.as_deref();
     let mut values: Vec<String> = Vec::new();
     for ga in &vf.gene_annotations {
-        if ga.json_key != spec.json_key || ga.gene_symbol != want {
+        if ga.json_key != spec.json_key {
             continue;
+        }
+        if let Some(want) = symbol_filter {
+            if ga.gene_symbol != want {
+                continue;
+            }
         }
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
@@ -1064,16 +1084,13 @@ fn uploaded_allele_for_annotation(vf: &VariationFeature, allele: &Allele) -> Str
 
 /// Format a VariationFeature as a tab-delimited VEP output line.
 ///
-/// `sa_keys` and `gene_keys` enumerate the supplementary annotation sources
-/// loaded for this run. For each loaded source, one extra tab column is
-/// appended carrying the same pipe-delimited value emitted into the VCF
-/// `FV_*` INFO field (`SpliceAI=` for the SpliceAI source). The column order
-/// matches `tab_supplementary_column_names`. Missing values render as `-`.
-pub fn format_tab_line(
-    vf: &VariationFeature,
-    sa_keys: &[String],
-    gene_keys: &[String],
-) -> Vec<String> {
+/// `specs` enumerates which supplementary annotation sources are loaded for
+/// this run (build once via `LoadedSupplementarySpecs::new`). For each
+/// loaded source, one extra tab column is appended carrying the same
+/// pipe-delimited value emitted into the corresponding VCF `FV_*` INFO field
+/// (and `SpliceAI=` for the SpliceAI source). The column order matches
+/// `tab_supplementary_column_names`. Missing values render as `-`.
+pub fn format_tab_line(vf: &VariationFeature, specs: &LoadedSupplementarySpecs) -> Vec<String> {
     let mut lines = Vec::new();
 
     let location = if vf.position.start == vf.position.end {
@@ -1090,7 +1107,8 @@ pub fn format_tab_line(
         .clone()
         .unwrap_or_else(|| format!("{}_{}", location, vf.allele_string));
 
-    let supplementary_loaded = !sa_keys.is_empty() || !gene_keys.is_empty();
+    let extra_count = specs.column_count();
+    let row_capacity = 17 + extra_count;
 
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
@@ -1106,7 +1124,7 @@ pub fn format_tab_line(
             let strand_str = format!("{}", tv.strand.as_int());
             let flags_str = if tv.canonical { "canonical" } else { "-" };
 
-            let mut parts: Vec<String> = Vec::with_capacity(17);
+            let mut parts: Vec<String> = Vec::with_capacity(row_capacity);
             parts.push(uploaded_variation.clone());
             parts.push(location.clone());
             parts.push(aa.allele.to_string());
@@ -1139,42 +1157,28 @@ pub fn format_tab_line(
             parts.push(strand_str);
             parts.push(flags_str.to_string());
 
-            if supplementary_loaded {
-                parts.extend(format_supplementary_tab_columns_for_allele(
-                    vf, tv, aa, sa_keys, gene_keys,
-                ));
+            if extra_count > 0 {
+                parts.extend(format_supplementary_tab_columns_for_allele(vf, tv, aa, specs));
             }
 
             lines.push(parts.join("\t"));
         }
     }
 
-    // If no transcript annotations, still output the variant with intergenic
+    // If no transcript annotations, still output the variant with intergenic.
+    // Pad the row to the full 17 + extra column shape so all tab rows share
+    // a header — even when only intergenic alleles are present.
     if vf.transcript_variations.is_empty() {
         for alt in &vf.alt_alleles {
-            let mut parts: Vec<String> = vec![
-                uploaded_variation.clone(),
-                location.clone(),
-                alt.to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                Consequence::IntergenicVariant.so_term().to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-            ];
-            if supplementary_loaded {
-                let column_count =
-                    tab_supplementary_column_names(sa_keys, gene_keys).len();
-                parts.extend(std::iter::repeat("-".to_string()).take(column_count));
+            let mut parts: Vec<String> = Vec::with_capacity(row_capacity);
+            parts.push(uploaded_variation.clone());
+            parts.push(location.clone());
+            parts.push(alt.to_string());
+            parts.extend(vec!["-".to_string(); 3]);
+            parts.push(Consequence::IntergenicVariant.so_term().to_string());
+            parts.extend(vec!["-".to_string(); 10]);
+            if extra_count > 0 {
+                parts.extend(vec!["-".to_string(); extra_count]);
             }
             lines.push(parts.join("\t"));
         }
@@ -1704,7 +1708,8 @@ mod tests {
     fn tab_supplementary_column_names_match_vcf_header_order() {
         let sa_keys = all_supplementary_sa_keys();
         let gene_keys = all_supplementary_gene_keys();
-        let cols = tab_supplementary_column_names(&sa_keys, &gene_keys);
+        let specs = LoadedSupplementarySpecs::new(&sa_keys, &gene_keys);
+        let cols = tab_supplementary_column_names(&specs);
         // SpliceAI is emitted first to mirror the VCF header ordering, then
         // every loaded VCF_PROJECTION_SPECS entry in declaration order.
         assert_eq!(cols.first().copied(), Some("SpliceAI"));
@@ -1734,7 +1739,8 @@ mod tests {
     fn tab_supplementary_header_lines_document_pipe_format() {
         let sa_keys = vec!["clinvar".into()];
         let gene_keys: Vec<String> = vec![];
-        let lines = tab_supplementary_header_lines(&sa_keys, &gene_keys);
+        let specs = LoadedSupplementarySpecs::new(&sa_keys, &gene_keys);
+        let lines = tab_supplementary_header_lines(&specs);
         let joined = lines.join("\n");
         assert!(
             joined.contains("## COLUMN=<ID=FV_CLINVAR,Description=\"fastVEP ClinVar annotations. Format: ALLELE|SIGNIFICANCE|REVIEW_STATUS|PHENOTYPES|VARIANT_CLASS|SO_ACCESSION\">"),
@@ -1747,20 +1753,19 @@ mod tests {
         let vf = projection_test_variant();
         let sa_keys = all_supplementary_sa_keys();
         let gene_keys = all_supplementary_gene_keys();
-        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        let specs = LoadedSupplementarySpecs::new(&sa_keys, &gene_keys);
+        let lines = format_tab_line(&vf, &specs);
         assert_eq!(lines.len(), 1, "test variant has exactly one TV×AA row");
         let row = &lines[0];
         let cols: Vec<&str> = row.split('\t').collect();
 
-        let extra_cols = tab_supplementary_column_names(&sa_keys, &gene_keys);
+        let extra_cols = tab_supplementary_column_names(&specs);
         assert_eq!(
             cols.len(),
             17 + extra_cols.len(),
             "tab row should carry 17 base columns plus one per loaded source"
         );
 
-        // Pipe values must match the VCF projection exactly — they share the
-        // same renderer.
         let vcf_projections: std::collections::HashMap<String, String> =
             format_supplementary_vcf_info(&vf)
                 .into_iter()
@@ -1775,7 +1780,6 @@ mod tests {
             );
         }
 
-        // No JSON braces or quotes leaked into tab output.
         assert!(!row.contains('{'), "tab row must not contain JSON: {row}");
         assert!(!row.contains('}'), "tab row must not contain JSON: {row}");
         assert!(!row.contains('"'), "tab row must not contain JSON quotes: {row}");
@@ -1784,7 +1788,6 @@ mod tests {
     #[test]
     fn tab_line_emits_dashes_when_no_supplementary_loaded_but_columns_requested() {
         let mut vf = projection_test_variant();
-        // Drop all supplementary content from the test fixture.
         for tv in &mut vf.transcript_variations {
             for aa in &mut tv.allele_annotations {
                 aa.supplementary.clear();
@@ -1792,9 +1795,11 @@ mod tests {
         }
         vf.gene_annotations.clear();
 
-        let sa_keys = vec!["clinvar".into(), "dbnsfp".into()];
-        let gene_keys: Vec<String> = vec![];
-        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        let specs = LoadedSupplementarySpecs::new(
+            &["clinvar".to_string(), "dbnsfp".to_string()],
+            &[],
+        );
+        let lines = format_tab_line(&vf, &specs);
         let cols: Vec<&str> = lines[0].split('\t').collect();
         assert_eq!(cols.len(), 17 + 2);
         assert_eq!(cols[17], "-", "FV_CLINVAR column should be '-' when absent");
@@ -1804,15 +1809,136 @@ mod tests {
     #[test]
     fn tab_line_has_no_extra_columns_when_no_sa_loaded() {
         let vf = projection_test_variant();
-        let sa_keys: Vec<String> = vec![];
-        let gene_keys: Vec<String> = vec![];
-        let lines = format_tab_line(&vf, &sa_keys, &gene_keys);
+        let specs = LoadedSupplementarySpecs::new(&[], &[]);
+        assert!(specs.is_empty());
+        let lines = format_tab_line(&vf, &specs);
         let cols: Vec<&str> = lines[0].split('\t').collect();
         assert_eq!(
             cols.len(),
             17,
             "without any loaded SA sources, the tab row keeps the original 17-column shape"
         );
+    }
+
+    #[test]
+    fn tab_line_intergenic_row_carries_full_column_shape_when_sources_loaded() {
+        // Regression test: when --sa-dir is loaded but a variant has no
+        // transcript hits, the intergenic-allele row must still match the
+        // header's column count so downstream parsers don't see ragged rows.
+        let mut vf = projection_test_variant();
+        vf.transcript_variations.clear();
+        let sa_keys = vec!["clinvar".to_string(), "dbnsfp".to_string()];
+        let gene_keys = vec!["omim".to_string()];
+        let specs = LoadedSupplementarySpecs::new(&sa_keys, &gene_keys);
+
+        let lines = format_tab_line(&vf, &specs);
+        assert_eq!(lines.len(), 1, "single alt allele yields one intergenic row");
+        let cols: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(cols.len(), 17 + 3, "intergenic row must include FV_* columns");
+        assert_eq!(cols[6], "intergenic_variant");
+        // All FV_* columns should be `-` for an intergenic row.
+        for tail in &cols[17..] {
+            assert_eq!(*tail, "-", "intergenic row should leave FV_* columns empty");
+        }
+    }
+
+    #[test]
+    fn tab_line_intergenic_row_keeps_17_columns_without_sa() {
+        // Backwards-compatibility check for users not passing --sa-dir.
+        let mut vf = projection_test_variant();
+        vf.transcript_variations.clear();
+        let specs = LoadedSupplementarySpecs::new(&[], &[]);
+        let lines = format_tab_line(&vf, &specs);
+        let cols: Vec<&str> = lines[0].split('\t').collect();
+        assert_eq!(cols.len(), 17);
+    }
+
+    #[test]
+    fn tab_line_emits_per_alt_values_for_multi_alt_variant() {
+        // Per-tab-row dedupe: a variant with two alts and a distinct
+        // supplementary payload per alt must produce two rows whose
+        // FV_CLINVAR cells differ.
+        use fastvep_core::Allele;
+
+        let mut vf = projection_test_variant();
+        // Replace single-alt transcript-variation with one TV per alt.
+        let base_tv = vf.transcript_variations[0].clone();
+        vf.alt_alleles = vec![Allele::from_str("G"), Allele::from_str("T")];
+        vf.allele_string = "A/G/T".into();
+        let mut tv_g = base_tv.clone();
+        tv_g.allele_annotations[0].allele = Allele::from_str("G");
+        tv_g.allele_annotations[0].supplementary = vec![(
+            "clinvar".into(),
+            r#"{"significance":["Pathogenic"],"reviewStatus":"","phenotypes":[],"variantClass":"SNV","soAccession":""}"#.into(),
+        )];
+        let mut tv_t = base_tv.clone();
+        tv_t.allele_annotations[0].allele = Allele::from_str("T");
+        tv_t.allele_annotations[0].supplementary = vec![(
+            "clinvar".into(),
+            r#"{"significance":["Benign"],"reviewStatus":"","phenotypes":[],"variantClass":"SNV","soAccession":""}"#.into(),
+        )];
+        vf.transcript_variations = vec![tv_g, tv_t];
+
+        let specs = LoadedSupplementarySpecs::new(&["clinvar".to_string()], &[]);
+        let lines = format_tab_line(&vf, &specs);
+        assert_eq!(lines.len(), 2);
+        assert!(
+            lines[0].split('\t').last().unwrap().starts_with("G|Pathogenic|"),
+            "first row should carry the ALT-G clinvar value: {}",
+            lines[0]
+        );
+        assert!(
+            lines[1].split('\t').last().unwrap().starts_with("T|Benign|"),
+            "second row should carry the ALT-T clinvar value: {}",
+            lines[1]
+        );
+    }
+
+    #[test]
+    fn tab_line_gene_projection_works_when_transcript_has_no_symbol() {
+        // Regression for the reviewer's Major #3: when a transcript has no
+        // gene_symbol, the per-tv gene filter previously fell back to
+        // gene_id which never matched any GeneAnnotation. Now we drop the
+        // symbol filter in that case so tab output carries the same value
+        // as VCF.
+        let mut vf = projection_test_variant();
+        vf.transcript_variations[0].gene_symbol = None;
+        let specs = LoadedSupplementarySpecs::new(&[], &["omim".to_string()]);
+        let lines = format_tab_line(&vf, &specs);
+        let cols: Vec<&str> = lines[0].split('\t').collect();
+        let fv_omim = cols.last().unwrap();
+        assert!(
+            fv_omim.starts_with("GENE1|113705|"),
+            "FV_OMIM cell should still carry the gene annotation: {}",
+            fv_omim
+        );
+    }
+
+    #[test]
+    fn tab_line_gracefully_handles_malformed_supplementary_json() {
+        // Garbage inside `aa.supplementary` must not panic and must not
+        // bleed into the tab output as raw bytes.
+        let mut vf = projection_test_variant();
+        for tv in &mut vf.transcript_variations {
+            for aa in &mut tv.allele_annotations {
+                aa.supplementary = vec![
+                    ("clinvar".into(), "{not valid json".into()),
+                    ("dbnsfp".into(), "".into()),
+                ];
+            }
+        }
+        vf.gene_annotations.clear();
+        let specs = LoadedSupplementarySpecs::new(
+            &["clinvar".to_string(), "dbnsfp".to_string()],
+            &[],
+        );
+        let lines = format_tab_line(&vf, &specs);
+        let row = &lines[0];
+        assert!(!row.contains('{'), "malformed JSON must not leak: {row}");
+        // Whatever the renderer does with the broken payload, the cell is
+        // a single tab-delimited field — not a multi-tab eruption.
+        let cols: Vec<&str> = row.split('\t').collect();
+        assert_eq!(cols.len(), 17 + 2);
     }
 
     #[test]

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -567,6 +567,10 @@ pub struct LoadedSupplementarySpecs {
     /// Parallel to `VCF_PROJECTION_SPECS`: `true` when that spec's source is
     /// loaded for this run.
     per_spec: Vec<bool>,
+    /// Total number of extra tab columns (`spliceai` + number of `true`
+    /// entries in `per_spec`), cached at construction so the per-row hot
+    /// path doesn't re-scan `per_spec` for the column count.
+    column_count: usize,
 }
 
 impl LoadedSupplementarySpecs {
@@ -574,7 +578,7 @@ impl LoadedSupplementarySpecs {
     /// computed by the annotation pipeline.
     pub fn new(sa_keys: &[String], gene_keys: &[String]) -> Self {
         let spliceai = sa_keys.iter().any(|key| key == "spliceAI");
-        let per_spec = VCF_PROJECTION_SPECS
+        let per_spec: Vec<bool> = VCF_PROJECTION_SPECS
             .iter()
             .map(|spec| match spec.kind {
                 VcfProjectionKind::GeneObject | VcfProjectionKind::ClinvarProtein => {
@@ -585,19 +589,20 @@ impl LoadedSupplementarySpecs {
                 }
             })
             .collect();
-        Self { spliceai, per_spec }
+        let column_count = spliceai as usize + per_spec.iter().filter(|b| **b).count();
+        Self { spliceai, per_spec, column_count }
     }
 
     /// Number of extra tab columns this lookup will produce (including
-    /// SpliceAI). O(1) — just `popcount` over the precomputed flags.
+    /// SpliceAI). True O(1) — value is cached at construction.
     pub fn column_count(&self) -> usize {
-        self.spliceai as usize + self.per_spec.iter().filter(|b| **b).count()
+        self.column_count
     }
 
     /// True when no supplementary source is loaded; callers can skip the
     /// per-row work entirely in that case.
     pub fn is_empty(&self) -> bool {
-        !self.spliceai && self.per_spec.iter().all(|b| !*b)
+        self.column_count == 0
     }
 
     fn loaded_specs(&self) -> impl Iterator<Item = &'static VcfProjectionSpec> + '_ {
@@ -801,8 +806,21 @@ fn format_allele_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> 
     if values.is_empty() { None } else { Some(values.join(",")) }
 }
 
+/// `GeneIndex::annotate_gene` returns either a single JSON object for a gene
+/// with one record or a JSON array of objects when several records hit the
+/// same gene symbol. This helper flattens both shapes to a slice of object
+/// `Value`s so the projection helpers can produce one pipe entry per record
+/// without losing data on multi-record genes.
+fn iter_gene_objects(parsed: &Value) -> Vec<&Value> {
+    match parsed {
+        Value::Object(_) => vec![parsed],
+        Value::Array(items) => items.iter().filter(|v| v.is_object()).collect(),
+        _ => Vec::new(),
+    }
+}
+
 fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Option<String> {
-    let mut values = Vec::new();
+    let mut values: Vec<String> = Vec::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -810,16 +828,18 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
         };
-        let mut parts = Vec::with_capacity(spec.fields.len() + 1);
-        parts.push(escape_vcf_subfield(&ga.gene_symbol));
-        if let Some(obj) = parsed.as_object() {
-            for (_, json_key) in spec.fields {
-                parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+        for object in iter_gene_objects(&parsed) {
+            let mut parts = Vec::with_capacity(spec.fields.len() + 1);
+            parts.push(escape_vcf_subfield(&ga.gene_symbol));
+            if let Some(obj) = object.as_object() {
+                for (_, json_key) in spec.fields {
+                    parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+                }
             }
-        }
-        let value = parts.join("|");
-        if !values.contains(&value) {
-            values.push(value);
+            let value = parts.join("|");
+            if !values.contains(&value) {
+                values.push(value);
+            }
         }
     }
     if values.is_empty() { None } else { Some(values.join(",")) }
@@ -892,16 +912,18 @@ fn format_gene_projection_for_tv(
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
         };
-        let mut parts = Vec::with_capacity(spec.fields.len() + 1);
-        parts.push(escape_vcf_subfield(&ga.gene_symbol));
-        if let Some(obj) = parsed.as_object() {
-            for (_, json_key) in spec.fields {
-                parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+        for object in iter_gene_objects(&parsed) {
+            let mut parts = Vec::with_capacity(spec.fields.len() + 1);
+            parts.push(escape_vcf_subfield(&ga.gene_symbol));
+            if let Some(obj) = object.as_object() {
+                for (_, json_key) in spec.fields {
+                    parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+                }
             }
-        }
-        let value = parts.join("|");
-        if !values.contains(&value) {
-            values.push(value);
+            let value = parts.join("|");
+            if !values.contains(&value) {
+                values.push(value);
+            }
         }
     }
     if values.is_empty() { None } else { Some(values.join(",")) }
@@ -928,22 +950,7 @@ fn format_clinvar_protein_projection_for_tv(
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
         };
-        let variants = parsed
-            .get("proteinVariants")
-            .and_then(|v| v.as_array())
-            .map(|vars| {
-                vars.iter()
-                    .filter_map(|v| {
-                        let pos = v.get("pos").map(json_leaf_to_string)?;
-                        let ref_aa = v.get("refAa").map(json_leaf_to_string)?;
-                        let alt_aa = v.get("altAa").map(json_leaf_to_string)?;
-                        let sig = v.get("sig").map(json_leaf_to_string).unwrap_or_default();
-                        Some(escape_vcf_subfield(&format!("{pos}:{ref_aa}>{alt_aa}:{sig}")))
-                    })
-                    .collect::<Vec<_>>()
-                    .join("&")
-            })
-            .unwrap_or_default();
+        let variants = collect_clinvar_protein_variants(&parsed);
         if variants.is_empty() {
             continue;
         }
@@ -955,11 +962,31 @@ fn format_clinvar_protein_projection_for_tv(
     if values.is_empty() { None } else { Some(values.join(",")) }
 }
 
+/// Pull every `proteinVariants[*]` entry out of a ClinVar-protein JSON
+/// payload and render the `&`-joined `pos:ref>alt:sig` list. Accepts either
+/// a single object payload or the JSON array `GeneIndex::annotate_gene`
+/// emits when a gene has multiple records.
+fn collect_clinvar_protein_variants(parsed: &Value) -> String {
+    iter_gene_objects(parsed)
+        .into_iter()
+        .filter_map(|obj| obj.get("proteinVariants").and_then(|v| v.as_array()))
+        .flat_map(|vars| vars.iter())
+        .filter_map(|v| {
+            let pos = v.get("pos").map(json_leaf_to_string)?;
+            let ref_aa = v.get("refAa").map(json_leaf_to_string)?;
+            let alt_aa = v.get("altAa").map(json_leaf_to_string)?;
+            let sig = v.get("sig").map(json_leaf_to_string).unwrap_or_default();
+            Some(escape_vcf_subfield(&format!("{pos}:{ref_aa}>{alt_aa}:{sig}")))
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
 fn format_clinvar_protein_projection(
     vf: &VariationFeature,
     spec: &VcfProjectionSpec,
 ) -> Option<String> {
-    let mut values = Vec::new();
+    let mut values: Vec<String> = Vec::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -967,22 +994,7 @@ fn format_clinvar_protein_projection(
         let Ok(parsed) = serde_json::from_str::<Value>(&ga.json_string) else {
             continue;
         };
-        let variants = parsed
-            .get("proteinVariants")
-            .and_then(|v| v.as_array())
-            .map(|vars| {
-                vars.iter()
-                    .filter_map(|v| {
-                        let pos = v.get("pos").map(json_leaf_to_string)?;
-                        let ref_aa = v.get("refAa").map(json_leaf_to_string)?;
-                        let alt_aa = v.get("altAa").map(json_leaf_to_string)?;
-                        let sig = v.get("sig").map(json_leaf_to_string).unwrap_or_default();
-                        Some(escape_vcf_subfield(&format!("{pos}:{ref_aa}>{alt_aa}:{sig}")))
-                    })
-                    .collect::<Vec<_>>()
-                    .join("&")
-            })
-            .unwrap_or_default();
+        let variants = collect_clinvar_protein_variants(&parsed);
         if variants.is_empty() {
             continue;
         }
@@ -1087,8 +1099,10 @@ fn uploaded_allele_for_annotation(vf: &VariationFeature, allele: &Allele) -> Str
 /// `specs` enumerates which supplementary annotation sources are loaded for
 /// this run (build once via `LoadedSupplementarySpecs::new`). For each
 /// loaded source, one extra tab column is appended carrying the same
-/// pipe-delimited value emitted into the corresponding VCF `FV_*` INFO field
-/// (and `SpliceAI=` for the SpliceAI source). The column order matches
+/// pipe-delimited value emitted into the corresponding VCF `FV_*` INFO
+/// field (or the `SpliceAI` INFO field for the SpliceAI source). The
+/// VCF-side `<ID>=` prefix is *not* included — the column header line
+/// already names each column. The column order matches
 /// `tab_supplementary_column_names`. Missing values render as `-`.
 pub fn format_tab_line(vf: &VariationFeature, specs: &LoadedSupplementarySpecs) -> Vec<String> {
     let mut lines = Vec::new();
@@ -1911,6 +1925,72 @@ mod tests {
             fv_omim.starts_with("GENE1|113705|"),
             "FV_OMIM cell should still carry the gene annotation: {}",
             fv_omim
+        );
+    }
+
+    #[test]
+    fn gene_projections_flatten_json_array_gene_payloads() {
+        // GeneIndex::annotate_gene wraps multi-record genes in a JSON
+        // array (`[{...},{...}]`). The variant- and per-tv-level helpers
+        // must flatten that into one pipe entry per record instead of
+        // emitting just `GENE1` with no fields (or dropping the value
+        // entirely for clinvar_protein). Regression test for Copilot
+        // review of PR #31.
+        let mut vf = projection_test_variant();
+        vf.gene_annotations = vec![
+            GeneAnnotation {
+                gene_symbol: "GENE1".into(),
+                json_key: "omim".into(),
+                json_string: r#"[{"mimNumber":113705,"phenotypes":["Breast cancer"]},{"mimNumber":167000,"phenotypes":["Ovarian cancer"]}]"#.into(),
+            },
+            GeneAnnotation {
+                gene_symbol: "GENE1".into(),
+                json_key: "clinvar_protein".into(),
+                json_string: r#"[{"proteinVariants":[{"pos":175,"refAa":"R","altAa":"H","sig":"Pathogenic"}]},{"proteinVariants":[{"pos":248,"refAa":"R","altAa":"W","sig":"Pathogenic"}]}]"#.into(),
+            },
+        ];
+
+        // VCF projection — should carry both OMIM entries comma-joined.
+        let info: std::collections::HashMap<String, String> =
+            format_supplementary_vcf_info(&vf).into_iter().collect();
+        let omim = info.get("FV_OMIM").expect("FV_OMIM should be present");
+        assert!(
+            omim.contains("GENE1|113705|Breast%20cancer"),
+            "FV_OMIM should carry first record: {omim}"
+        );
+        assert!(
+            omim.contains("GENE1|167000|Ovarian%20cancer"),
+            "FV_OMIM should carry second record: {omim}"
+        );
+        let cvp = info
+            .get("FV_CLINVAR_PROTEIN")
+            .expect("FV_CLINVAR_PROTEIN should be present even for array payload");
+        assert!(
+            cvp.contains("175%3AR>H%3APathogenic"),
+            "FV_CLINVAR_PROTEIN should carry first proteinVariants entry: {cvp}"
+        );
+        assert!(
+            cvp.contains("248%3AR>W%3APathogenic"),
+            "FV_CLINVAR_PROTEIN should carry second proteinVariants entry: {cvp}"
+        );
+
+        // Tab projection — same pipe values land in the per-row cells.
+        let specs = LoadedSupplementarySpecs::new(
+            &[],
+            &["omim".to_string(), "clinvar_protein".to_string()],
+        );
+        let lines = format_tab_line(&vf, &specs);
+        let row = &lines[0];
+        let cols: Vec<&str> = row.split('\t').collect();
+        let fv_omim = cols[17];
+        let fv_cvp = cols[18];
+        assert!(
+            fv_omim.contains("113705") && fv_omim.contains("167000"),
+            "tab FV_OMIM cell should carry both records: {fv_omim}"
+        );
+        assert!(
+            fv_cvp.contains("175%3AR>H") && fv_cvp.contains("248%3AR>W"),
+            "tab FV_CLINVAR_PROTEIN cell should carry both proteinVariants: {fv_cvp}"
         );
     }
 

--- a/docs/SUPPLEMENTARY_ANNOTATIONS.md
+++ b/docs/SUPPLEMENTARY_ANNOTATIONS.md
@@ -1,0 +1,136 @@
+# Supplementary annotation (fastSA) output contract
+
+This document is the authoritative schema for every supplementary annotation
+source produced by `fastvep sa-build` and emitted by `fastvep annotate`. The
+same per-source pipe format is used by the **VCF** `FV_*` INFO fields and by
+the **tab** `FV_*` columns; the **JSON** output carries the same data as a
+structured object under the source's JSON key.
+
+All identifiers prefixed with `FV_` are owned by fastVEP. When you annotate
+an input VCF that already declares one of these IDs, fastVEP strips the
+input's `##INFO=<ID=FV_*>` headers and any existing `FV_*` values from each
+record's INFO column before writing its own. Non-fastVEP INFO fields and the
+input's other headers pass through unchanged.
+
+## Identifiers across output formats
+
+| Source            | `sa-build --source` | JSON key          | VCF INFO ID         | Tab column          | Scope        |
+|-------------------|---------------------|-------------------|---------------------|---------------------|--------------|
+| ClinVar           | `clinvar`           | `clinvar`         | `FV_CLINVAR`        | `FV_CLINVAR`        | Allele       |
+| gnomAD            | `gnomad`            | `gnomad`          | `FV_GNOMAD`         | `FV_GNOMAD`         | Allele       |
+| dbSNP             | `dbsnp`             | `dbsnp`           | `FV_DBSNP`          | `FV_DBSNP`          | Allele       |
+| COSMIC            | `cosmic`            | `cosmic`          | `FV_COSMIC`         | `FV_COSMIC`         | Allele       |
+| 1000 Genomes      | `onekg`             | `oneKg`           | `FV_1KG`            | `FV_1KG`            | Allele       |
+| TOPMed            | `topmed`            | `topmed`          | `FV_TOPMED`         | `FV_TOPMED`         | Allele       |
+| MitoMap           | `mitomap`           | `mitomap`         | `FV_MITOMAP`        | `FV_MITOMAP`        | Allele       |
+| PhyloP            | `phylop`            | `phylop`          | `FV_PHYLOP`         | `FV_PHYLOP`         | Allele       |
+| GERP              | `gerp`              | `gerp`            | `FV_GERP`           | `FV_GERP`           | Allele       |
+| DANN              | `dann`              | `dann`            | `FV_DANN`           | `FV_DANN`           | Allele       |
+| REVEL             | `revel`             | `revel`           | `FV_REVEL`          | `FV_REVEL`          | Allele       |
+| PrimateAI         | `primateai`         | `primateAI`       | `FV_PRIMATEAI`      | `FV_PRIMATEAI`      | Allele       |
+| dbNSFP            | `dbnsfp`            | `dbnsfp`          | `FV_DBNSFP`         | `FV_DBNSFP`         | Allele       |
+| SpliceAI          | `spliceai`          | `spliceAI`        | `SpliceAI`          | `SpliceAI`          | Allele       |
+| OMIM / ClinGen GDV| `omim`              | `omim`            | `FV_OMIM`           | `FV_OMIM`           | Gene         |
+| gnomAD constraint | `gnomad_genes`      | `gnomad_genes`    | `FV_GNOMAD_GENE`    | `FV_GNOMAD_GENE`    | Gene         |
+| ClinVar protein   | `clinvar_protein`   | `clinvar_protein` | `FV_CLINVAR_PROTEIN`| `FV_CLINVAR_PROTEIN`| Gene         |
+
+`SpliceAI` is intentionally **not** namespaced under `FV_*` to remain
+compatible with the standard SpliceAI INFO contract that downstream tools
+already parse.
+
+## Pipe formats
+
+Each value is a pipe-delimited string. Multiple values for the same record
+(for example, multiple alt alleles or multiple gene entries) are separated by
+`,` in VCF and by `,` within the same tab cell. Empty fields render as the
+empty string between two pipes (`A||C`).
+
+Allele-level sources lead with the **uploaded ALT allele** (preserving the
+original REF/ALT of the input VCF, especially for indels); gene-level sources
+lead with the **gene symbol**.
+
+### Allele-level
+
+- `FV_CLINVAR`: `ALLELE|SIGNIFICANCE|REVIEW_STATUS|PHENOTYPES|VARIANT_CLASS|SO_ACCESSION`
+- `FV_GNOMAD`: `ALLELE|ALL_AF|ALL_AC|ALL_AN|ALL_HC|AFR_AF|AMR_AF|ASJ_AF|EAS_AF|FIN_AF|MID_AF|NFE_AF|OTH_AF|REMAINING_AF|SAS_AF`
+- `FV_DBSNP`: `ALLELE|ID|GLOBAL_MAF`
+- `FV_COSMIC`: `ALLELE|ID|GENE|COUNT`
+- `FV_1KG`: `ALLELE|ALL_AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF`
+- `FV_TOPMED`: `ALLELE|ALL_AF|ALL_AC|ALL_AN`
+- `FV_MITOMAP`: `ALLELE|DISEASE|STATUS`
+- `FV_PHYLOP`: `ALLELE|SCORE`
+- `FV_GERP`: `ALLELE|SCORE`
+- `FV_DANN`: `ALLELE|SCORE`
+- `FV_REVEL`: `ALLELE|SCORE`
+- `FV_PRIMATEAI`: `ALLELE|SCORE`
+- `FV_DBNSFP`: `ALLELE|SIFT|POLYPHEN`
+- `SpliceAI`: `ALLELE|SYMBOL|DS_AG|DS_AL|DS_DG|DS_DL|DP_AG|DP_AL|DP_DG|DP_DL`
+
+### Gene-level
+
+- `FV_OMIM`: `SYMBOL|MIM_NUMBER|PHENOTYPES`
+- `FV_GNOMAD_GENE`: `SYMBOL|PLI|LOEUF|MIS_Z|SYN_Z`
+- `FV_CLINVAR_PROTEIN`: `SYMBOL|PROTEIN_VARIANTS` — the `PROTEIN_VARIANTS`
+  segment is itself a `&`-joined list of `pos:ref>alt:significance` records.
+
+## Escaping inside pipe fields
+
+To keep `FV_*` values parseable by `bcftools` and similar tools without
+double-decoding, fastVEP percent-encodes the following characters within any
+pipe field:
+
+| Character | Replacement |
+|-----------|-------------|
+| `:`       | `%3A`       |
+| `;`       | `%3B`       |
+| `=`       | `%3D`       |
+| `%`       | `%25`       |
+| `,`       | `%2C`       |
+| `\r`      | `%0D`       |
+| `\n`      | `%0A`       |
+| `\t`      | `%09`       |
+| ` ` (space)| `%20`       |
+| `"`       | `%22`       |
+| `\|`      | `%7C`       |
+| `&`       | `%26`       |
+
+Lists within a single pipe field (for example, multiple ClinVar
+significances) are joined with `&` *after* per-element escaping, so the
+delimiter cannot collide with payload content.
+
+`bcftools query -f '%INFO/FV_CLINVAR\n'` returns the raw escaped value; a
+single percent-decode pass recovers the original. JSON output is **not**
+escaped this way — it carries the original strings unmodified inside a
+structured object.
+
+## Output-format behavior
+
+- **VCF**: each loaded source emits one `##INFO=<ID=FV_*,Number=.,Type=String,Description="...">`
+  header line and one `FV_*=<pipe value>` entry per record (omitted when the
+  variant has no annotation). The header `Description` carries the exact
+  pipe format above.
+- **Tab**: each loaded source appends one column to the row, after the 17
+  built-in columns. The file prologue contains one
+  `## COLUMN=<ID=FV_*,Description="...">` line per loaded source documenting
+  the pipe format. Empty cells render as `-`.
+- **JSON**: each loaded source places its full structured payload under its
+  JSON key (`clinvar`, `dbnsfp`, …) on the relevant transcript consequence
+  (allele-level) or under the variant's `genes` map (gene-level). JSON
+  output is the richest projection; VCF and tab are flattened views.
+
+## Adding a new source
+
+`crates/fastvep-io/src/output.rs` defines the single `VCF_PROJECTION_SPECS`
+constant that drives VCF emission, tab columns, header documentation, and
+input-VCF conflict stripping. Adding an entry there automatically:
+
+- declares the `##INFO=<ID=FV_NEW,...>` header,
+- appends the `FV_NEW` tab column,
+- strips any pre-existing `FV_NEW` INFO field from the input VCF,
+- and the unit test `tab_supplementary_column_names_match_vcf_header_order`
+  asserts the column appears in tab output.
+
+When you add a spec, update this document with the new row in the table
+above and the new pipe format in the per-source list. The doc-coverage check
+in CI fails if the schema in `output.rs` documents an INFO ID that is missing
+from this file.


### PR DESCRIPTION
## Summary

This PR adds support for supplementary annotation (fastSA) columns in tab-delimited output, addressing issue #30 where tab output was silently dropping all supplementary annotation sources. The implementation ensures tab and VCF outputs document and emit the same schema for allele-level and gene-level annotations.

## Key Changes

- **New `LoadedSupplementarySpecs` struct**: Precomputes which supplementary sources are loaded once at startup, avoiding O(specs × keys) membership scans for every variant row. Provides methods to query column count, check if empty, and iterate loaded specs.

- **Tab column helpers**: 
  - `tab_supplementary_column_names()` - returns column names in VCF header order (SpliceAI first, then VCF_PROJECTION_SPECS)
  - `tab_supplementary_header_lines()` - generates `## COLUMN=<...>` prologue lines documenting pipe formats
  - `format_supplementary_tab_columns_for_allele()` - renders per-allele supplementary values for a single row

- **Per-allele/per-gene formatting functions**: Extracted allele-level and gene-level projection logic into reusable helpers (`format_spliceai_for_allele()`, `format_allele_projection_for_aa()`, `format_gene_projection_for_tv()`, `format_clinvar_protein_projection_for_tv()`) that work on individual annotations rather than entire variants, enabling both VCF and tab output to use the same formatting code.

- **Updated `format_tab_line()`**: Now accepts a `LoadedSupplementarySpecs` parameter and appends supplementary columns to each row. Intergenic rows are padded with `-` values to maintain consistent column count across all rows.

- **Shared schema documentation**: Introduced `SPLICEAI_DESCRIPTION` constant used by both VCF `##INFO=` headers and tab `## COLUMN=` prologues, ensuring both formats document identical pipe formats.

- **New documentation**: Added `docs/SUPPLEMENTARY_ANNOTATIONS.md` as the authoritative schema reference for all supplementary sources, including identifier mappings across output formats, pipe format specifications, escaping rules, and per-format behavior.

- **Pipeline integration**: Updated `run_annotate()` to build `LoadedSupplementarySpecs` once and pass it to tab writer, plus emit supplementary header lines before the column header.

## Notable Implementation Details

- Missing supplementary values render as `-` in tab output (matching VCF's omission behavior) to maintain fixed column counts
- Per-row deduplication remains entry-by-entry rather than across whole allele payloads by splitting comma-joined values
- Gene-level projections filter by transcript's gene_symbol when available; fall back to variant-level deduplication when symbol is absent
- Comprehensive test coverage including multi-alt variants, malformed JSON handling, intergenic rows, and backwards compatibility for users without `--sa-dir`
- Documentation test verifies every `VCF_PROJECTION_SPECS` entry is documented in the schema file

https://claude.ai/code/session_0182EymYvVQ2d9H6tMP3KhRW