### PR TITLE
cleanup: remove dead genomes/ symlinks to missing OxiVEP project

### DIFF
--- a/genomes/arabidopsis
+++ b/genomes/arabidopsis
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/arabidopsis

--- a/genomes/drosophila
+++ b/genomes/drosophila
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/drosophila

--- a/genomes/elegans
+++ b/genomes/elegans
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/elegans

--- a/genomes/human
+++ b/genomes/human
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/human

--- a/genomes/mouse
+++ b/genomes/mouse
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/mouse

--- a/genomes/yeast
+++ b/genomes/yeast
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/yeast

--- a/genomes/zebrafish
+++ b/genomes/zebrafish
@@ -1,1 +1,0 @@
-/Users/kuan-lin.huang/Projects/OxiVEP/test_data/organisms/zebrafish


### PR DESCRIPTION
## Summary
Removes the `genomes/` directory, which contained **7 git-tracked symlinks** all pointing to `/Users/.../Projects/OxiVEP/test_data/organisms/*` — a project path that no longer exists. Every link was dangling (verified: `du` = 0B, 28/28 symlinks broken, 0 real files).

## Why it's safe
- **No references**: nothing in the Rust code, `benchmarks/`, or `validation/` scripts uses `genomes/`.
- **Real data is elsewhere**: organism data lives under `test_data/organisms/` (17G), which *is* the actual dependency — used by [run_benchmark.sh:26](benchmarks/run_benchmark.sh#L26), [run_validation.sh:22](validation/run_validation.sh#L22), and the fastvep-cache tabix test at [variation.rs:578](crates/fastvep-cache/src/variation.rs#L578).
- `genomes/*` is already in `.gitignore`; these symlinks predated that and lingered as tracked files.

## Also cleaned locally (not in this commit)
Removed 24 stale root-level `gnomad.exomes.v4.1.sites.chr*.vcf.bgz.tbi` files — htslib remote-query cache artifacts, already covered by the `*.tbi` gitignore rule, so not part of version control.

## Verification
- No large (>5M) non-gitignored files exist anywhere in the tree, so no stray data is at risk of being committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)