### PR TITLE
Surface data corruption instead of silently masking it as false negatives

### DIFF
--- a/crates/fastvep-cache/src/fasta.rs
+++ b/crates/fastvep-cache/src/fasta.rs
@@ -25,7 +25,20 @@ impl FastaReader {
                 if let Some(name) = current_name.take() {
                     sequences.insert(name, std::mem::take(&mut current_seq));
                 }
-                let name = line[1..].split_whitespace().next().unwrap_or("").to_string();
+                // The FASTA spec requires a non-empty identifier after `>`.
+                // An empty header would silently produce an unnamed sequence
+                // that downstream lookups can never match; surface it
+                // explicitly so the caller knows the file is malformed.
+                let name = line[1..]
+                    .split_whitespace()
+                    .next()
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "FASTA contains a `>` line with no sequence identifier"
+                        )
+                    })?;
                 current_name = Some(name);
                 current_seq.clear();
             } else if !line.is_empty() {

--- a/crates/fastvep-cache/src/gff.rs
+++ b/crates/fastvep-cache/src/gff.rs
@@ -10,20 +10,18 @@ use std::sync::Arc;
 ///
 /// Builds gene -> transcript -> exon/CDS hierarchy from GFF3 features.
 ///
-/// Surfaces line-read errors instead of swallowing them (earlier this
-/// folded any IO error into an empty line via `unwrap_or_default`, which
-/// silently produced an empty transcript set on truncated or unreadable
-/// GFF3 files).
+/// Streams lines from `reader` straight into the parser so a multi-GB
+/// Ensembl/GENCODE GFF3 doesn't have to be materialised as `Vec<String>`
+/// before parsing begins. Per-line IO errors are surfaced via the
+/// `Result<String>` iterator with a 1-based line number for diagnostics
+/// (earlier code folded IO errors into empty lines via `unwrap_or_default`,
+/// which silently produced an empty transcript set on truncated files).
 pub fn parse_gff3<R: Read>(reader: R) -> Result<Vec<Transcript>> {
     let buf = BufReader::new(reader);
-    let mut lines: Vec<String> = Vec::new();
-    for (i, line) in buf.lines().enumerate() {
-        let line = line.map_err(|e| {
-            anyhow::anyhow!("Reading GFF3 line {}: {}", i + 1, e)
-        })?;
-        lines.push(line);
-    }
-    parse_gff3_lines(lines.into_iter())
+    let lines = buf.lines().enumerate().map(|(i, line)| {
+        line.map_err(|e| anyhow::anyhow!("Reading GFF3 line {}: {}", i + 1, e))
+    });
+    parse_gff3_lines(lines)
 }
 
 /// Parse a tabix-indexed GFF3 file, loading only transcripts overlapping given regions.
@@ -117,17 +115,25 @@ pub fn parse_gff3_indexed(
         }
     }
 
-    parse_gff3_lines(all_lines.into_iter())
+    // Lines were already collected into memory by the tabix-chunk loop above,
+    // so wrap them in `Ok` to satisfy the streaming-aware parser signature.
+    parse_gff3_lines(all_lines.into_iter().map(Ok))
 }
 
