### PR TITLE
fix: Enforce deterministic cache serialization and correct --pick filtering logic

### DIFF
--- a/crates/fastvep-cache/src/gff.rs
+++ b/crates/fastvep-cache/src/gff.rs
@@ -630,6 +630,9 @@ fn parse_gff3_lines(lines: impl Iterator<Item = String>) -> Result<Vec<Transcrip
         });
     }
 
+    // Sort transcripts by stable ID to ensure deterministic cache serialization
+    result.sort_by(|a, b| a.stable_id.cmp(&b.stable_id));
+
     Ok(result)
 }
 

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -977,10 +977,8 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                     })
                     .collect();
 
-                // Apply pick filter if needed
-                let should_include = !config.pick || tc.canonical || vf.transcript_variations.is_empty();
-
-                if should_include {
+                // Include all transcripts (filtering will be done as a post-process if --pick is enabled)
+                if true {
                     vf.transcript_variations.push(TranscriptVariation {
                         transcript_id: tc.transcript_id.clone(),
                         gene_id: tc.gene_id.clone(),
@@ -1130,6 +1128,33 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
             }
 
             if !sa_only {
+                // Apply pick filter if requested, selecting exactly one best transcript variation
+                if config.pick && !vf.transcript_variations.is_empty() {
+                    let best_idx = vf.transcript_variations.iter()
+                        .enumerate()
+                        .min_by_key(|(_, tv)| {
+                            let most_severe_rank = tv.allele_annotations.iter()
+                                .flat_map(|aa| aa.consequences.iter())
+                                .map(|c| c.rank())
+                                .min()
+                                .unwrap_or(u32::MAX);
+
+                            (
+                                !tv.canonical,
+                                if tv.biotype.as_ref() == "protein_coding" { 0 } else { 1 },
+                                most_severe_rank,
+                                tv.transcript_id.clone(),
+                            )
+                        })
+                        .map(|(idx, _)| idx);
+
+                    if let Some(idx) = best_idx {
+                        let best = vf.transcript_variations.remove(idx);
+                        vf.transcript_variations.clear();
+                        vf.transcript_variations.push(best);
+                    }
+                }
+
                 vf.compute_most_severe();
             }
         }); // end par_iter_mut


### PR DESCRIPTION
# Description

This pull request resolves two issues in `fastVEP` related to non-deterministic binary cache generation and incorrect transcript variation selection when using the `--pick` flag.

---

## 1. Fix Non-deterministic Cache Generation
* **Problem:** GFF3 lines are parsed into a standard Rust `HashMap` inside `parse_gff3_lines`. Since Rust's default `HashMap` uses a randomized hashing seed per execution, iterating over the map to produce the `Vec<Transcript>` yields a different order on every program run. This caused newly compiled cache files for the exact same inputs to differ in bytes and size, leading to non-reproducible VCF annotations when multiple transcripts share start coordinates (stable sort preserved the randomized order).
* **Solution:** Added an alphabetical sort on `stable_id` at the end of the GFF3 parsing process (`crates/fastvep-cache/src/gff.rs`). Every cache build run from the same GFF3 and FASTA file is now 100% bit-for-bit identical, restoring determinism.

## 2. Correct `--pick` Filtering Logic
* **Problem:** The current `--pick` logic evaluates transcript variations on-the-fly inside the transcript parallel loop using `!config.pick || tc.canonical || vf.transcript_variations.is_empty()`. This results in two major bugs:
  1. It can output **multiple** transcripts if a canonical transcript is evaluated after a non-canonical transcript (violating `--pick` which must output exactly one consequence block per variant).
  2. When no transcripts are canonical, it selects one based on genomic start coordinates/arbitrary cache layout order, rather than clinical significance.
* **Solution:** Disabled early-filtering in the transcript loop (`crates/fastvep-cli/src/pipeline.rs`) to collect all variations first. A post-processing `--pick` filter has been added before `vf.compute_most_severe()`. When `--pick` is enabled, this filter ranks all consequences and selects exactly one best transcript variation according to standard VEP preference hierarchy:
  1. **Canonical status** (canonical preferred)
  2. **Biotype** (protein-coding preferred)
  3. **Consequence severity** (most severe Sequence Ontology term rank)
  4. **Stable ID** (alphabetical tie-breaker)

---

## Verification
* Built the codebase (`cargo build`) to verify that the changes compile successfully.
* Validated that running the exact same annotation command across successive cache builds now yields completely identical, deterministic VCF output file sizes and contents.
