### PR TITLE
cache: add --synonyms for cross-source chromosome naming (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to fastVEP will be documented in this file. Dates are
 ISO 8601. Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- `fastvep cache --synonyms <chr_synonyms.txt>`: VEP-style chromosome
+  synonym support, so a merged Ensembl + RefSeq cache built against a
+  single FASTA reconciles accession seqids (`NC_000017.11`) with the
+  FASTA's contig names (`17`). Transcripts are canonicalized to the FASTA
+  naming at build time, so the merged cache uses one consistent scheme and
+  `annotate` matches a VCF regardless of which GFF3 a transcript came from.
+  Resolves issue #47.
+
+### Changed
+
+- Cache build and FASTA lookups now resolve `chr` ↔ bare and
+  mitochondrial (`M`/`MT`/`chrM`/`chrMT`) contig aliases automatically
+  (no synonyms file needed). `IndexedTranscriptProvider` applies the same
+  aliasing at query time, so a `chr17` VCF matches a `17` cache.
+- The "Chromosome … not found in FASTA index" error now suggests
+  `--synonyms` when the missing name looks like a RefSeq accession.
+- `chrom_aliases()` moved to `fastvep-core` (re-exported from
+  `fastvep-sa::common`) so the cache builder and SA readers share one
+  implementation.
+
 ## [0.2.0] — 2026-06-10
 
 This release accumulates ~55 commits since v0.1.0, headlined by an

--- a/README.md
+++ b/README.md
@@ -311,6 +311,40 @@ cache with `fastvep cache --gff3 ensembl.gff3 -o combined.cache` once
 per source and pass `--transcript-cache combined.cache` on subsequent
 runs — though GFF3 parsing is fast enough that this is rarely needed.
 
+#### Chromosome naming across sources (`--synonyms`)
+
+Ensembl GFF3/FASTA use bare contig names (`17`), UCSC prefixes `chr`
+(`chr17`), and NCBI RefSeq GFF3 uses accessions (`NC_000017.11`). When
+you build a merged cache against one FASTA, those names must be
+reconciled or sequence-building fails with
+`Chromosome 'NC_000017.11' not found in FASTA index`.
+
+- **`chr` ↔ bare and mitochondrial (`M`/`MT`/`chrM`/`chrMT`) forms resolve
+  automatically** — no configuration needed.
+- **RefSeq accessions need a mapping table.** Pass a VEP-style synonyms
+  file with `--synonyms` (only takes effect together with `--fasta`):
+
+  ```bash
+  fastvep cache \
+    --gff3 Homo_sapiens.GRCh38.115.gff3 \
+    --gff3 GCF_000001405.40_GRCh38.p14_genomic.gff \
+    --fasta GRCh38.fa \
+    --synonyms chr_synonyms.txt \
+    -o combined.cache
+  ```
+
+  The file format matches Ensembl VEP's `chr_synonyms.txt`: one line per
+  contig, whitespace/tab-separated equivalent names
+  (e.g. `17  chr17  NC_000017.11`). Ensembl ships one with each release;
+  you can also generate a two-column map from the NCBI
+  `*_assembly_report.txt` (`Sequence-Name` ↔ `RefSeq-Accn` columns).
+
+Every transcript is **canonicalized to the FASTA's contig names at build
+time**, so the merged cache uses one consistent naming scheme and
+`annotate` matches your VCF regardless of which GFF3 each transcript came
+from. Contigs with no FASTA match are reported in a warning and skipped
+(no sequences built for them).
+
 ## Supplementary Annotation Sources
 
 fastVEP supports direct integration with clinical and population databases through its native fastSA binary format. Build once with `fastvep sa-build`, then use `--sa-dir` to annotate:
@@ -456,6 +490,7 @@ multi-`--gff3` / `LABEL=path` syntax as `annotate`, so a merged Ensembl
 |------|-------------|---------|
 | `--gff3` | GFF3 annotation file(s). Repeatable; each value may be `LABEL=path`. | *required* |
 | `--fasta` | Reference FASTA (for pre-building spliced sequences) | -- |
+| `--synonyms` | VEP-style `chr_synonyms.txt` mapping equivalent contig names (e.g. RefSeq `NC_000017.11` ↔ `17`). Reconciles mixed Ensembl/RefSeq naming against the FASTA. Only effective with `--fasta`. | -- |
 | `-o, --output` | Output cache file path | *required* |
 
 ## Output Formats

--- a/crates/fastvep-cache/src/fasta.rs
+++ b/crates/fastvep-cache/src/fasta.rs
@@ -1,6 +1,23 @@
 use anyhow::{Context, Result};
+use fastvep_core::{chrom_aliases, looks_like_refseq_accession};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+
+/// Build the "not found" error for a missing contig, adding an actionable
+/// hint when the name looks like an NCBI RefSeq accession (the common cause:
+/// a RefSeq GFF3/VCF queried against an Ensembl/UCSC-named FASTA).
+fn not_found_error(chrom: &str, location: &str) -> anyhow::Error {
+    if looks_like_refseq_accession(chrom) {
+        anyhow::anyhow!(
+            "Chromosome '{chrom}' not found in {location} — it looks like an NCBI RefSeq \
+             accession. Build the cache with a VEP-style synonyms file \
+             (`fastvep cache --synonyms chr_synonyms.txt ...`) to map RefSeq accessions to \
+             your FASTA's contig names."
+        )
+    } else {
+        anyhow::anyhow!("Chromosome '{chrom}' not found in {location}")
+    }
+}
 
 /// Indexed FASTA reader for reference sequence access.
 ///
@@ -63,10 +80,17 @@ impl FastaReader {
     /// Fetch a region as a borrowed slice (1-based, inclusive coordinates).
     /// Zero-allocation since data is already stored uppercase in memory.
     pub fn fetch_slice(&self, chrom: &str, start: u64, end: u64) -> Result<&[u8]> {
-        let seq = self
-            .sequences
-            .get(chrom)
-            .with_context(|| format!("Chromosome '{}' not found in FASTA", chrom))?;
+        // Exact match is the fast path; fall back to chr↔bare / mitochondrial
+        // aliases so a `chr1` query hits a FASTA built with `1` (and vice
+        // versa) without a synonyms file. RefSeq accessions are reconciled
+        // upstream at cache-build time, so they reach here already canonical.
+        let seq = match self.sequences.get(chrom) {
+            Some(seq) => seq,
+            None => chrom_aliases(chrom)
+                .iter()
+                .find_map(|alias| self.sequences.get(alias))
+                .ok_or_else(|| not_found_error(chrom, "FASTA"))?,
+        };
 
         let start_idx = (start.saturating_sub(1)) as usize;
         let end_idx = (end as usize).min(seq.len());
@@ -89,9 +113,12 @@ impl FastaReader {
         self.fetch_slice(chrom, start, end).map(|s| s.to_vec())
     }
 
-    /// Get the length of a chromosome.
+    /// Get the length of a chromosome (with chr↔bare / mito alias fallback).
     pub fn sequence_length(&self, chrom: &str) -> Option<u64> {
-        self.sequences.get(chrom).map(|s| s.len() as u64)
+        chrom_aliases(chrom)
+            .iter()
+            .find_map(|alias| self.sequences.get(alias))
+            .map(|s| s.len() as u64)
     }
 }
 
@@ -126,9 +153,15 @@ impl MmapFastaReader {
 
     #[inline]
     fn get_entry(&self, chrom: &str) -> Result<&FaiEntry> {
-        let idx = self.name_to_idx.get(chrom)
-            .with_context(|| format!("Chromosome '{}' not found in FASTA index", chrom))?;
-        Ok(&self.index[*idx])
+        // Exact match first; fall back to chr↔bare / mitochondrial aliases.
+        let idx = match self.name_to_idx.get(chrom) {
+            Some(idx) => *idx,
+            None => *chrom_aliases(chrom)
+                .iter()
+                .find_map(|alias| self.name_to_idx.get(alias))
+                .ok_or_else(|| not_found_error(chrom, "FASTA index"))?,
+        };
+        Ok(&self.index[idx])
     }
 
     /// Fetch a region as a new Vec (1-based, inclusive coordinates).
@@ -216,10 +249,10 @@ pub fn fetch_with_index<RS: Read + Seek>(
     start: u64,
     end: u64,
 ) -> Result<Vec<u8>> {
-    let entry = fai_entries
+    let entry = chrom_aliases(chrom)
         .iter()
-        .find(|e| e.name == chrom)
-        .with_context(|| format!("Chromosome '{}' not found in FASTA index", chrom))?;
+        .find_map(|alias| fai_entries.iter().find(|e| &e.name == alias))
+        .ok_or_else(|| not_found_error(chrom, "FASTA index"))?;
 
     let start_0 = start.saturating_sub(1);
     let end_0 = (end.min(entry.length)).saturating_sub(1);
@@ -281,6 +314,24 @@ mod tests {
         let fasta = ">chr1\nACGT\n";
         let reader = FastaReader::from_reader(fasta.as_bytes()).unwrap();
         assert!(reader.fetch("chr99", 1, 4).is_err());
+    }
+
+    #[test]
+    fn test_fasta_reader_chr_bare_alias_fallback() {
+        // FASTA uses bare `1`; a `chr1` query should still resolve.
+        let fasta = ">1\nACGTACGT\n";
+        let reader = FastaReader::from_reader(fasta.as_bytes()).unwrap();
+        assert_eq!(reader.fetch("chr1", 1, 4).unwrap(), b"ACGT");
+        assert_eq!(reader.sequence_length("chr1"), Some(8));
+    }
+
+    #[test]
+    fn test_refseq_accession_miss_has_actionable_hint() {
+        let fasta = ">17\nACGT\n";
+        let reader = FastaReader::from_reader(fasta.as_bytes()).unwrap();
+        let err = reader.fetch("NC_000017.11", 1, 4).unwrap_err().to_string();
+        assert!(err.contains("RefSeq"), "missing RefSeq hint: {err}");
+        assert!(err.contains("--synonyms"), "missing --synonyms hint: {err}");
     }
 
     #[test]

--- a/crates/fastvep-cache/src/providers.rs
+++ b/crates/fastvep-cache/src/providers.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use fastvep_core::chrom_aliases;
 use fastvep_genome::Transcript;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -106,15 +107,28 @@ impl IndexedTranscriptProvider {
     pub fn transcript_count(&self) -> usize {
         self.by_chrom.values().map(|v| v.len()).sum()
     }
+
+    /// Resolve a query chromosome to the stored key, falling back to chr↔bare
+    /// and mitochondrial aliases. Lets a `chr17` VCF match a cache built with
+    /// `17` (and vice versa) instead of silently returning no transcripts.
+    fn resolve_key(&self, chrom: &str) -> Option<&str> {
+        if let Some((k, _)) = self.by_chrom.get_key_value(chrom) {
+            return Some(k.as_ref());
+        }
+        chrom_aliases(chrom)
+            .into_iter()
+            .find_map(|alias| self.by_chrom.get_key_value(alias.as_str()).map(|(k, _)| k.as_ref()))
+    }
 }
 
 impl TranscriptProvider for IndexedTranscriptProvider {
     fn get_transcripts(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<&Transcript>> {
-        let trs = match self.by_chrom.get(chrom) {
-            Some(trs) => trs,
+        let key = match self.resolve_key(chrom) {
+            Some(key) => key,
             None => return Ok(Vec::new()),
         };
-        let sme = &self.suffix_max_end[chrom];
+        let trs = &self.by_chrom[key];
+        let sme = &self.suffix_max_end[key];
 
         // Binary search: find the first transcript whose start > end (query end).
         // All transcripts that could overlap must have start <= end, so they're in [0..upper).
@@ -137,8 +151,8 @@ impl TranscriptProvider for IndexedTranscriptProvider {
     }
 
     fn get_transcripts_by_chrom(&self, chrom: &str) -> Result<Vec<&Transcript>> {
-        match self.by_chrom.get(chrom) {
-            Some(trs) => Ok(trs.iter().collect()),
+        match self.resolve_key(chrom) {
+            Some(key) => Ok(self.by_chrom[key].iter().collect()),
             None => Ok(Vec::new()),
         }
     }

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -157,6 +157,13 @@ enum Commands {
         #[arg(long)]
         fasta: Option<String>,
 
+        /// VEP-style chromosome synonyms file (e.g. Ensembl `chr_synonyms.txt`):
+        /// one line per contig, whitespace-separated equivalent names. Used to
+        /// reconcile GFF3 seqids (e.g. RefSeq `NC_000017.11`) with the FASTA's
+        /// contig names. Only takes effect together with `--fasta`.
+        #[arg(long)]
+        synonyms: Option<String>,
+
         /// Output cache file path
         #[arg(short, long)]
         output: String,
@@ -270,8 +277,8 @@ fn main() -> Result<()> {
                 qc_rules,
             })?;
         }
-        Commands::Cache { gff3, fasta, output } => {
-            pipeline::run_cache_build(&gff3, fasta.as_deref(), &output)?;
+        Commands::Cache { gff3, fasta, synonyms, output } => {
+            pipeline::run_cache_build(&gff3, fasta.as_deref(), synonyms.as_deref(), &output)?;
         }
         Commands::Web { port, gff3, fasta } => {
             webserver::run_server(port, gff3, fasta)?;

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1866,7 +1866,12 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
 /// With multiple GFF3 inputs (e.g. Ensembl + RefSeq), transcripts from all
 /// files are merged into a single cache, each stamped with its source so
 /// the SOURCE column on annotate output stays per-transcript.
-pub fn run_cache_build(gff3_paths: &[String], fasta_path: Option<&str>, output_path: &str) -> Result<()> {
+pub fn run_cache_build(
+    gff3_paths: &[String],
+    fasta_path: Option<&str>,
+    synonyms_path: Option<&str>,
+    output_path: &str,
+) -> Result<()> {
     if gff3_paths.is_empty() {
         return Err(anyhow::anyhow!("`fastvep cache` requires at least one --gff3"));
     }
@@ -1898,13 +1903,77 @@ pub fn run_cache_build(gff3_paths: &[String], fasta_path: Option<&str>, output_p
         eprintln!("Merged {} GFF3 sources into {} total transcripts", specs.len(), transcripts.len());
     }
 
+    // Chromosome synonyms (VEP `chr_synonyms.txt`). An empty table still
+    // resolves chr↔bare / mitochondrial forms via mechanical aliases.
+    let synonyms = match synonyms_path {
+        Some(p) => {
+            let contents = std::fs::read_to_string(p)
+                .with_context(|| format!("Reading synonyms file: {}", p))?;
+            eprintln!("Loaded chromosome synonyms from {}", p);
+            fastvep_core::ChromSynonyms::parse(&contents)
+        }
+        None => fastvep_core::ChromSynonyms::new(),
+    };
+
     if let Some(fasta) = fasta_path {
         let fasta_file = File::open(fasta)
             .with_context(|| format!("Opening FASTA file: {}", fasta))?;
         let reader = FastaReader::from_reader(fasta_file)?;
-        let sp = FastaSequenceProvider::new(reader);
         eprintln!("Loaded reference FASTA from {}", fasta);
 
+        // Canonicalize every transcript (and its gene) to the FASTA's contig
+        // naming. This both lets sequence fetch succeed and makes a merged
+        // Ensembl + RefSeq cache use one consistent naming scheme, so
+        // `annotate` matches a VCF regardless of which GFF3 the transcript
+        // came from. RefSeq accessions only resolve when a synonyms file maps
+        // them; chr↔bare / mito resolve with no synonyms file at all.
+        let contigs: std::collections::HashSet<String> =
+            reader.sequence_names().into_iter().map(|s| s.to_string()).collect();
+        let mut resolved: HashMap<String, Option<std::sync::Arc<str>>> = HashMap::new();
+        let mut unresolved: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for tr in &mut transcripts {
+            let orig: &str = tr.chromosome.as_ref();
+            if contigs.contains(orig) {
+                continue; // already matches a FASTA contig
+            }
+            let canonical = resolved
+                .entry(orig.to_string())
+                .or_insert_with(|| {
+                    synonyms
+                        .aliases(orig)
+                        .into_iter()
+                        .find(|a| contigs.contains(a))
+                        .map(|a| std::sync::Arc::from(a.as_str()))
+                })
+                .clone();
+            match canonical {
+                Some(name) => {
+                    tr.chromosome = std::sync::Arc::clone(&name);
+                    tr.gene.chromosome = name;
+                }
+                None => {
+                    unresolved.insert(orig.to_string());
+                }
+            }
+        }
+        if !unresolved.is_empty() {
+            let refseq_like = unresolved
+                .iter()
+                .any(|c| fastvep_core::looks_like_refseq_accession(c));
+            let hint = if refseq_like && synonyms_path.is_none() {
+                " — some look like RefSeq accessions; pass a VEP-style synonyms file with `--synonyms` to map them"
+            } else {
+                ""
+            };
+            eprintln!(
+                "Warning: {} GFF3 contig(s) have no matching FASTA sequence{}: {}",
+                unresolved.len(),
+                hint,
+                unresolved.iter().cloned().collect::<Vec<_>>().join(", ")
+            );
+        }
+
+        let sp = FastaSequenceProvider::new(reader);
         let mut built = 0usize;
         for tr in &mut transcripts {
             if tr.is_coding() {
@@ -1919,6 +1988,10 @@ pub fn run_cache_build(gff3_paths: &[String], fasta_path: Option<&str>, output_p
             }
         }
         eprintln!("Built sequences for {} coding transcripts", built);
+    } else if synonyms_path.is_some() {
+        eprintln!(
+            "Warning: --synonyms has no effect without --fasta; chromosome names are kept as-is from the GFF3."
+        );
     }
 
     fastvep_cache::transcript_cache::save_cache(&transcripts, Path::new(output_path))?;

--- a/crates/fastvep-cli/tests/cache_synonyms.rs
+++ b/crates/fastvep-cli/tests/cache_synonyms.rs
@@ -1,0 +1,100 @@
+//! End-to-end tests for merged cache building across chromosome naming
+//! schemes (issue #47): Ensembl bare names (`17`) + RefSeq accessions
+//! (`NC_000017.11`) reconciled against a single FASTA via `--synonyms`.
+
+use fastvep_cli::pipeline::run_cache_build;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+// Ensembl-style GFF3: bare seqid `17`.
+const ENSEMBL_GFF3: &str = "##gff-version 3\n\
+17\tensembl\tgene\t1\t30\t.\t+\t.\tID=gene:ENSG1;Name=ENSG1;gene_name=ENSG1\n\
+17\tensembl\tmRNA\t1\t30\t.\t+\t.\tID=transcript:ENST1;Parent=gene:ENSG1;biotype=protein_coding\n\
+17\tensembl\texon\t1\t30\t.\t+\t.\tID=exon:EE1;Parent=transcript:ENST1;rank=1\n\
+17\tensembl\tCDS\t1\t30\t.\t+\t0\tID=CDS:EP1;Parent=transcript:ENST1\n";
+
+// RefSeq-style GFF3: accession seqid `NC_000017.11`.
+const REFSEQ_GFF3: &str = "##gff-version 3\n\
+NC_000017.11\tBestRefSeq\tgene\t1\t30\t.\t+\t.\tID=gene:RSG1;Name=RSG1;gene_name=RSG1\n\
+NC_000017.11\tBestRefSeq\tmRNA\t1\t30\t.\t+\t.\tID=transcript:RST1;Parent=gene:RSG1;biotype=protein_coding\n\
+NC_000017.11\tBestRefSeq\texon\t1\t30\t.\t+\t.\tID=exon:RE1;Parent=transcript:RST1;rank=1\n\
+NC_000017.11\tBestRefSeq\tCDS\t1\t30\t.\t+\t0\tID=CDS:RP1;Parent=transcript:RST1\n";
+
+// FASTA uses the Ensembl bare contig name only.
+const FASTA: &str = ">17\nACGTACGTACGTACGTACGTACGTACGTAC\n";
+
+// VEP chr_synonyms.txt mapping the three equivalent names.
+const SYNONYMS: &str = "17\tchr17\tNC_000017.11\n";
+
+fn write(path: &Path, contents: &str) {
+    File::create(path).unwrap().write_all(contents.as_bytes()).unwrap();
+}
+
+#[test]
+fn merged_cache_with_synonyms_canonicalizes_to_fasta_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ens = tmp.path().join("ensembl.gff3");
+    let rs = tmp.path().join("refseq.gff3");
+    let fa = tmp.path().join("ref.fa");
+    let syn = tmp.path().join("chr_synonyms.txt");
+    let out = tmp.path().join("combined.cache");
+    write(&ens, ENSEMBL_GFF3);
+    write(&rs, REFSEQ_GFF3);
+    write(&fa, FASTA);
+    write(&syn, SYNONYMS);
+
+    run_cache_build(
+        &[ens.to_string_lossy().into(), rs.to_string_lossy().into()],
+        Some(fa.to_str().unwrap()),
+        Some(syn.to_str().unwrap()),
+        out.to_str().unwrap(),
+    )
+    .expect("merged cache build should succeed with a synonyms file");
+
+    let transcripts = fastvep_cache::transcript_cache::load_cache(&out).unwrap();
+    assert_eq!(transcripts.len(), 2, "both sources should contribute a transcript");
+    for tr in &transcripts {
+        // (b) every transcript canonicalized to the FASTA contig name.
+        assert_eq!(&*tr.chromosome, "17", "transcript {} not canonicalized", tr.stable_id);
+        assert_eq!(&*tr.gene.chromosome, "17", "gene of {} not canonicalized", tr.stable_id);
+        // (c) coding sequences were built for both sources.
+        assert!(
+            tr.spliced_seq.is_some(),
+            "sequence not built for {} — FASTA fetch must have matched",
+            tr.stable_id
+        );
+    }
+}
+
+#[test]
+fn refseq_unresolved_without_synonyms_but_build_still_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ens = tmp.path().join("ensembl.gff3");
+    let rs = tmp.path().join("refseq.gff3");
+    let fa = tmp.path().join("ref.fa");
+    let out = tmp.path().join("combined.cache");
+    write(&ens, ENSEMBL_GFF3);
+    write(&rs, REFSEQ_GFF3);
+    write(&fa, FASTA);
+
+    // No synonyms file: the RefSeq accession has no mechanical relationship to
+    // `17`, so it can't be canonicalized. The build must still succeed.
+    run_cache_build(
+        &[ens.to_string_lossy().into(), rs.to_string_lossy().into()],
+        Some(fa.to_str().unwrap()),
+        None,
+        out.to_str().unwrap(),
+    )
+    .expect("build should not fail just because one contig is unresolved");
+
+    let transcripts = fastvep_cache::transcript_cache::load_cache(&out).unwrap();
+    let ens_tr = transcripts.iter().find(|t| &*t.stable_id == "ENST1").unwrap();
+    let rs_tr = transcripts.iter().find(|t| &*t.stable_id == "RST1").unwrap();
+    // Ensembl transcript resolves and gets a sequence.
+    assert_eq!(&*ens_tr.chromosome, "17");
+    assert!(ens_tr.spliced_seq.is_some());
+    // RefSeq transcript keeps its accession and has no sequence.
+    assert_eq!(&*rs_tr.chromosome, "NC_000017.11");
+    assert!(rs_tr.spliced_seq.is_none());
+}

--- a/crates/fastvep-core/src/chrom.rs
+++ b/crates/fastvep-core/src/chrom.rs
@@ -1,0 +1,265 @@
+//! Chromosome name aliasing and synonym resolution.
+//!
+//! Genome resources disagree about how to name contigs: Ensembl uses bare
+//! names (`1`, `X`, `MT`), UCSC prefixes `chr` (`chr1`, `chrX`, `chrM`), and
+//! NCBI RefSeq uses accessions (`NC_000001.11`). The first two differ by a
+//! mechanical rule and are handled by [`chrom_aliases`]; the RefSeq accessions
+//! have no algorithmic relationship to the others and can only be reconciled
+//! with a mapping table — a VEP-style `chr_synonyms.txt`, parsed by
+//! [`ChromSynonyms`].
+
+use std::collections::HashMap;
+
+/// Equivalent on-disk names for a chromosome, derived by mechanical rules.
+///
+/// Different upstream sources (and different user VCFs) mix `chr*` and bare
+/// styles, and historically the SA writer canonicalized to the bare form
+/// (`"1"`, `"X"`, `"MT"`) while modern inputs use `chr*`. This returns the
+/// query name first, then all known aliases — so the reader can satisfy a
+/// `chr1` query against an index built with `1`, or vice versa, without
+/// requiring users to rebuild databases. See issue #37.
+///
+/// The returned `Vec` is small (1–3 entries) so caller-side iteration is
+/// cheap. The first element is always the input name unchanged.
+pub fn chrom_aliases(chrom: &str) -> Vec<String> {
+    let mut out = Vec::with_capacity(3);
+    out.push(chrom.to_string());
+
+    // An empty input is most likely a programming error upstream — return
+    // it unchanged so the caller still sees a single (empty) "alias" and
+    // can surface a meaningful miss, rather than synthesizing a bogus
+    // `"chr"` lookup.
+    if chrom.is_empty() {
+        return out;
+    }
+
+    // chr1 <-> 1
+    if let Some(stripped) = chrom.strip_prefix("chr") {
+        if !stripped.is_empty() && stripped != chrom {
+            out.push(stripped.to_string());
+        }
+    } else {
+        out.push(format!("chr{}", chrom));
+    }
+
+    // Mitochondrial special case: chrM / M / MT / chrMT all refer to the
+    // same contig but UCSC uses chrM, NCBI uses MT.
+    let mito_set = ["chrM", "M", "MT", "chrMT"];
+    if mito_set.contains(&chrom) {
+        for alt in mito_set {
+            if alt != chrom && !out.iter().any(|n| n == alt) {
+                out.push(alt.to_string());
+            }
+        }
+    }
+
+    out
+}
+
+/// Heuristic: does this name look like an NCBI RefSeq molecule accession
+/// (`NC_000017.11`, `NW_…`, `NT_…`, `NG_…`)?
+///
+/// Used only to enrich error messages — when a contig like `NC_000017.11`
+/// can't be found in a FASTA built with Ensembl bare names, the failure is
+/// almost certainly a naming mismatch that `--synonyms` would fix, so we say
+/// so. The pattern is `^N[CWTG]_\d+\.\d+$`; implemented by hand to avoid
+/// pulling a regex dependency into the foundational crate.
+pub fn looks_like_refseq_accession(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.len() < 6 {
+        return false;
+    }
+    if bytes[0] != b'N' || !matches!(bytes[1], b'C' | b'W' | b'T' | b'G') || bytes[2] != b'_' {
+        return false;
+    }
+    let rest = &name[3..];
+    let Some((digits, version)) = rest.split_once('.') else {
+        return false;
+    };
+    !digits.is_empty()
+        && digits.bytes().all(|b| b.is_ascii_digit())
+        && !version.is_empty()
+        && version.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Bidirectional chromosome synonym table, loaded from a VEP-style
+/// `chr_synonyms.txt`.
+///
+/// Each non-empty line of the file lists names that all refer to the same
+/// contig, separated by whitespace/tabs (e.g. `1\tchr1\tNC_000001.11`). Every
+/// name on a line maps to the full set of its line-mates, so a lookup from any
+/// synonym yields all the others regardless of column order.
+#[derive(Debug, Clone, Default)]
+pub struct ChromSynonyms {
+    /// name -> the other names sharing its line (the name itself excluded).
+    map: HashMap<String, Vec<String>>,
+}
+
+impl ChromSynonyms {
+    /// An empty table. Lookups still return the mechanical [`chrom_aliases`]
+    /// fallbacks, so chr↔bare and mitochondrial forms resolve with zero
+    /// configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parse a VEP `chr_synonyms.txt`. Lines are split on any whitespace;
+    /// blank lines and single-token lines are ignored (nothing to map).
+    pub fn parse(contents: &str) -> Self {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for line in contents.lines() {
+            let names: Vec<&str> = line.split_whitespace().collect();
+            if names.len() < 2 {
+                continue;
+            }
+            for &name in &names {
+                let entry = map.entry(name.to_string()).or_default();
+                for &other in &names {
+                    if other != name && !entry.iter().any(|n| n == other) {
+                        entry.push(other.to_string());
+                    }
+                }
+            }
+        }
+        Self { map }
+    }
+
+    /// True when no synonym lines were loaded.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// All names equivalent to `query`, most-specific first: the query itself,
+    /// then its file synonyms, then the mechanical [`chrom_aliases`]
+    /// (chr↔bare, mito) of all of those. De-duplicated, query first.
+    pub fn aliases(&self, query: &str) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        let push = |name: String, out: &mut Vec<String>| {
+            if !out.iter().any(|n| n == &name) {
+                out.push(name);
+            }
+        };
+
+        push(query.to_string(), &mut out);
+        if let Some(syns) = self.map.get(query) {
+            for s in syns {
+                push(s.clone(), &mut out);
+            }
+        }
+        // Fold in mechanical aliases for the query and each synonym so a
+        // synonyms file that only lists `NC_000001.11 1` still satisfies a
+        // `chr1` FASTA.
+        for base in out.clone() {
+            for alias in chrom_aliases(&base) {
+                push(alias, &mut out);
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod chrom_alias_tests {
+    use super::chrom_aliases;
+
+    #[test]
+    fn chr_prefix_round_trips() {
+        let aliases = chrom_aliases("chr1");
+        assert!(aliases.iter().any(|n| n == "chr1"));
+        assert!(aliases.iter().any(|n| n == "1"));
+    }
+
+    #[test]
+    fn bare_form_round_trips() {
+        let aliases = chrom_aliases("1");
+        assert!(aliases.iter().any(|n| n == "1"));
+        assert!(aliases.iter().any(|n| n == "chr1"));
+    }
+
+    #[test]
+    fn mitochondrial_aliases_cover_all_four_forms() {
+        for name in ["chrM", "M", "MT", "chrMT"] {
+            let aliases = chrom_aliases(name);
+            for form in ["chrM", "M", "MT", "chrMT"] {
+                assert!(
+                    aliases.iter().any(|n| n == form),
+                    "{} should resolve {}",
+                    name,
+                    form
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_contig_returns_just_self_and_chr_variant() {
+        let aliases = chrom_aliases("HLA-A*01:01");
+        // Exactly two: the input plus its `chr`-prefixed form. Pinning the
+        // length here keeps a future over-eager alias expansion from
+        // silently broadening the lookup set.
+        assert_eq!(aliases.len(), 2, "unexpected aliases: {:?}", aliases);
+        assert_eq!(aliases[0], "HLA-A*01:01");
+        assert_eq!(aliases[1], "chrHLA-A*01:01");
+    }
+
+    #[test]
+    fn empty_input_does_not_synthesize_bogus_chr_alias() {
+        // Regression: an earlier version pushed `format!("chr{}", "")` =
+        // `"chr"` for empty input, which then collided with the synthetic
+        // chr-strip case and could match unrelated index keys.
+        let aliases = chrom_aliases("");
+        assert_eq!(aliases, vec![String::new()]);
+    }
+}
+
+#[cfg(test)]
+mod synonym_tests {
+    use super::{looks_like_refseq_accession, ChromSynonyms};
+
+    #[test]
+    fn refseq_accession_detected() {
+        assert!(looks_like_refseq_accession("NC_000017.11"));
+        assert!(looks_like_refseq_accession("NW_009646201.1"));
+        assert!(looks_like_refseq_accession("NT_187361.1"));
+        assert!(looks_like_refseq_accession("NG_012232.1"));
+    }
+
+    #[test]
+    fn non_refseq_names_rejected() {
+        for n in ["17", "chr17", "NC_00017", "NC_000017", "X", "", "NX_000017.11"] {
+            assert!(!looks_like_refseq_accession(n), "{} misclassified", n);
+        }
+    }
+
+    #[test]
+    fn synonyms_map_bidirectionally() {
+        let syn = ChromSynonyms::parse("17\tchr17\tNC_000017.11\n1 chr1\n");
+        // From the RefSeq accession we reach the Ensembl bare name.
+        assert!(syn.aliases("NC_000017.11").iter().any(|n| n == "17"));
+        // From the bare name we reach the accession.
+        assert!(syn.aliases("17").iter().any(|n| n == "NC_000017.11"));
+        // Query itself comes first.
+        assert_eq!(syn.aliases("NC_000017.11")[0], "NC_000017.11");
+    }
+
+    #[test]
+    fn empty_table_still_yields_mechanical_aliases() {
+        let syn = ChromSynonyms::new();
+        assert!(syn.is_empty());
+        assert!(syn.aliases("chr1").iter().any(|n| n == "1"));
+    }
+
+    #[test]
+    fn single_token_lines_ignored() {
+        let syn = ChromSynonyms::parse("17\n\nchr17\n");
+        assert!(syn.is_empty());
+    }
+
+    #[test]
+    fn partial_synonyms_fold_in_chr_prefix() {
+        // File maps accession <-> bare only; chr-prefixed FASTA should still
+        // resolve via the mechanical fallback.
+        let syn = ChromSynonyms::parse("NC_000001.11\t1\n");
+        assert!(syn.aliases("NC_000001.11").iter().any(|n| n == "chr1"));
+    }
+}

--- a/crates/fastvep-core/src/lib.rs
+++ b/crates/fastvep-core/src/lib.rs
@@ -1,7 +1,9 @@
 mod annotation_types;
+pub mod chrom;
 mod consequence;
 mod position;
 
 pub use annotation_types::{GeneAnnotation, SupplementaryAnnotation};
+pub use chrom::{chrom_aliases, looks_like_refseq_accession, ChromSynonyms};
 pub use consequence::{Consequence, Impact};
 pub use position::{Allele, GenomicPosition, Strand, VariantType};

--- a/crates/fastvep-sa/src/common.rs
+++ b/crates/fastvep-sa/src/common.rs
@@ -98,105 +98,11 @@ impl ChromMap {
     }
 }
 
-/// Equivalent on-disk names for a chromosome.
+/// Equivalent on-disk names for a chromosome (chr↔bare, mitochondrial forms).
 ///
-/// Different upstream sources (and different user VCFs) mix `chr*` and bare
-/// styles, and historically the SA writer canonicalized to the bare form
-/// (`"1"`, `"X"`, `"MT"`) while modern inputs use `chr*`. This returns the
-/// query name first, then all known aliases — so the reader can satisfy a
-/// `chr1` query against an index built with `1`, or vice versa, without
-/// requiring users to rebuild databases. See issue #37.
-///
-/// The returned `Vec` is small (1–3 entries) so caller-side iteration is
-/// cheap. The first element is always the input name unchanged.
-pub fn chrom_aliases(chrom: &str) -> Vec<String> {
-    let mut out = Vec::with_capacity(3);
-    out.push(chrom.to_string());
-
-    // An empty input is most likely a programming error upstream — return
-    // it unchanged so the caller still sees a single (empty) "alias" and
-    // can surface a meaningful miss, rather than synthesizing a bogus
-    // `"chr"` lookup.
-    if chrom.is_empty() {
-        return out;
-    }
-
-    // chr1 <-> 1
-    if let Some(stripped) = chrom.strip_prefix("chr") {
-        if !stripped.is_empty() && stripped != chrom {
-            out.push(stripped.to_string());
-        }
-    } else {
-        out.push(format!("chr{}", chrom));
-    }
-
-    // Mitochondrial special case: chrM / M / MT / chrMT all refer to the
-    // same contig but UCSC uses chrM, NCBI uses MT.
-    let mito_set = ["chrM", "M", "MT", "chrMT"];
-    if mito_set.contains(&chrom) {
-        for alt in mito_set {
-            if alt != chrom && !out.iter().any(|n| n == alt) {
-                out.push(alt.to_string());
-            }
-        }
-    }
-
-    out
-}
-
-#[cfg(test)]
-mod chrom_alias_tests {
-    use super::chrom_aliases;
-
-    #[test]
-    fn chr_prefix_round_trips() {
-        let aliases = chrom_aliases("chr1");
-        assert!(aliases.iter().any(|n| n == "chr1"));
-        assert!(aliases.iter().any(|n| n == "1"));
-    }
-
-    #[test]
-    fn bare_form_round_trips() {
-        let aliases = chrom_aliases("1");
-        assert!(aliases.iter().any(|n| n == "1"));
-        assert!(aliases.iter().any(|n| n == "chr1"));
-    }
-
-    #[test]
-    fn mitochondrial_aliases_cover_all_four_forms() {
-        for name in ["chrM", "M", "MT", "chrMT"] {
-            let aliases = chrom_aliases(name);
-            for form in ["chrM", "M", "MT", "chrMT"] {
-                assert!(
-                    aliases.iter().any(|n| n == form),
-                    "{} should resolve {}",
-                    name,
-                    form
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn unknown_contig_returns_just_self_and_chr_variant() {
-        let aliases = chrom_aliases("HLA-A*01:01");
-        // Exactly two: the input plus its `chr`-prefixed form. Pinning the
-        // length here keeps a future over-eager alias expansion from
-        // silently broadening the lookup set.
-        assert_eq!(aliases.len(), 2, "unexpected aliases: {:?}", aliases);
-        assert_eq!(aliases[0], "HLA-A*01:01");
-        assert_eq!(aliases[1], "chrHLA-A*01:01");
-    }
-
-    #[test]
-    fn empty_input_does_not_synthesize_bogus_chr_alias() {
-        // Regression: an earlier version pushed `format!("chr{}", "")` =
-        // `"chr"` for empty input, which then collided with the synthetic
-        // chr-strip case and could match unrelated index keys.
-        let aliases = chrom_aliases("");
-        assert_eq!(aliases, vec![String::new()]);
-    }
-}
+/// Re-exported from `fastvep-core` so SA readers and the cache builder share a
+/// single implementation. See [`fastvep_core::chrom::chrom_aliases`].
+pub use fastvep_core::chrom_aliases;
 
 /// A single gene annotation record.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Problem

Closes #47. Building a merged Ensembl + RefSeq cache against a single FASTA fails:

```
fastvep cache --gff3 Homo_sapiens.GRCh38.115.gff3 \
  --gff3 GCF_000001405.40_GRCh38.p14_genomic.gff \
  --fasta GRCh38.fa -o combined.cache
# Chromosome 'NC_000017.11' not found in FASTA index
```

GFF3 seqids were matched to the FASTA by **exact string only**. Ensembl uses bare names (`17`), the RefSeq GFF3 uses accessions (`NC_000017.11`), and accessions have no algorithmic relationship to bare names — so they can only be reconciled with a mapping table, exactly what Ensembl VEP's `--synonyms` provides.

## Changes

- **`fastvep cache --synonyms <chr_synonyms.txt>`** (VEP-compatible format: one line per contig, whitespace-separated equivalent names). Every transcript **and its gene** is canonicalized to the FASTA's contig names at build time, so a merged cache uses one consistent naming scheme and `annotate` matches a VCF regardless of which GFF3 a transcript came from. Effective together with `--fasta`.
- **Zero-config `chr`↔bare + mitochondrial (`M`/`MT`/`chrM`/`chrMT`) aliasing** in FASTA lookups and in `IndexedTranscriptProvider`, so the common `chr17`/`17` mismatch needs no synonyms file (and a `chr17` VCF now matches a `17` cache at annotate time instead of silently returning nothing).
- **Actionable error**: the "not found in FASTA index" message now suggests `--synonyms` when the missing name looks like a RefSeq accession; unresolved contigs during build are reported in a single aggregated warning.
- **Refactor**: `chrom_aliases()` moved to `fastvep-core` (re-exported from `fastvep-sa::common` so SA call sites are untouched); added `ChromSynonyms` and `looks_like_refseq_accession`.

## Best-practice answer for the issue

Pass a VEP-style `chr_synonyms.txt` (Ensembl ships one per release, or generate a two-column map from the NCBI `*_assembly_report.txt` `Sequence-Name` ↔ `RefSeq-Accn` columns). A single merged cache is then fine — no need to maintain separate Ensembl/RefSeq caches. README documents this under "Merged annotation".

## Testing

- Unit tests: `chrom.rs` (synonym parse/ordering, RefSeq detector), `fasta.rs` (alias fetch + hinted error).
- Integration test (`crates/fastvep-cli/tests/cache_synonyms.rs`): builds a merged Ensembl (`17`) + RefSeq (`NC_000017.11`) cache against a single FASTA, asserts both transcripts canonicalize to `17` with sequences built; plus the no-synonyms case where RefSeq stays unresolved but the build still succeeds.
- CI-equivalent `cargo check --workspace --lib --bins` + `cargo test --workspace --lib` pass (462 lib tests, 0 failures).
- Verified the issue's exact command end-to-end against the real binary: succeeds with `--synonyms`; without it, emits the aggregated RefSeq hint and still completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)