-/// Core GFF3 parsing logic: takes an iterator of lines and builds Transcript models.
-fn parse_gff3_lines(lines: impl Iterator<Item = String>) -> Result<Vec<Transcript>> {
+/// Core GFF3 parsing logic: takes an iterator of `Result<String>` lines and
+/// builds Transcript models. Each item is either a raw line or a typed IO
+/// error from the underlying reader; the latter aborts parsing immediately
+/// rather than being silently treated as an empty line.
+fn parse_gff3_lines(
+    lines: impl Iterator<Item = Result<String>>,
+) -> Result<Vec<Transcript>> {
     let mut genes: HashMap<String, GffGene> = HashMap::new();
     let mut transcripts: HashMap<String, GffTranscript> = HashMap::new();
     let mut exons: Vec<GffExon> = Vec::new();
     let mut cds_features: Vec<GffCds> = Vec::new();
 
     for line in lines {
+        let line = line?;
         let line = line.trim().to_string();
         let line = line.as_str();
         if line.is_empty() || line.starts_with('#') {

--- a/crates/fastvep-cache/src/gff.rs
+++ b/crates/fastvep-cache/src/gff.rs
@@ -9,9 +9,21 @@ use std::sync::Arc;
 /// Parse a GFF3 file into Transcript models.
 ///
 /// Builds gene -> transcript -> exon/CDS hierarchy from GFF3 features.
+///
+/// Surfaces line-read errors instead of swallowing them (earlier this
+/// folded any IO error into an empty line via `unwrap_or_default`, which
+/// silently produced an empty transcript set on truncated or unreadable
+/// GFF3 files).
 pub fn parse_gff3<R: Read>(reader: R) -> Result<Vec<Transcript>> {
     let buf = BufReader::new(reader);
-    parse_gff3_lines(buf.lines().map(|l| l.unwrap_or_default()))
+    let mut lines: Vec<String> = Vec::new();
+    for (i, line) in buf.lines().enumerate() {
+        let line = line.map_err(|e| {
+            anyhow::anyhow!("Reading GFF3 line {}: {}", i + 1, e)
+        })?;
+        lines.push(line);
+    }
+    parse_gff3_lines(lines.into_iter())
 }
 
 /// Parse a tabix-indexed GFF3 file, loading only transcripts overlapping given regions.
@@ -129,12 +141,23 @@ fn parse_gff3_lines(lines: impl Iterator<Item = String>) -> Result<Vec<Transcrip
 
         let seqid = fields[0];
         let feature_type = fields[2];
-        let start: u64 = fields[3].parse().unwrap_or(0);
-        let end: u64 = fields[4].parse().unwrap_or(0);
+        // Coordinates are required and integral. Earlier these defaulted to 0
+        // on parse failure, silently emitting features at position 0 — which
+        // then collided with everything during overlap queries. Skip the
+        // line with a warning instead so the rest of the file still parses.
+        let Ok(start) = fields[3].parse::<u64>() else {
+            log::warn!("GFF3: skipping line with non-numeric start: {}", fields[3]);
+            continue;
+        };
+        let Ok(end) = fields[4].parse::<u64>() else {
+            log::warn!("GFF3: skipping line with non-numeric end: {}", fields[4]);
+            continue;
+        };
         let strand = match fields[6] {
             "-" => Strand::Reverse,
             _ => Strand::Forward,
         };
+        // Phase is allowed to be "." in GFF3 (no phase); use -1 sentinel.
         let phase: i8 = fields[7].parse().unwrap_or(-1);
         let attrs = parse_attributes(fields[8]);
 
@@ -836,5 +859,33 @@ chr1\tensembl\texon\t6000\t9000\t.\t-\t.\tID=exon:ENSE00000002;Parent=transcript
         assert_eq!(url_decode("hello%20world"), "hello world");
         assert_eq!(url_decode("100%25"), "100%");
         assert_eq!(url_decode("normal"), "normal");
+    }
+
+    #[test]
+    fn test_gff3_skips_malformed_coordinate_lines() {
+        // Two lines: one valid mRNA, one with a non-numeric start. The malformed
+        // line used to silently parse as start=0, end=0 — colliding with every
+        // overlap query. It should now be skipped (with a logged warning),
+        // leaving the valid line intact.
+        let gff = "##gff-version 3
+chr1\tensembl\tgene\t1000\t5000\t.\t+\t.\tID=gene:G1;Name=T;biotype=protein_coding
+chr1\tensembl\tmRNA\tNOT_A_NUMBER\t5000\t.\t+\t.\tID=transcript:TX1;Parent=gene:G1;biotype=protein_coding
+chr1\tensembl\tmRNA\t1000\t5000\t.\t+\t.\tID=transcript:TX2;Parent=gene:G1;biotype=protein_coding;tag=Ensembl_canonical
+chr1\tensembl\texon\t1000\t1200\t.\t+\t.\tID=exon:E1;Parent=transcript:TX2;rank=1
+chr1\tensembl\tCDS\t1050\t1200\t.\t+\t0\tID=CDS:P1;Parent=transcript:TX2";
+        let transcripts = parse_gff3(gff.as_bytes()).unwrap();
+        // Only TX2 should appear; TX1 had a bogus start and was skipped.
+        assert_eq!(transcripts.len(), 1);
+        assert_eq!(&*transcripts[0].stable_id, "TX2");
+        assert_eq!(transcripts[0].start, 1000);
+    }
+
+    #[test]
+    fn test_fasta_rejects_empty_header() {
+        // An empty `>` line would silently make every following base part of an
+        // unnamed sequence that no downstream query can fetch.
+        let bad = ">\nACGT\n";
+        let res = crate::fasta::FastaReader::from_reader(bad.as_bytes());
+        assert!(res.is_err(), "FASTA with empty header should fail to parse");
     }
 }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -279,11 +279,23 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
     // would emit always-empty headers/columns.
     let gene_providers: Vec<fastvep_sa::gene::GeneIndex> = if sa_only {
         if let Some(ref dir) = config.sa_dir {
-            let probe = load_gene_providers(Path::new(dir))?;
-            if !probe.is_empty() {
+            // Cheap probe: just count `.oga` files instead of fully loading
+            // each one. Earlier this path called `load_gene_providers` and
+            // discarded the result, paying the full disk-read cost for a
+            // warning message that only needs a yes/no on presence.
+            let oga_count = std::fs::read_dir(Path::new(dir))
+                .map(|it| {
+                    it.flatten()
+                        .filter(|e| {
+                            e.path().extension().and_then(|s| s.to_str()) == Some("oga")
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            if oga_count > 0 {
                 eprintln!(
                     "warning: --sa-only ignores {} gene-level annotation source(s) (.oga) in {}; gene-level SA requires transcript overlap.",
-                    probe.len(),
+                    oga_count,
                     dir
                 );
             }
@@ -342,7 +354,11 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                 .with_context(|| format!("Creating output file: {}", config.output))?,
         )
     };
-    let mut writer = BufWriter::new(output_writer);
+    // 1 MiB buffer instead of the default 8 KiB: the per-variant output path
+    // emits dozens of small `write!` calls per row, so a larger buffer cuts
+    // the number of syscalls on a typical VCF (millions of variants) by
+    // roughly two orders of magnitude.
+    let mut writer = BufWriter::with_capacity(1 << 20, output_writer);
     let sa_json_keys: Vec<String> = sa_providers
         .iter()
         .map(|sa| sa.json_key().to_string())
@@ -1534,13 +1550,13 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
         Box::new(io::BufReader::new(f))
     };
 
-    // Open output
+    // Open output. 1 MiB buffer same rationale as the main annotation path.
     let mut writer: Box<dyn Write> = if output_path == "-" {
-        Box::new(BufWriter::new(io::stdout()))
+        Box::new(BufWriter::with_capacity(1 << 20, io::stdout()))
     } else {
         let f = File::create(output_path)
             .with_context(|| format!("Creating output: {}", output_path))?;
-        Box::new(BufWriter::new(f))
+        Box::new(BufWriter::with_capacity(1 << 20, f))
     };
 
     // Parse CSQ header to get field names

--- a/crates/fastvep-cli/tests/sa_build_oga.rs
+++ b/crates/fastvep-cli/tests/sa_build_oga.rs
@@ -847,6 +847,89 @@ fn sa_only_requires_sa_dir() {
 }
 
 #[test]
+fn sa_only_multi_allelic_emits_per_alt_rows_with_independent_sa_columns() {
+    // Regression: --sa-only mode must lookup supplementary annotations
+    // independently for each ALT of a multi-allelic site. The input has
+    // 1:30000 C>T,A. A ClinVar fixture is seeded with a match for C>T only.
+    // We expect exactly two rows for 1:30000 — one per alt — with
+    // FV_CLINVAR populated only on the T row.
+    let tmp = tempfile::tempdir().unwrap();
+    let input_vcf = tmp.path().join("input.vcf");
+    let output_tab = tmp.path().join("annotated.tab");
+    fs::write(&input_vcf, INPUT_NO_SPLICEAI_INFO_VCF).unwrap();
+
+    // Custom ClinVar fixture: pathogenic for C>T at chr1:30000, nothing at A.
+    let clinvar_source = tmp.path().join("clinvar-mini.vcf");
+    let clinvar_base = tmp.path().join("clinvar-mini");
+    let clinvar_fixture = "\
+##fileformat=VCFv4.1
+##INFO=<ID=CLNSIG,Number=.,Type=String>
+##INFO=<ID=CLNREVSTAT,Number=.,Type=String>
+##INFO=<ID=CLNDN,Number=.,Type=String>
+##INFO=<ID=CLNVC,Number=.,Type=String>
+##INFO=<ID=CLNVCSO,Number=.,Type=String>
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t30000\trs2\tC\tT\t.\t.\tCLNSIG=Likely_pathogenic;CLNREVSTAT=criteria_provided;CLNDN=Test;CLNVC=SNV;CLNVCSO=SO:0001483
+";
+    fs::write(&clinvar_source, clinvar_fixture).unwrap();
+    run_sa_build(
+        "clinvar",
+        clinvar_source.to_str().unwrap(),
+        clinvar_base.to_str().unwrap(),
+        "GRCh38",
+    )
+    .unwrap();
+
+    run_annotate(AnnotateConfig {
+        input: input_vcf.to_string_lossy().into_owned(),
+        output: output_tab.to_string_lossy().into_owned(),
+        gff3: None,
+        fasta: None,
+        output_format: "tab".into(),
+        pick: false,
+        hgvs: false,
+        distance: 0,
+        cache_dir: None,
+        transcript_cache: None,
+        sa_dir: Some(tmp.path().to_string_lossy().into_owned()),
+        sa_only: true,
+        acmg: false,
+        acmg_config: None,
+        proband: None,
+        mother: None,
+        father: None,
+    })
+    .unwrap();
+
+    let annotated = fs::read_to_string(&output_tab).unwrap();
+    let rows_30k: Vec<&str> = annotated
+        .lines()
+        .filter(|l| !l.starts_with('#') && l.contains("1:30000\t"))
+        .collect();
+    assert_eq!(rows_30k.len(), 2, "expected one row per ALT, got: {:?}", rows_30k);
+
+    let mut t_row = None;
+    let mut a_row = None;
+    for row in rows_30k {
+        let cols: Vec<&str> = row.split('\t').collect();
+        assert_eq!(cols.len(), 4, "sa-only tab row must be 4 cols: {}", row);
+        match cols[2] {
+            "T" => t_row = Some(cols[3].to_string()),
+            "A" => a_row = Some(cols[3].to_string()),
+            other => panic!("unexpected allele: {}", other),
+        }
+    }
+    let t_fv = t_row.expect("missing T row");
+    let a_fv = a_row.expect("missing A row");
+    assert!(
+        t_fv.starts_with("T|Likely_pathogenic"),
+        "T row must carry ClinVar match: {}",
+        t_fv
+    );
+    assert_eq!(a_fv, "-", "A row must have no ClinVar match: {}", a_fv);
+}
+
+#[test]
 fn sa_only_strips_preexisting_csq_from_input_info() {
     // Regression: --sa-only must strip any stale CSQ=... already present in
     // the input VCF's INFO column. Otherwise the output has CSQ= data rows
@@ -910,6 +993,56 @@ fn sa_only_strips_preexisting_csq_from_input_info() {
         "FV_CLINVAR must still be added: {}",
         data_row
     );
+}
+
+#[test]
+fn sa_only_strips_csq_when_in_middle_of_info_field() {
+    // CSQ stripping must work even when CSQ is sandwiched between other INFO
+    // keys. Earlier this was only tested with CSQ at the leading position;
+    // make sure the middle case also leaves neighbouring fields intact.
+    let tmp = tempfile::tempdir().unwrap();
+    let input_vcf = tmp.path().join("input_csq_middle.vcf");
+    let output_vcf = tmp.path().join("annotated.vcf");
+    fs::write(
+        &input_vcf,
+        "##fileformat=VCFv4.2\n\
+         ##INFO=<ID=CSQ,Number=.,Type=String,Description=\"stale\">\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         1\t25000\t.\tA\tG\t.\t.\tAC=1;CSQ=stale_middle;AF=0.5\n",
+    )
+    .unwrap();
+    write_clinvar_fixture(tmp.path());
+
+    run_annotate(AnnotateConfig {
+        input: input_vcf.to_string_lossy().into_owned(),
+        output: output_vcf.to_string_lossy().into_owned(),
+        gff3: None,
+        fasta: None,
+        output_format: "vcf".into(),
+        pick: false,
+        hgvs: false,
+        distance: 0,
+        cache_dir: None,
+        transcript_cache: None,
+        sa_dir: Some(tmp.path().to_string_lossy().into_owned()),
+        sa_only: true,
+        acmg: false,
+        acmg_config: None,
+        proband: None,
+        mother: None,
+        father: None,
+    })
+    .unwrap();
+
+    let annotated = fs::read_to_string(&output_vcf).unwrap();
+    let row = annotated
+        .lines()
+        .find(|l| !l.starts_with('#'))
+        .expect("expected a data row");
+    assert!(!row.contains("CSQ=stale"), "stale CSQ in middle not stripped: {}", row);
+    assert!(row.contains("AC=1"), "AC must be preserved: {}", row);
+    assert!(row.contains("AF=0.5"), "AF must be preserved: {}", row);
+    assert!(row.contains("FV_CLINVAR="), "FV_CLINVAR must still be added: {}", row);
 }
 
 #[test]

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -757,8 +757,13 @@ fn format_spliceai_projection(vf: &VariationFeature) -> Option<String> {
             // allele; split them back out so variant-level dedupe stays
             // entry-by-entry rather than across whole allele payloads.
             for value in joined.split(',') {
-                if seen.insert(value.to_string()) {
-                    values.push(value.to_string());
+                // Allocate the owned String once; clone it into the HashSet
+                // and only retain it in `values` on first-seen. Earlier code
+                // called `value.to_string()` twice per unique entry, doubling
+                // allocations in this hot path.
+                let owned = value.to_string();
+                if seen.insert(owned.clone()) {
+                    values.push(owned);
                 }
             }
         }
@@ -815,8 +820,10 @@ fn format_allele_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> 
                 continue;
             };
             for value in joined.split(',') {
-                if seen.insert(value.to_string()) {
-                    values.push(value.to_string());
+                // Single allocation per unique value (see `format_spliceai_projection`).
+                let owned = value.to_string();
+                if seen.insert(owned.clone()) {
+                    values.push(owned);
                 }
             }
         }

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -745,7 +745,9 @@ pub fn format_vcf_info_fields(original_info: &str, vf: &VariationFeature, csq: &
 }
 
 fn format_spliceai_projection(vf: &VariationFeature) -> Option<String> {
+    // O(n) order-preserving dedup (was O(n^2) via `Vec::contains`).
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
             let Some(joined) = format_spliceai_for_allele(vf, aa) else {
@@ -755,9 +757,8 @@ fn format_spliceai_projection(vf: &VariationFeature) -> Option<String> {
             // allele; split them back out so variant-level dedupe stays
             // entry-by-entry rather than across whole allele payloads.
             for value in joined.split(',') {
-                let owned = value.to_string();
-                if !values.contains(&owned) {
-                    values.push(owned);
+                if seen.insert(value.to_string()) {
+                    values.push(value.to_string());
                 }
             }
         }
@@ -802,16 +803,20 @@ fn escape_spliceai_field(value: &str) -> String {
 }
 
 fn format_allele_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Option<String> {
+    // Preserve first-seen order while deduplicating in O(n) instead of the
+    // earlier O(n^2) `Vec::contains` scan. A variant overlapping many
+    // transcripts with the same SA payload can otherwise quadruple-walk
+    // every projection string in a hot loop.
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for tv in &vf.transcript_variations {
         for aa in &tv.allele_annotations {
             let Some(joined) = format_allele_projection_for_aa(vf, aa, spec) else {
                 continue;
             };
             for value in joined.split(',') {
-                let owned = value.to_string();
-                if !values.contains(&owned) {
-                    values.push(owned);
+                if seen.insert(value.to_string()) {
+                    values.push(value.to_string());
                 }
             }
         }
@@ -834,6 +839,7 @@ fn iter_gene_objects(parsed: &Value) -> Vec<&Value> {
 
 fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Option<String> {
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -850,7 +856,7 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
                 }
             }
             let value = parts.join("|");
-            if !values.contains(&value) {
+            if seen.insert(value.clone()) {
                 values.push(value);
             }
         }
@@ -861,12 +867,13 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
 fn format_spliceai_for_allele(vf: &VariationFeature, aa: &AlleleAnnotation) -> Option<String> {
     let allele = uploaded_allele_for_annotation(vf, &aa.allele);
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (key, json_str) in &aa.supplementary {
         if key != "spliceAI" {
             continue;
         }
         if let Some(value) = format_spliceai_entry(&allele, json_str) {
-            if !values.contains(&value) {
+            if seen.insert(value.clone()) {
                 values.push(value);
             }
         }
@@ -881,12 +888,28 @@ fn format_allele_projection_for_aa(
 ) -> Option<String> {
     let allele = uploaded_allele_for_annotation(vf, &aa.allele);
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (key, json_str) in &aa.supplementary {
         if key != spec.json_key {
             continue;
         }
-        let parsed = serde_json::from_str::<Value>(json_str)
-            .unwrap_or_else(|_| Value::String(json_str.clone()));
+        // Truncated or otherwise non-JSON supplementary payloads used to fall
+        // back to `Value::String(json_str.clone())` here, which silently
+        // pushed the raw blob into the projection. Now we log at debug level
+        // and skip this entry — callers see a missing column instead of a
+        // mis-shaped one.
+        let parsed = match serde_json::from_str::<Value>(json_str) {
+            Ok(v) => v,
+            Err(e) => {
+                log::debug!(
+                    "Skipping non-JSON supplementary payload for key='{}': {} (payload snippet: {})",
+                    spec.json_key,
+                    e,
+                    &json_str.chars().take(80).collect::<String>(),
+                );
+                continue;
+            }
+        };
         let entries = match spec.kind {
             VcfProjectionKind::AlleleScalar => {
                 vec![format!("{}|{}", escape_vcf_subfield(&allele), json_value_to_vcf(&parsed))]
@@ -894,7 +917,7 @@ fn format_allele_projection_for_aa(
             _ => format_object_projection_entries(&allele, &parsed, spec.fields),
         };
         for value in entries {
-            if !values.contains(&value) {
+            if seen.insert(value.clone()) {
                 values.push(value);
             }
         }
@@ -913,6 +936,7 @@ fn format_gene_projection_for_tv(
     // uses — so tab rows for transcripts with no symbol don't lose data.
     let symbol_filter = tv.gene_symbol.as_deref();
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -934,7 +958,7 @@ fn format_gene_projection_for_tv(
                 }
             }
             let value = parts.join("|");
-            if !values.contains(&value) {
+            if seen.insert(value.clone()) {
                 values.push(value);
             }
         }
@@ -951,6 +975,7 @@ fn format_clinvar_protein_projection_for_tv(
     // dedupe when the transcript has no associated gene symbol.
     let symbol_filter = tv.gene_symbol.as_deref();
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -968,7 +993,7 @@ fn format_clinvar_protein_projection_for_tv(
             continue;
         }
         let value = format!("{}|{}", escape_vcf_subfield(&ga.gene_symbol), variants);
-        if !values.contains(&value) {
+        if seen.insert(value.clone()) {
             values.push(value);
         }
     }
@@ -1000,6 +1025,7 @@ fn format_clinvar_protein_projection(
     spec: &VcfProjectionSpec,
 ) -> Option<String> {
     let mut values: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ga in &vf.gene_annotations {
         if ga.json_key != spec.json_key {
             continue;
@@ -1012,7 +1038,7 @@ fn format_clinvar_protein_projection(
             continue;
         }
         let value = format!("{}|{}", escape_vcf_subfield(&ga.gene_symbol), variants);
-        if !values.contains(&value) {
+        if seen.insert(value.clone()) {
             values.push(value);
         }
     }

--- a/crates/fastvep-sa/src/bloom.rs
+++ b/crates/fastvep-sa/src/bloom.rs
@@ -69,13 +69,23 @@ fn fmix32(mut h: u32) -> u32 {
 /// fast and bounded.
 const MAX_HASHES: u32 = 16;
 
-/// Upper bound on bits per element. At 14 bits/element a Bloom filter with
-/// the optimal number of hashes has a false-positive rate of ~1e-4, which is
-/// more than enough for any reasonable genomic deployment. Capping here
-/// keeps the bit-count math entirely inside `u64`/`usize` even when `n`
-/// exceeds `2^53` (the f64 mantissa) — beyond that point the `as f64` cast
-/// loses integer precision and the previous formula could yield 0 or +∞.
+/// Upper bound on bits per element. The optimal formula
+/// `m = -n * ln(p) / (ln 2)^2` runs through `as f64` and loses integer
+/// precision once `n` exceeds `2^53` (the f64 mantissa). For tiny `p` or
+/// huge `n` the unbounded result can also be 0 or +∞. Capping the
+/// bits/element ratio keeps the result in a sane range no matter what the
+/// caller asks for.
+///
+/// 64 bits/element is generous (well below `f64`'s precision boundary and
+/// far past the ~14 bits/element that already gives FPR ≈ 1e-4 at the
+/// optimal hash count). A reasonable genomic deployment will never hit it;
+/// the cap exists solely as a numerical-safety belt.
 const MAX_BITS_PER_ELEMENT: usize = 64;
+
+/// Headroom we hold back from `usize::MAX` so that downstream word-count
+/// math like `(num_bits + 63) / 64` cannot overflow even in debug builds.
+/// Choosing 1024 leaves room for any conceivable round-up by the caller.
+const NUM_BITS_HEADROOM: usize = 1024;
 
 fn optimal_num_bits(n: usize, p: f64) -> usize {
     if n == 0 {
@@ -84,7 +94,13 @@ fn optimal_num_bits(n: usize, p: f64) -> usize {
     // Clamp false-positive rate to a sane open interval so `p.ln()` is finite
     // and negative.
     let p = p.clamp(1e-12, 0.5);
-    let hard_cap = n.saturating_mul(MAX_BITS_PER_ELEMENT);
+    // `saturating_mul` can return `usize::MAX` for astronomically large `n`.
+    // Subtract a small headroom so downstream callers (e.g.
+    // `BloomFilter::new`, which computes `(num_bits + 63) / 64`) cannot
+    // overflow on the round-up to whole 64-bit words.
+    let hard_cap = n
+        .saturating_mul(MAX_BITS_PER_ELEMENT)
+        .min(usize::MAX - NUM_BITS_HEADROOM);
     let ln2_sq = std::f64::consts::LN_2 * std::f64::consts::LN_2;
     let bits = (-(n as f64) * p.ln() / ln2_sq).ceil();
     if !bits.is_finite() || bits <= 0.0 {
@@ -155,6 +171,33 @@ mod tests {
         let bits = optimal_num_bits(1usize << 53, 1e-12);
         assert!(bits >= 64);
         assert!(bits <= (1usize << 53).saturating_mul(MAX_BITS_PER_ELEMENT));
+    }
+
+    #[test]
+    fn test_optimal_num_bits_does_not_saturate_to_usize_max() {
+        // For an `n` so large that `n * MAX_BITS_PER_ELEMENT` saturates
+        // `usize::MAX`, the helper must still leave room for the caller's
+        // `(num_bits + 63) / 64` round-up. Earlier the saturating multiply
+        // could return `usize::MAX` directly, which then overflowed in
+        // `BloomFilter::new`.
+        let bits = optimal_num_bits(usize::MAX, 1e-12);
+        assert!(bits <= usize::MAX - NUM_BITS_HEADROOM);
+        // And the headroom is sufficient for the downstream word-count math.
+        let _ = bits.checked_add(63).expect("(num_bits + 63) must not overflow");
+    }
+
+    #[test]
+    fn test_bloom_new_does_not_panic_for_huge_n() {
+        // Smoke test: construction with absurd `n` must not panic. We don't
+        // actually allocate the bit vector at this size — we just want to
+        // prove the arithmetic guards work.
+        let n = (1usize << 40) - 1;
+        let bits = optimal_num_bits(n, 1e-9);
+        let words = bits
+            .checked_add(63)
+            .map(|x| x / 64)
+            .expect("word-count math must not overflow");
+        assert!(words >= 1);
     }
 
     #[test]

--- a/crates/fastvep-sa/src/bloom.rs
+++ b/crates/fastvep-sa/src/bloom.rs
@@ -69,6 +69,14 @@ fn fmix32(mut h: u32) -> u32 {
 /// fast and bounded.
 const MAX_HASHES: u32 = 16;
 
+/// Upper bound on bits per element. At 14 bits/element a Bloom filter with
+/// the optimal number of hashes has a false-positive rate of ~1e-4, which is
+/// more than enough for any reasonable genomic deployment. Capping here
+/// keeps the bit-count math entirely inside `u64`/`usize` even when `n`
+/// exceeds `2^53` (the f64 mantissa) — beyond that point the `as f64` cast
+/// loses integer precision and the previous formula could yield 0 or +∞.
+const MAX_BITS_PER_ELEMENT: usize = 64;
+
 fn optimal_num_bits(n: usize, p: f64) -> usize {
     if n == 0 {
         return 64;
@@ -76,12 +84,19 @@ fn optimal_num_bits(n: usize, p: f64) -> usize {
     // Clamp false-positive rate to a sane open interval so `p.ln()` is finite
     // and negative.
     let p = p.clamp(1e-12, 0.5);
+    let hard_cap = n.saturating_mul(MAX_BITS_PER_ELEMENT);
     let ln2_sq = std::f64::consts::LN_2 * std::f64::consts::LN_2;
     let bits = (-(n as f64) * p.ln() / ln2_sq).ceil();
     if !bits.is_finite() || bits <= 0.0 {
+        return hard_cap.max(64);
+    }
+    // Compare bits as f64 against the hard cap as f64; convert back via min
+    // to avoid an out-of-range f64-to-usize cast on astronomically large n.
+    let capped = bits.min(hard_cap as f64);
+    if capped <= 0.0 {
         64
     } else {
-        bits as usize
+        capped as usize
     }
 }
 
@@ -130,5 +145,22 @@ mod tests {
     fn test_bloom_empty() {
         let bloom = BloomFilter::new(100, 0.01);
         assert!(!bloom.might_contain(12345));
+    }
+
+    #[test]
+    fn test_optimal_num_bits_huge_n_stays_finite() {
+        // At 2^53 elements (the f64 integer-precision limit) the previous
+        // formula could lose precision and yield zero. The hard cap on
+        // bits/element keeps the result finite and bounded.
+        let bits = optimal_num_bits(1usize << 53, 1e-12);
+        assert!(bits >= 64);
+        assert!(bits <= (1usize << 53).saturating_mul(MAX_BITS_PER_ELEMENT));
+    }
+
+    #[test]
+    fn test_optimal_num_bits_basic_shape() {
+        // Sanity: small n with reasonable p falls in a sensible range.
+        let bits = optimal_num_bits(1000, 0.01);
+        assert!(bits >= 1000 && bits <= 1000 * MAX_BITS_PER_ELEMENT);
     }
 }

--- a/crates/fastvep-sa/src/chunk.rs
+++ b/crates/fastvep-sa/src/chunk.rs
@@ -45,11 +45,16 @@ impl Chunk {
     }
 
     /// Look up a long variant. Returns the index into value arrays.
+    ///
+    /// Returns `None` if either allele contains a non-ACGT base: such a
+    /// variant could not have been written into the index without being
+    /// silently corrupted, so we report a miss rather than guessing.
     pub fn find_long(&self, position: u32, ref_allele: &[u8], alt_allele: &[u8]) -> Option<usize> {
+        let sequence = crate::kmer16::encode_var(ref_allele, alt_allele)?;
         let query = LongVariant {
             position,
             idx: 0,
-            sequence: crate::kmer16::encode_var(ref_allele, alt_allele),
+            sequence,
         };
         self.longs.binary_search(&query).ok().map(|i| self.longs[i].idx as usize)
     }

--- a/crates/fastvep-sa/src/interval.rs
+++ b/crates/fastvep-sa/src/interval.rs
@@ -132,7 +132,26 @@ impl IntervalIndex {
             .map_err(|_| anyhow::anyhow!("OSI payload size {} exceeds usize", len_u64))?;
         let mut data = vec![0u8; len];
         reader.read_exact(&mut data)?;
-        let index: IntervalIndex = bincode::deserialize(&data)?;
+        let mut index: IntervalIndex = bincode::deserialize(&data)?;
+        // `find_overlapping` relies on per-chromosome intervals being sorted
+        // by `start`. The writer enforces this via `sort()`, but a hand-
+        // crafted or partially-corrupted .osi could violate the invariant
+        // and produce silent missed overlaps. Sort on read as a safety net;
+        // this is O(n log n) once per open and negligible at query time.
+        let mut needed_sort = false;
+        for intervals in index.intervals.values_mut() {
+            if !intervals.windows(2).all(|w| w[0].start <= w[1].start) {
+                intervals.sort_by_key(|i| i.start);
+                needed_sort = true;
+            }
+        }
+        if needed_sort {
+            log::warn!(
+                "OSI '{}': intervals were not stored in sorted order; \
+                 sorted on load (writer should have called .sort())",
+                index.header.name
+            );
+        }
         Ok(index)
     }
 }
@@ -183,6 +202,37 @@ mod tests {
 
         assert_eq!(loaded.header.json_key, "dgv");
         assert_eq!(loaded.intervals["chr1"].len(), 2);
+    }
+
+    #[test]
+    fn test_read_sorts_unsorted_intervals() {
+        // Build an index with intervals deliberately out of order, serialize
+        // it (skipping the writer's `sort()`), then verify read_from puts
+        // them back in start-order so find_overlapping is correct.
+        let header = IntervalHeader {
+            schema_version: SCHEMA_VERSION,
+            json_key: "test".into(),
+            name: "Unsorted".into(),
+            version: "1.0".into(),
+            assembly: "GRCh38".into(),
+        };
+        let mut index = IntervalIndex::new(header);
+        // Intentionally out of order:
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 500, end: 700, json: "{\"id\":\"B\"}".into() });
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 100, end: 200, json: "{\"id\":\"A\"}".into() });
+        // Skip index.sort() so the on-disk layout is unsorted.
+
+        let mut buf = Vec::new();
+        index.write_to(&mut buf).unwrap();
+        let loaded = IntervalIndex::read_from(&mut std::io::Cursor::new(buf)).unwrap();
+
+        let intervals = &loaded.intervals["chr1"];
+        assert_eq!(intervals[0].start, 100);
+        assert_eq!(intervals[1].start, 500);
+
+        // And find_overlapping returns both when the query spans them.
+        let hits = loaded.find_overlapping("chr1", 50, 800);
+        assert_eq!(hits.len(), 2);
     }
 
     #[test]

--- a/crates/fastvep-sa/src/kmer16.rs
+++ b/crates/fastvep-sa/src/kmer16.rs
@@ -3,6 +3,7 @@
 //! For variants where ref+alt exceeds 4 bases (the Var32 limit), we pack
 //! the allele sequences into a vector of u32 words at 16 bases per word.
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 /// A variant too long for Var32 encoding.
@@ -38,14 +39,16 @@ impl Ord for LongVariant {
     }
 }
 
-/// DNA base to 2-bit encoding.
+/// DNA base to 2-bit encoding. Returns `None` for non-ACGT bytes so callers
+/// can surface the problem instead of silently encoding `N`/IUPAC as 'T'.
 #[inline]
-fn base_to_bits(b: u8) -> u32 {
+fn base_to_bits(b: u8) -> Option<u32> {
     match b {
-        b'A' | b'a' => 0,
-        b'C' | b'c' => 1,
-        b'G' | b'g' => 2,
-        _ => 3, // T and anything else
+        b'A' | b'a' => Some(0),
+        b'C' | b'c' => Some(1),
+        b'G' | b'g' => Some(2),
+        b'T' | b't' => Some(3),
+        _ => None,
     }
 }
 
@@ -53,9 +56,13 @@ fn base_to_bits(b: u8) -> u32 {
 ///
 /// Format: `[ref_len as u32, alt_len as u32, packed_bases...]`
 /// Each u32 word holds 16 bases at 2 bits each.
-pub fn encode_var(ref_allele: &[u8], alt_allele: &[u8]) -> Vec<u32> {
+///
+/// Returns `None` if any base is not in {A,C,G,T,a,c,g,t}. Earlier revisions
+/// silently mapped non-ACGT bytes to 'T', which caused encode/decode round
+/// trips to diverge from the input sequence.
+pub fn encode_var(ref_allele: &[u8], alt_allele: &[u8]) -> Option<Vec<u32>> {
     let total_bases = ref_allele.len() + alt_allele.len();
-    let num_words = (total_bases + 15) / 16;
+    let num_words = total_bases.div_ceil(16);
 
     let mut result = Vec::with_capacity(2 + num_words);
     result.push(ref_allele.len() as u32);
@@ -65,7 +72,8 @@ pub fn encode_var(ref_allele: &[u8], alt_allele: &[u8]) -> Vec<u32> {
     let mut bit_pos: u32 = 0;
 
     for &b in ref_allele.iter().chain(alt_allele.iter()) {
-        word |= base_to_bits(b) << bit_pos;
+        let bits = base_to_bits(b)?;
+        word |= bits << bit_pos;
         bit_pos += 2;
         if bit_pos >= 32 {
             result.push(word);
@@ -77,29 +85,34 @@ pub fn encode_var(ref_allele: &[u8], alt_allele: &[u8]) -> Vec<u32> {
         result.push(word);
     }
 
-    result
+    Some(result)
 }
 
 /// Decode a kmer16 sequence vector back to (ref_allele, alt_allele).
 ///
-/// Returns empty vectors if the sequence is malformed or claims a length that
-/// exceeds the bases packed into its trailing words.
-pub fn decode_var(sequence: &[u32]) -> (Vec<u8>, Vec<u8>) {
+/// Returns `Err` if the sequence is malformed or claims a length that
+/// exceeds the bases packed into its trailing words. Earlier revisions
+/// silently returned empty vectors here, which produced false-negative
+/// lookups against malformed chunks instead of surfacing the corruption.
+pub fn decode_var(sequence: &[u32]) -> Result<(Vec<u8>, Vec<u8>)> {
     if sequence.len() < 2 {
-        return (Vec::new(), Vec::new());
+        anyhow::bail!("kmer16 sequence too short: need ref_len/alt_len header");
     }
     let ref_len = sequence[0] as usize;
     let alt_len = sequence[1] as usize;
-    let total = match ref_len.checked_add(alt_len) {
-        Some(t) => t,
-        None => return (Vec::new(), Vec::new()),
-    };
+    let total = ref_len
+        .checked_add(alt_len)
+        .ok_or_else(|| anyhow::anyhow!("kmer16 ref_len + alt_len overflows usize"))?;
 
     // Each trailing word holds 16 bases; verify the encoded sequence has
     // capacity for the claimed total before decoding.
     let max_bases = sequence.len().saturating_sub(2).saturating_mul(16);
     if total > max_bases {
-        return (Vec::new(), Vec::new());
+        anyhow::bail!(
+            "kmer16 sequence claims {} bases but only {} fit in payload",
+            total,
+            max_bases
+        );
     }
 
     let bases_decode = [b'A', b'C', b'G', b'T'];
@@ -118,12 +131,16 @@ pub fn decode_var(sequence: &[u32]) -> (Vec<u8>, Vec<u8>) {
     }
 
     if all_bases.len() < total {
-        return (Vec::new(), Vec::new());
+        anyhow::bail!(
+            "kmer16 decoded only {} of {} expected bases",
+            all_bases.len(),
+            total
+        );
     }
 
     let ref_allele = all_bases[..ref_len].to_vec();
     let alt_allele = all_bases[ref_len..ref_len + alt_len].to_vec();
-    (ref_allele, alt_allele)
+    Ok((ref_allele, alt_allele))
 }
 
 #[cfg(test)]
@@ -132,8 +149,8 @@ mod tests {
 
     #[test]
     fn test_encode_decode_short() {
-        let seq = encode_var(b"ACGT", b"TGCA");
-        let (r, a) = decode_var(&seq);
+        let seq = encode_var(b"ACGT", b"TGCA").unwrap();
+        let (r, a) = decode_var(&seq).unwrap();
         assert_eq!(r, b"ACGT");
         assert_eq!(a, b"TGCA");
     }
@@ -142,8 +159,8 @@ mod tests {
     fn test_encode_decode_long() {
         let ref_allele = b"ACGTACGTACGTACGT"; // 16 bases
         let alt_allele = b"TGCATGCATGCATGCA"; // 16 bases
-        let seq = encode_var(ref_allele, alt_allele);
-        let (r, a) = decode_var(&seq);
+        let seq = encode_var(ref_allele, alt_allele).unwrap();
+        let (r, a) = decode_var(&seq).unwrap();
         assert_eq!(r, ref_allele);
         assert_eq!(a, alt_allele);
     }
@@ -153,17 +170,17 @@ mod tests {
         let a = LongVariant {
             position: 100,
             idx: 0,
-            sequence: encode_var(b"ACGTAC", b"T"),
+            sequence: encode_var(b"ACGTAC", b"T").unwrap(),
         };
         let b = LongVariant {
             position: 200,
             idx: 1,
-            sequence: encode_var(b"ACGTAC", b"T"),
+            sequence: encode_var(b"ACGTAC", b"T").unwrap(),
         };
         let c = LongVariant {
             position: 100,
             idx: 2,
-            sequence: encode_var(b"TTTTT", b"A"),
+            sequence: encode_var(b"TTTTT", b"A").unwrap(),
         };
         assert!(a < b); // position 100 < 200
         assert!(a != c); // same position, different sequence
@@ -171,8 +188,30 @@ mod tests {
 
     #[test]
     fn test_equality_ignores_idx() {
-        let a = LongVariant { position: 100, idx: 0, sequence: encode_var(b"ACGTAC", b"T") };
-        let b = LongVariant { position: 100, idx: 999, sequence: encode_var(b"ACGTAC", b"T") };
+        let a = LongVariant { position: 100, idx: 0, sequence: encode_var(b"ACGTAC", b"T").unwrap() };
+        let b = LongVariant { position: 100, idx: 999, sequence: encode_var(b"ACGTAC", b"T").unwrap() };
         assert_eq!(a, b); // idx is ignored in PartialEq
+    }
+
+    #[test]
+    fn test_encode_var_rejects_non_acgt() {
+        assert!(encode_var(b"ACGTN", b"A").is_none());
+        assert!(encode_var(b"A", b"ACGTN").is_none());
+        assert!(encode_var(b"R", b"Y").is_none()); // IUPAC
+        assert!(encode_var(b"acgt", b"A").is_some()); // lowercase ACGT ok
+    }
+
+    #[test]
+    fn test_decode_var_errors_on_undersized_payload() {
+        // Claims 32 bases but provides only one trailing word (16 bases).
+        let bogus = vec![16u32, 16u32, 0u32];
+        let err = decode_var(&bogus).unwrap_err();
+        assert!(err.to_string().contains("only 16 fit"));
+    }
+
+    #[test]
+    fn test_decode_var_errors_on_truncated_header() {
+        assert!(decode_var(&[]).is_err());
+        assert!(decode_var(&[5u32]).is_err());
     }
 }

--- a/crates/fastvep-sa/src/reader.rs
+++ b/crates/fastvep-sa/src/reader.rs
@@ -191,11 +191,13 @@ impl SaReader {
         // disagree the `.osa` and `.osa.idx` are out of sync (corrupt or
         // mismatched files) and we'd otherwise silently decompress the wrong
         // byte range.
-        let on_disk_len = u32::from_le_bytes(
-            self.mmap[offset..offset + 4]
-                .try_into()
-                .expect("4-byte slice"),
-        );
+        // Bounds were just verified, but never `.expect()` on parsed bytes:
+        // surface any unexpected slice shape as a typed error so debugging a
+        // mismatched .osa/.osa.idx pair never produces a panic.
+        let len_bytes: [u8; 4] = self.mmap[offset..offset + 4]
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("expected 4-byte block length prefix at offset {}", offset))?;
+        let on_disk_len = u32::from_le_bytes(len_bytes);
         if on_disk_len != compressed_len {
             anyhow::bail!(
                 "Block length mismatch at offset {}: index says {} bytes, data file prefix says {}",
@@ -325,7 +327,20 @@ impl AnnotationProvider for SaReader {
 
         let blocks = match self.index.chromosomes.get(chrom) {
             Some(b) => b.as_slice(),
-            None => return Ok(()),
+            None => {
+                // A chromosome the caller asked about that is not in the
+                // index isn't necessarily an error (e.g., chrM absent from
+                // ClinVar), but a typo would otherwise produce silently
+                // empty annotations forever. Surface it at debug level so
+                // operators can grep their logs without drowning in noise
+                // on normal runs.
+                log::debug!(
+                    "SA preload: chromosome '{}' not present in {} index",
+                    chrom,
+                    self.metadata.name
+                );
+                return Ok(());
+            }
         };
         if blocks.is_empty() {
             return Ok(());

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -120,39 +120,67 @@ impl Osa2Reader {
     /// Build a chunk by reading its files from the ZIP archive. Pure (no cache
     /// access), so it can run with the cache mutex unheld and avoid blocking
     /// other readers during disk I/O.
+    ///
+    /// Each sub-entry is treated as follows:
+    ///   * absent from the archive (`ZipError::FileNotFound`) — legitimate
+    ///     "this chunk has no data for this field", continue with the empty
+    ///     case;
+    ///   * any other archive error — propagate, since this means the .osa2 is
+    ///     corrupt or unreadable.
+    /// Earlier revisions collapsed both cases together via `Err(_) => …`,
+    /// which silently turned data corruption into false-negative lookups.
     fn build_chunk(&self, chrom: &str, chunk_id: u32) -> Result<Chunk> {
         let file = File::open(&self.zip_path)?;
         let mut archive = zip::ZipArchive::new(file)?;
         let prefix = format!("fastsa/{}/{}/", chrom, chunk_id);
 
-        // Read var32 keys
-        let var32s = {
-            let name = format!("{}var32.bin", prefix);
-            match archive.by_name(&name) {
-                Ok(mut entry) => {
-                    let mut buf = Vec::new();
-                    entry.read_to_end(&mut buf)?;
-                    let mut keys = read_u32_array(&buf)?;
-                    delta_decode(&mut keys); // Reconstruct from deltas
-                    keys
-                }
-                Err(_) => {
-                    // Chunk doesn't exist in this archive
-                    return Ok(Chunk::empty());
-                }
+        // Read var32 keys. If absent, this chunk has no short variants at all,
+        // which also implies no long variants and no parallel value arrays —
+        // short-circuit to an empty chunk.
+        let var32s = match archive.by_name(&format!("{}var32.bin", prefix)) {
+            Ok(mut entry) => {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf)?;
+                let mut keys = read_u32_array(&buf)?;
+                delta_decode(&mut keys);
+                keys
+            }
+            Err(zip::result::ZipError::FileNotFound) => return Ok(Chunk::empty()),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to read var32 entry for chunk {}/{}: {}",
+                    chrom,
+                    chunk_id,
+                    e
+                ));
             }
         };
 
-        // Read long variants
-        let longs: Vec<LongVariant> = {
-            let name = format!("{}too-long.enc", prefix);
-            match archive.by_name(&name) {
-                Ok(mut entry) => {
-                    let mut buf = Vec::new();
-                    entry.read_to_end(&mut buf)?;
-                    bincode::deserialize(&buf).unwrap_or_default()
-                }
-                Err(_) => Vec::new(),
+        // Read long variants.
+        let longs: Vec<LongVariant> = match archive.by_name(&format!("{}too-long.enc", prefix)) {
+            Ok(mut entry) => {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf)?;
+                // Propagate bincode errors so a corrupt `too-long.enc` is
+                // reported instead of silently masquerading as "no long
+                // variants in this chunk".
+                bincode::deserialize(&buf).map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to deserialize long-variant block for chunk {}/{}: {}",
+                        chrom,
+                        chunk_id,
+                        e
+                    )
+                })?
+            }
+            Err(zip::result::ZipError::FileNotFound) => Vec::new(),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to read long-variant entry for chunk {}/{}: {}",
+                    chrom,
+                    chunk_id,
+                    e
+                ));
             }
         };
 
@@ -169,35 +197,48 @@ impl Osa2Reader {
                     entry.read_to_end(&mut buf)?;
                     values.push(read_u32_array(&buf)?);
                 }
-                Err(_) => {
-                    // Fill with missing values
+                Err(zip::result::ZipError::FileNotFound) => {
                     values.push(vec![field.missing_value; var32s.len()]);
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to read value column '{}' for chunk {}/{}: {}",
+                        field.alias,
+                        chrom,
+                        chunk_id,
+                        e
+                    ));
                 }
             }
         }
 
         // Read JSON blobs if any
-        let json_blobs = {
-            let name = format!("{}json_blobs.zst", prefix);
-            match archive.by_name(&name) {
-                Ok(mut entry) => {
-                    let mut buf = Vec::new();
-                    entry.read_to_end(&mut buf)?;
-                    // Bound the decompressed size to defend against zstd bombs.
-                    let mut decoder = zstd::stream::Decoder::new(buf.as_slice())?;
-                    let mut decompressed = Vec::new();
-                    let mut limited = (&mut decoder).take(MAX_JSON_BLOB_DECOMPRESSED as u64 + 1);
-                    limited.read_to_end(&mut decompressed)?;
-                    if decompressed.len() > MAX_JSON_BLOB_DECOMPRESSED {
-                        anyhow::bail!(
-                            "JSON blob decompressed size exceeds limit ({} bytes)",
-                            MAX_JSON_BLOB_DECOMPRESSED
-                        );
-                    }
-                    let text = String::from_utf8(decompressed)?;
-                    Some(text.lines().map(|l| l.to_string()).collect())
+        let json_blobs = match archive.by_name(&format!("{}json_blobs.zst", prefix)) {
+            Ok(mut entry) => {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf)?;
+                // Bound the decompressed size to defend against zstd bombs.
+                let mut decoder = zstd::stream::Decoder::new(buf.as_slice())?;
+                let mut decompressed = Vec::new();
+                let mut limited = (&mut decoder).take(MAX_JSON_BLOB_DECOMPRESSED as u64 + 1);
+                limited.read_to_end(&mut decompressed)?;
+                if decompressed.len() > MAX_JSON_BLOB_DECOMPRESSED {
+                    anyhow::bail!(
+                        "JSON blob decompressed size exceeds limit ({} bytes)",
+                        MAX_JSON_BLOB_DECOMPRESSED
+                    );
                 }
-                Err(_) => None,
+                let text = String::from_utf8(decompressed)?;
+                Some(text.lines().map(|l| l.to_string()).collect())
+            }
+            Err(zip::result::ZipError::FileNotFound) => None,
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to read json_blobs for chunk {}/{}: {}",
+                    chrom,
+                    chunk_id,
+                    e
+                ));
             }
         };
 
@@ -274,6 +315,12 @@ impl Osa2Reader {
                 // the value columns and JSON-blob array. Without this guard
                 // `reconstruct_json` would silently return `{}` and the caller
                 // would treat it as a positive match.
+                //
+                // We take the *max* across the column lengths and the
+                // json_blobs length (the writer keeps them parallel to the
+                // sorted record order). A truly corrupt chunk with a value
+                // column shorter than the others is caught by the per-column
+                // `column.get(idx)` guard inside `reconstruct_json`.
                 let data_len = chunk
                     .values
                     .iter()

--- a/crates/fastvep-sa/src/var32.rs
+++ b/crates/fastvep-sa/src/var32.rs
@@ -24,9 +24,16 @@ pub const CHUNK_BITS: u32 = 20;
 /// Maximum combined ref+alt bases that fit in a Var32.
 pub const MAX_COMBINED_LEN: usize = 4;
 
-/// DNA base to 2-bit encoding lookup (indexed by ASCII byte).
-const BASE_ENC: [u8; 128] = {
-    let mut table = [3u8; 128]; // default T
+/// DNA base to 2-bit encoding lookup (indexed by ASCII byte). A sentinel of
+/// 0xFF marks any byte that is not one of `{A,C,G,T,a,c,g,t}`; callers must
+/// reject those before reaching the encoder. Earlier revisions silently
+/// clamped non-ACGT bytes to 'T', which made variants containing `N` or
+/// IUPAC codes round-trip to a different sequence — a latent
+/// silent-mismatch bug — so the table now carries an explicit invalid
+/// marker.
+const INVALID_BASE: u8 = 0xFF;
+const BASE_ENC: [u8; 256] = {
+    let mut table = [INVALID_BASE; 256];
     table[b'A' as usize] = 0;
     table[b'a' as usize] = 0;
     table[b'C' as usize] = 1;
@@ -71,8 +78,14 @@ pub fn encode(pos: u32, ref_allele: &[u8], alt_allele: &[u8]) -> Option<u32> {
     let mut enc: u8 = 0;
     let mut bit_pos = 6; // Start from high bits of the 8-bit field
     for &b in ref_allele.iter().chain(alt_allele.iter()) {
-        let idx = (b as usize).min(127);
-        enc |= BASE_ENC[idx] << bit_pos;
+        let bits = BASE_ENC[b as usize];
+        if bits == INVALID_BASE {
+            // Non-ACGT base (N, IUPAC, lowercase non-DNA, etc.). Reject so the
+            // caller can normalise the allele upstream instead of getting a
+            // silently corrupted encoding that round-trips to something else.
+            return None;
+        }
+        enc |= bits << bit_pos;
         if bit_pos >= 2 {
             bit_pos -= 2;
         }
@@ -216,6 +229,21 @@ mod tests {
                 assert_eq!(da, a, "alt mismatch for rlen={} alen={}", rlen, alen);
             }
         }
+    }
+
+    #[test]
+    fn test_non_acgt_rejected() {
+        // N, IUPAC codes, and arbitrary high bytes must NOT silently encode
+        // as 'T' (the historic behaviour). Each should return None.
+        assert!(encode(0, b"N", b"A").is_none());
+        assert!(encode(0, b"A", b"N").is_none());
+        assert!(encode(0, b"R", b"Y").is_none()); // IUPAC
+        assert!(encode(0, b"a", b"x").is_none()); // arbitrary letter
+        assert!(encode(0, &[0u8], b"A").is_none()); // null byte
+        assert!(encode(0, &[0xC3, 0xA9], b"A").is_none()); // multi-byte UTF-8
+        // Valid ACGT (mixed case) still works.
+        assert!(encode(0, b"a", b"G").is_some());
+        assert!(encode(0, b"Ac", b"gT").is_some());
     }
 
     #[test]

--- a/crates/fastvep-sa/src/writer_v2.rs
+++ b/crates/fastvep-sa/src/writer_v2.rs
@@ -135,16 +135,43 @@ impl Osa2Writer {
             let within_chunk_pos = record.position & chunk_mask;
 
             if var32::is_long(record.ref_allele.len(), record.alt_allele.len()) {
+                // Skip variants whose alleles contain non-ACGT bases. Earlier
+                // revisions silently encoded them as runs of 'T', producing
+                // index entries that could never be retrieved with their
+                // original allele string.
+                let Some(sequence) = kmer16::encode_var(&record.ref_allele, &record.alt_allele)
+                else {
+                    log::warn!(
+                        "Skipping long variant at {}:{} with non-ACGT allele \
+                         (ref={:?} alt={:?})",
+                        chrom,
+                        record.position,
+                        String::from_utf8_lossy(&record.ref_allele),
+                        String::from_utf8_lossy(&record.alt_allele),
+                    );
+                    continue;
+                };
                 long_entries.push((
                     LongVariant {
                         position: record.position,
                         idx: sort_idx as u32,
-                        sequence: kmer16::encode_var(&record.ref_allele, &record.alt_allele),
+                        sequence,
                     },
                     ri,
                 ));
             } else if let Some(key) = var32::encode(within_chunk_pos, &record.ref_allele, &record.alt_allele) {
                 short_entries.push((key, ri));
+            } else {
+                // Short variant that fails Var32 encoding only when it
+                // contains a non-ACGT base; same skip-with-warning policy.
+                log::warn!(
+                    "Skipping short variant at {}:{} with non-ACGT allele \
+                     (ref={:?} alt={:?})",
+                    chrom,
+                    record.position,
+                    String::from_utf8_lossy(&record.ref_allele),
+                    String::from_utf8_lossy(&record.alt_allele),
+                );
             }
         }
 


### PR DESCRIPTION
This PR hardens error handling throughout the codebase to surface data corruption and malformed inputs instead of silently converting them into false-negative lookups or empty results.

## Summary

The codebase had several patterns where errors were caught and converted to empty/default values, which masked data corruption as legitimate "no data found" cases. This made it impossible to distinguish between a variant genuinely absent from an index and an index that was corrupt or unreadable. This PR systematically fixes those patterns by:

1. **Distinguishing between "not found" and "error"** — File-not-found errors (legitimate absence) are handled separately from other errors (corruption/unreadability)
2. **Rejecting invalid input** — Non-ACGT bases in allele sequences are now rejected at encoding time rather than silently mapped to 'T'
3. **Validating parsed data** — Malformed coordinates, sequences, and headers are now caught and reported instead of defaulting to sentinel values
4. **Improving error messages** — Errors now include context (chromosome, chunk ID, field name, line number) to aid debugging

## Key Changes

**Variant encoding (var32.rs, kmer16.rs, writer_v2.rs):**
- `var32::encode()` and `kmer16::encode_var()` now return `Option` and reject non-ACGT bases instead of silently encoding them as 'T'
- Writer skips variants with non-ACGT alleles with a warning instead of creating unfindable index entries
- `kmer16::decode_var()` returns `Result` with detailed error messages instead of empty vectors on malformed sequences

**Archive reading (reader_v2.rs):**
- Distinguishes `ZipError::FileNotFound` (legitimate chunk absence) from other errors (corruption)
- Propagates bincode deserialization errors instead of silently treating corrupt `too-long.enc` as "no long variants"
- All archive read failures now include context (chromosome, chunk ID, field name)

**GFF3 parsing (gff.rs):**
- Surfaces line-read errors instead of swallowing them via `unwrap_or_default()`
- Skips lines with non-numeric coordinates (with warning) instead of defaulting to position 0
- Validates FASTA headers are non-empty

**Interval index (interval.rs):**
- Sorts intervals on load if they're not in the expected order, with a warning
- Prevents silent missed overlaps from hand-crafted or partially-corrupted `.osi` files

**Output formatting (output.rs):**
- Deduplication in `format_spliceai_projection()`, `format_allele_projection()`, and `format_gene_projection()` now uses `HashSet` (O(n)) instead of `Vec::contains()` (O(n²))

**Bloom filter (bloom.rs):**
- Caps bits-per-element to prevent overflow and loss of precision at extreme `n` values

**Pipeline (pipeline.rs):**
- Cheap probe for `.oga` files instead of fully loading them just to count presence
- Larger output buffer (1 MiB) to reduce syscalls on large VCF files

## Tests

Added regression tests for:
- Multi-allelic sites with independent SA column lookups per ALT
- CSQ stripping when CSQ appears in the middle of INFO fields
- Non-ACGT base rejection in var32 and kmer16 encoding
- Malformed GFF3 coordinate lines being skipped
- Unsorted intervals being sorted on load
- Bloom filter behavior at extreme `n` values

https://claude.ai/code/session_014Cij1g1ACPrUqBnyVDRes7