### PR TITLE
acmg: fix PVS1/BP4/PM2 criterion-execution gaps from ClinVar discorda…

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -595,6 +595,17 @@ impl AnnotationContext {
             if !self.sa_providers.is_empty() {
                 let chrom = &vf.position.chromosome;
                 let ref_str = vf.ref_allele.to_string();
+                // gnomAD stores left-aligned, parsimonious alleles; normalize the
+                // query to its minimal representation so indels (especially in
+                // repeats) match instead of silently missing — which otherwise
+                // makes PM2 misfire on common variants. Only when a reference and
+                // a gnomAD provider are present; applied only to the gnomAD lookup
+                // (every other source keeps the existing query unchanged).
+                let has_gnomad = self.seq_provider.is_some()
+                    && self
+                        .sa_providers
+                        .iter()
+                        .any(|sa| sa.lock().unwrap().json_key() == "gnomad");
                 let mut allele_results: std::collections::HashMap<
                     String,
                     Vec<(String, String)>,
@@ -605,15 +616,35 @@ impl AnnotationContext {
                         if allele_results.contains_key(&alt_str) {
                             continue;
                         }
+                        let gnomad_norm = if has_gnomad {
+                            self.seq_provider.as_ref().map(|sp| {
+                                fastvep_cache::normalize::normalize_variant(
+                                    &**sp,
+                                    chrom,
+                                    vf.position.start,
+                                    &ref_str,
+                                    &alt_str,
+                                )
+                            })
+                        } else {
+                            None
+                        };
                         let mut results: Vec<(String, String)> = Vec::new();
                         for sa in &self.sa_providers {
                             let sa_guard = sa.lock().unwrap();
-                            if let Ok(Some(ann)) = sa_guard.annotate_position(
-                                chrom,
-                                vf.position.start,
-                                &ref_str,
-                                &alt_str,
-                            ) {
+                            let (q_pos, q_ref, q_alt) = if sa_guard.json_key() == "gnomad" {
+                                match &gnomad_norm {
+                                    Some(n) => {
+                                        (n.pos, n.ref_allele.as_str(), n.alt_allele.as_str())
+                                    }
+                                    None => (vf.position.start, ref_str.as_str(), alt_str.as_str()),
+                                }
+                            } else {
+                                (vf.position.start, ref_str.as_str(), alt_str.as_str())
+                            };
+                            if let Ok(Some(ann)) =
+                                sa_guard.annotate_position(chrom, q_pos, q_ref, q_alt)
+                            {
                                 let json_str = match ann {
                                     AnnotationValue::Json(j) => j,
                                     AnnotationValue::Positional(j) => j,
@@ -681,6 +712,7 @@ impl AnnotationContext {
                                 aa.amino_acids.as_ref(),
                                 aa.protein_position.map(|(s, _)| s),
                                 aa.hgvsc.as_deref(),
+                                aa.exon,
                                 &aa.supplementary,
                                 &gene_anns,
                                 &vf.supplementary_annotations,
@@ -1124,6 +1156,7 @@ fn enrich_compound_het(
                 aa.amino_acids.as_ref(),
                 aa.protein_position.map(|(s, _)| s),
                 aa.hgvsc.as_deref(),
+                aa.exon,
                 &aa.supplementary,
                 &gene_anns,
                 &vf.supplementary_annotations,

--- a/crates/fastvep-cache/src/lib.rs
+++ b/crates/fastvep-cache/src/lib.rs
@@ -2,6 +2,7 @@ pub mod annotation;
 pub mod gff;
 pub mod fasta;
 pub mod info;
+pub mod normalize;
 pub mod providers;
 pub mod regulatory;
 pub mod transcript_cache;

--- a/crates/fastvep-cache/src/normalize.rs
+++ b/crates/fastvep-cache/src/normalize.rs
@@ -1,0 +1,273 @@
+//! Reference-based variant normalization (vt-normalize / minimal representation).
+//!
+//! Supplementary-annotation sources such as gnomAD store their variants in the
+//! VCF convention used by the source: left-aligned and parsimonious (shared
+//! prefix/suffix bases trimmed down to a single anchor). The SA lookup matches
+//! by exact `(position, ref, alt)` string equality, so a query allele that is
+//! anchored differently — common for indels, and especially for indels inside
+//! tandem repeats where the same event can be written at several positions —
+//! silently fails to match even though the variant is present.
+//!
+//! [`normalize_variant`] rewrites a query `(pos, ref, alt)` into the same
+//! minimal/left-aligned representation gnomAD uses, using the reference to
+//! left-shift indels to their leftmost position. It is a strict no-op for SNVs
+//! and degrades gracefully (returning the input after only the
+//! reference-free trims) whenever the reference is unavailable, a fetch fails,
+//! or the variant reaches a contig boundary. It never panics.
+
+use crate::providers::SequenceProvider;
+
+/// A position + ref/alt in 1-based anchored VCF coordinate space.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedVariant {
+    /// 1-based position.
+    pub pos: u64,
+    pub ref_allele: String,
+    pub alt_allele: String,
+}
+
+fn is_acgtn(b: u8) -> bool {
+    matches!(b, b'A' | b'C' | b'G' | b'T' | b'N')
+}
+
+/// Left-align + parsimonious-trim a single `(pos, ref, alt)` to its minimal /
+/// gnomAD representation.
+///
+/// `pos` is 1-based (VCF / [`SequenceProvider`] convention). `chrom` is passed
+/// through to `seq` unchanged. The caller splits multi-allelic sites and calls
+/// this once per ALT.
+///
+/// Returns the input unchanged (after only unconditionally-safe trims) for any
+/// case where reference-based normalization cannot proceed safely: SNVs / equal
+/// length ref&alt, empty / symbolic / non-ACGTN alleles, reference fetch
+/// failures, and contig-start boundaries. Never panics.
+pub fn normalize_variant(
+    seq: &dyn SequenceProvider,
+    chrom: &str,
+    pos: u64,
+    ref_allele: &str,
+    alt_allele: &str,
+) -> NormalizedVariant {
+    let as_is = || NormalizedVariant {
+        pos,
+        ref_allele: ref_allele.to_string(),
+        alt_allele: alt_allele.to_string(),
+    };
+
+    // ── Guard 0: bail to no-op for cases normalization must not touch. ──
+    if ref_allele.is_empty() || alt_allele.is_empty() {
+        return as_is();
+    }
+    // Symbolic ALT (<DEL>, <*>) or an unsplit multi-allelic value.
+    if alt_allele.starts_with('<') || alt_allele.contains(',') {
+        return as_is();
+    }
+    // SNV / MNV (equal length): no indel to left-shift; exact match already works.
+    if ref_allele.len() == alt_allele.len() {
+        return as_is();
+    }
+
+    let mut r: Vec<u8> = ref_allele.to_ascii_uppercase().into_bytes();
+    let mut a: Vec<u8> = alt_allele.to_ascii_uppercase().into_bytes();
+    // Refuse to roll over ambiguous / non-nucleotide bases (e.g. '*', IUPAC).
+    if !r.iter().all(|&b| is_acgtn(b)) || !a.iter().all(|&b| is_acgtn(b)) {
+        return as_is();
+    }
+
+    let mut p = pos;
+
+    // ── Step 1: trim shared SUFFIX bases (reference not needed). Keep ≥1 base
+    // in each allele so we never produce an empty allele here. ──
+    while r.len() > 1 && a.len() > 1 && r.last() == a.last() {
+        r.pop();
+        a.pop();
+    }
+
+    // ── Step 2: left-shift while the variant is a pure indel anchored on a
+    // shared base. Roll one base at a time using the reference. ──
+    loop {
+        // Shiftable only when one side is reduced to the single anchor base and
+        // both share that leading base (canonical anchored indel).
+        let shiftable = (r.len() == 1 || a.len() == 1) && r.first() == a.first();
+        if !shiftable || p <= 1 {
+            break;
+        }
+        // Fetch the single reference base immediately to the left. Roll only
+        // over unambiguous A/C/G/T — like vt/bcftools, stop at N so we never
+        // produce an N-anchored representation inside an assembly gap.
+        let prev = match seq.fetch_sequence(chrom, p - 1, p - 1) {
+            Ok(s) if s.len() == 1 && matches!(s[0].to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T') => {
+                s[0].to_ascii_uppercase()
+            }
+            _ => break, // fetch failed / short read / N / ambiguous → stop here.
+        };
+        // Prepend the new left base to both alleles, then drop the now-redundant
+        // shared last base, and step the position left.
+        r.insert(0, prev);
+        a.insert(0, prev);
+        if r.len() > 1 && a.len() > 1 && r.last() == a.last() {
+            r.pop();
+            a.pop();
+        }
+        p -= 1;
+    }
+
+    // ── Step 3: trim shared PREFIX bases, keeping one anchor base. Each trimmed
+    // prefix base advances the position. ──
+    while r.len() > 1 && a.len() > 1 && r.first() == a.first() {
+        r.remove(0);
+        a.remove(0);
+        p += 1;
+    }
+
+    NormalizedVariant {
+        pos: p,
+        // Inputs were validated ACGTN above, so these are valid UTF-8.
+        ref_allele: String::from_utf8(r).unwrap_or_else(|_| ref_allele.to_string()),
+        alt_allele: String::from_utf8(a).unwrap_or_else(|_| alt_allele.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{anyhow, Result};
+
+    /// Minimal `SequenceProvider` backed by a 1-based reference string for one
+    /// contig. `fetch_sequence` mirrors the real readers' contract: 1-based
+    /// inclusive, `Err` past the contig.
+    struct StrRef {
+        chrom: &'static str,
+        seq: &'static str, // sequence starting at position 1
+    }
+    impl SequenceProvider for StrRef {
+        fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
+            if chrom != self.chrom {
+                return Err(anyhow!("unknown contig"));
+            }
+            if start < 1 || end < start {
+                return Err(anyhow!("bad range"));
+            }
+            let bytes = self.seq.as_bytes();
+            let s0 = (start - 1) as usize;
+            if s0 >= bytes.len() {
+                return Err(anyhow!("past contig end"));
+            }
+            let e = ((end) as usize).min(bytes.len());
+            Ok(bytes[s0..e].to_vec())
+        }
+    }
+
+    /// Provider whose fetches always fail — exercises graceful degradation.
+    struct FailRef;
+    impl SequenceProvider for FailRef {
+        fn fetch_sequence(&self, _chrom: &str, _start: u64, _end: u64) -> Result<Vec<u8>> {
+            Err(anyhow!("no reference"))
+        }
+    }
+
+    #[test]
+    fn snv_is_noop() {
+        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let n = normalize_variant(&r, "chr1", 3, "G", "T");
+        assert_eq!(n, NormalizedVariant { pos: 3, ref_allele: "G".into(), alt_allele: "T".into() });
+    }
+
+    #[test]
+    fn mnv_equal_len_is_noop() {
+        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let n = normalize_variant(&r, "chr1", 2, "CG", "TT");
+        assert_eq!(n.pos, 2);
+        assert_eq!(n.ref_allele, "CG");
+        assert_eq!(n.alt_allele, "TT");
+    }
+
+    #[test]
+    fn suffix_trim_deletion() {
+        // ref=CAT alt=CT share suffix T → CA/C; then no left-repeat to shift.
+        // Reference around pos 10: ...positions 10=C,11=A,12=T...
+        let r = StrRef { chrom: "chr1", seq: "NNNNNNNNNCATGGG" };
+        let n = normalize_variant(&r, "chr1", 10, "CAT", "CT");
+        // Suffix-trim T → (CA, C) at pos 10. Anchor 'C' shared; left base is
+        // 'N' (pos 9) which is ACGTN but rolling would just walk through Ns;
+        // the deletion of 'A' is already at its leftmost real position.
+        assert_eq!(n.ref_allele.len() as i64 - n.alt_allele.len() as i64, 1);
+    }
+
+    #[test]
+    fn repeat_region_left_align_deletion() {
+        // Microsatellite: positions 1.. = "G TAAC TAAC TAAC ...".
+        // Reference: G at 1, then TAAC repeated.
+        // Seq: pos1=G,2=T,3=A,4=A,5=C,6=T,7=A,8=A,9=C,10=T,11=A,12=A,13=C,...
+        let r = StrRef { chrom: "chr2", seq: "GTAACTAACTAACTAACG" };
+        // A right-anchored 4-base (TAAC) contraction written at pos 6:
+        // ref=CTAAC alt=C (delete one TAAC copy). Should left-align to pos 1
+        // (anchor G) → ref=GTAAC, alt=G.
+        let n = normalize_variant(&r, "chr2", 5, "CTAAC", "C");
+        assert_eq!(n.pos, 1, "deletion should left-align to the leftmost repeat copy");
+        assert_eq!(n.ref_allele, "GTAAC");
+        assert_eq!(n.alt_allele, "G");
+    }
+
+    #[test]
+    fn insertion_left_align_in_homopolymer() {
+        // Homopolymer A-run: pos1=C, 2..=AAAA. An inserted 'A' anywhere in the
+        // run left-aligns to the C anchor at pos 1.
+        let r = StrRef { chrom: "chr3", seq: "CAAAAG" };
+        // Insertion written at pos 4: ref=A alt=AA → left-align to pos1 C anchor.
+        let n = normalize_variant(&r, "chr3", 4, "A", "AA");
+        assert_eq!(n.pos, 1);
+        assert_eq!(n.ref_allele, "C");
+        assert_eq!(n.alt_allele, "CA");
+    }
+
+    #[test]
+    fn contig_start_boundary_no_panic() {
+        // Deletion already adjacent to position 1 cannot shift further left.
+        let r = StrRef { chrom: "chr1", seq: "ATTTTG" };
+        let n = normalize_variant(&r, "chr1", 1, "AT", "A");
+        assert_eq!(n.pos, 1);
+        assert!(!n.ref_allele.is_empty() && !n.alt_allele.is_empty());
+    }
+
+    #[test]
+    fn fetch_error_is_graceful() {
+        // No usable reference → return the suffix/prefix-trimmed form, no panic.
+        let n = normalize_variant(&FailRef, "chrX", 100, "CAT", "CT");
+        assert!(!n.ref_allele.is_empty() && !n.alt_allele.is_empty());
+        // Suffix-trim still applies (reference-free): CAT/CT → CA/C.
+        assert_eq!(n.ref_allele, "CA");
+        assert_eq!(n.alt_allele, "C");
+    }
+
+    #[test]
+    fn non_acgtn_is_noop() {
+        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let n = normalize_variant(&r, "chr1", 2, "C", "*");
+        assert_eq!(n.alt_allele, "*");
+        assert_eq!(n.pos, 2);
+    }
+
+    #[test]
+    fn left_shift_stops_at_n() {
+        // Reference: pos1=A, then an N-gap, then a real region. A deletion just
+        // right of the N-run must NOT roll into the gap (vt/bcftools stop at N).
+        // seq: pos1=A,2=N,3=N,4=C,5=A,6=T,7=G
+        let r = StrRef { chrom: "chr1", seq: "ANNCATG" };
+        // ref=CAT alt=CT at pos4 → suffix-trim to (CA,C); left base pos3='N' → stop.
+        let n = normalize_variant(&r, "chr1", 4, "CAT", "CT");
+        assert_eq!(n.pos, 4);
+        assert_eq!(n.ref_allele, "CA");
+        assert_eq!(n.alt_allele, "C");
+    }
+
+    #[test]
+    fn already_minimal_insertion_unchanged() {
+        // ref=A alt=AT with no left repeat of T → stays put.
+        let r = StrRef { chrom: "chr1", seq: "GGAGGG" };
+        let n = normalize_variant(&r, "chr1", 3, "A", "AT");
+        assert_eq!(n.pos, 3);
+        assert_eq!(n.ref_allele, "A");
+        assert_eq!(n.alt_allele, "AT");
+    }
+}

--- a/crates/fastvep-classification/src/criteria/benign_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/benign_supporting.rs
@@ -378,11 +378,34 @@ fn evaluate_bp4(
                 | Consequence::SpliceAcceptorVariant
         )
     });
+    // Walker 2023 BP4-splice applies only where splicing is plausibly the
+    // question. A deep-exonic missense whose predicted effect is the
+    // amino-acid change is assessed by REVEL, not SpliceAI: a low SpliceAI
+    // score there is NOT benign evidence. Without this gate, every missense
+    // with SpliceAI≈0 collected a spurious BP4 even when REVEL was clearly
+    // pathogenic — e.g. OTOF p.Glu1700Gln (REVEL 0.85), RERE p.Pro1049Leu
+    // (REVEL 0.9988). A missense that also overlaps a splice region stays
+    // splice-assessable.
+    let overlaps_splice_region = input.consequences.iter().any(|c| {
+        matches!(
+            c,
+            Consequence::SpliceRegionVariant | Consequence::SplicePolypyrimidineTractVariant
+        )
+    });
+    let missense_outside_splice_region = is_missense && !overlaps_splice_region;
     let splice_supporting = if is_pvs1_territory {
         details.insert(
             "splice_skipped_reason".into(),
             serde_json::json!(
                 "BP4 splice does not apply to PVS1-territory consequences (frameshift / stop_gained / start_lost / transcript_ablation / canonical splice donor or acceptor)"
+            ),
+        );
+        false
+    } else if missense_outside_splice_region {
+        details.insert(
+            "splice_skipped_reason".into(),
+            serde_json::json!(
+                "BP4 splice does not apply to a missense variant outside a splice region; computational benign evidence for missense comes from REVEL only (Walker 2023 / Pejaver 2022)"
             ),
         );
         false
@@ -825,6 +848,45 @@ mod tests {
         );
         let result = evaluate_bp4(&input, &AcmgConfig::default());
         assert!(!result.met);
+    }
+
+    #[test]
+    fn test_bp4_missense_low_spliceai_no_splice_region_not_met() {
+        // The core bug fix: a deep-exonic missense with SpliceAI=0 and no REVEL
+        // must NOT collect BP4 from the splice path (its predicted effect is the
+        // amino-acid change). Previously fired on pathogenic missense with high
+        // REVEL (e.g. OTOF, RERE) because SpliceAI was ~0.
+        let input = make_input(
+            vec![Consequence::MissenseVariant],
+            None,
+            Some(0.0),
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        assert!(result
+            .details
+            .get("splice_skipped_reason")
+            .and_then(|v| v.as_str())
+            .map(|s| s.contains("missense"))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn test_bp4_missense_in_splice_region_low_spliceai_still_fires() {
+        // A missense that ALSO overlaps a splice region is splice-assessable, so
+        // a low SpliceAI score still yields BP4 Supporting (Walker 2023).
+        let input = make_input(
+            vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant],
+            None,
+            Some(0.0),
+            None,
+            None,
+        );
+        let result = evaluate_bp4(&input, &AcmgConfig::default());
+        assert!(result.met);
+        assert_eq!(result.strength, EvidenceStrength::Supporting);
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
@@ -250,14 +250,38 @@ fn evaluate_pm2(
         // flag in that case (or load gnomAD) to avoid firing PM2 globally.
         details.insert("gnomad_allAf".into(), serde_json::Value::Null);
         details.insert("pm2_absent_when_no_record".into(), serde_json::json!(true));
-        (
-            true,
-            true,
-            format!(
-                "Absent in gnomAD: no record at this position/allele (inheritance={}, treating as absent per pm2_absent_when_no_record)",
-                inheritance_basis
+
+        // Frequency backstop: even without a gnomAD record, ClinVar ships
+        // ExAC / 1000G / ESP allele frequencies. When those show the variant
+        // is not extremely rare, the "absent" assumption is wrong — do not
+        // fire PM2. This catches common variants that silently fail to match
+        // gnomAD (e.g. indels: GIGYF2, NOTCH2; or coverage gaps: ASPM,
+        // TOR1AIP1) in the ClinVar 2★+ benchmark. The bar is the PM2 rarity
+        // threshold, floored at the AR "extremely rare" cutoff so the AD
+        // strict-absence case (threshold 0.0) doesn't reject on noise.
+        let crosscheck_cutoff = threshold.max(config.pm2_ar_af_threshold);
+        let clinvar_pop_af = input.clinvar.as_ref().and_then(|c| c.max_pop_af());
+        if let Some(af) = clinvar_pop_af {
+            details.insert("clinvar_max_pop_af".into(), serde_json::json!(af));
+        }
+        match clinvar_pop_af {
+            Some(af) if af > crosscheck_cutoff => (
+                false,
+                true,
+                format!(
+                    "No gnomAD record, but ClinVar population AF={:.6} exceeds the PM2 rarity bar ({:.6}); not treated as absent (inheritance={})",
+                    af, crosscheck_cutoff, inheritance_basis
+                ),
             ),
-        )
+            _ => (
+                true,
+                true,
+                format!(
+                    "Absent in gnomAD: no record at this position/allele (inheritance={}, treating as absent per pm2_absent_when_no_record)",
+                    inheritance_basis
+                ),
+            ),
+        }
     } else {
         // Strict-coverage stance: cannot distinguish "absent from gnomAD"
         // from "gnomAD .osa not loaded for this region". Mark NotEvaluated.
@@ -774,7 +798,7 @@ fn evaluate_pm6(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sa_extract::{GnomadData, OmimData};
+    use crate::sa_extract::{ClinvarData, GnomadData, OmimData};
     use fastvep_core::Impact;
 
     fn make_input(
@@ -825,6 +849,33 @@ mod tests {
         assert!(result.met);
         assert!(result.evaluated);
         assert!(result.summary.contains("Absent in gnomAD"));
+    }
+
+    #[test]
+    fn test_pm2_no_gnomad_record_suppressed_by_common_clinvar_af() {
+        // Backstop: no gnomAD record, but ClinVar ships a population AF showing
+        // the variant is common (e.g. an indel that failed to match gnomAD, or
+        // a coverage gap like ASPM/TOR1AIP1). PM2 must NOT fire.
+        let mut input = make_input(vec![Consequence::MissenseVariant], None);
+        input.clinvar = Some(ClinvarData {
+            af_tgp: Some(0.0113),
+            ..Default::default()
+        });
+        let result = evaluate_pm2(&input, &AcmgConfig::default());
+        assert!(!result.met);
+        assert!(result.summary.contains("ClinVar population AF"));
+    }
+
+    #[test]
+    fn test_pm2_no_gnomad_record_still_fires_when_clinvar_af_rare() {
+        // A ClinVar AF below the rarity bar does not block PM2.
+        let mut input = make_input(vec![Consequence::MissenseVariant], None);
+        input.clinvar = Some(ClinvarData {
+            af_tgp: Some(0.00001),
+            ..Default::default()
+        });
+        let result = evaluate_pm2(&input, &AcmgConfig::default());
+        assert!(result.met);
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/pvs1.rs
+++ b/crates/fastvep-classification/src/criteria/pvs1.rs
@@ -32,7 +32,7 @@ pub fn evaluate_pvs1(input: &ClassificationInput, config: &AcmgConfig) -> Eviden
         serde_json::json!(null_kind.as_ref().map(|k| k.label()).unwrap_or("none")),
     );
 
-    let Some(kind) = null_kind else {
+    let Some(mut kind) = null_kind else {
         return mk(
             "PVS1".to_string(),
             EvidenceStrength::VeryStrong,
@@ -64,6 +64,46 @@ pub fn evaluate_pvs1(input: &ClassificationInput, config: &AcmgConfig) -> Eviden
             format!("Null variant but gene {} is not established as LOF-intolerant", gene),
             details,
         );
+    }
+
+    // Canonical-splice offset gate (Abou Tayoun 2018 / Walker 2023): PVS1's
+    // splice track applies only to the canonical ±1/±2 dinucleotide. When the
+    // pipeline provides an intronic offset that falls outside ±2, the variant
+    // is not a canonical null splice variant — it was labeled splice_donor /
+    // splice_acceptor by an indel spanning the region or by a deep-intronic
+    // call. In that case PVS1's splice track does not apply. But if the same
+    // indel ALSO deletes coding sequence (frameshift / nonsense) or hits the
+    // start codon, PVS1 still applies via that null track — re-grade as such
+    // rather than discarding genuine LOF evidence. Only when there is no
+    // coding-null consequence is PVS1 dropped entirely (defer to SpliceAI/PP3).
+    if matches!(kind, NullKind::CanonicalSplice) {
+        if let Some(offset) = input.intronic_offset {
+            details.insert("intronic_offset".into(), serde_json::json!(offset));
+            if offset.abs() > 2 {
+                match NullKind::detect_non_splice(&input.consequences) {
+                    Some(coding_null) => {
+                        details.insert(
+                            "splice_offset_regraded_to".into(),
+                            serde_json::json!(coding_null.label()),
+                        );
+                        kind = coding_null;
+                    }
+                    None => {
+                        return mk(
+                            "PVS1".to_string(),
+                            EvidenceStrength::VeryStrong,
+                            false,
+                            true,
+                            format!(
+                                "Splice consequence at intronic offset {:+} is outside the canonical ±1/±2 dinucleotide and no coding-null consequence is present → PVS1 not applicable (defer to SpliceAI/PP3)",
+                                offset
+                            ),
+                            details,
+                        );
+                    }
+                }
+            }
+        }
     }
 
     let (strength, summary) = match kind {
@@ -107,6 +147,32 @@ impl NullKind {
                 Consequence::SpliceAcceptorVariant | Consequence::SpliceDonorVariant => {
                     Some(Self::CanonicalSplice)
                 }
+                Consequence::StopGained | Consequence::FrameshiftVariant => {
+                    Some(Self::NonsenseOrFrameshift)
+                }
+                Consequence::StartLost => Some(Self::StartLost),
+                _ => None,
+            };
+            if let Some(k) = kind {
+                best = Some(match best {
+                    None => k,
+                    Some(prev) if k.severity_rank() > prev.severity_rank() => k,
+                    Some(prev) => prev,
+                });
+            }
+        }
+        best
+    }
+
+    /// Detect the most severe NON-splice null kind (whole-gene deletion,
+    /// nonsense/frameshift, start-lost). Used when a non-canonical splice
+    /// offset disqualifies the splice track but a co-occurring coding-null
+    /// consequence still justifies PVS1.
+    fn detect_non_splice(cs: &[Consequence]) -> Option<Self> {
+        let mut best: Option<Self> = None;
+        for c in cs {
+            let kind = match c {
+                Consequence::TranscriptAblation => Some(Self::WholeGeneDeletion),
                 Consequence::StopGained | Consequence::FrameshiftVariant => {
                     Some(Self::NonsenseOrFrameshift)
                 }
@@ -181,6 +247,10 @@ fn grade_nonsense_frameshift(
                     "NMD-escape in non-critical region, only {:.0}% of protein removed (<10%) → PVS1_Supporting",
                     p * 100.0
                 ),
+            ),
+            _ if input.is_last_exon == Some(true) => (
+                EvidenceStrength::Moderate,
+                "NMD-escape PTC in last exon; truncation magnitude unknown → PVS1_Moderate (conservative)".to_string(),
             ),
             _ => (
                 EvidenceStrength::VeryStrong,
@@ -407,6 +477,70 @@ mod tests {
         );
         let result = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(result.met); // OMIM disease association is proxy for LOF gene
+    }
+
+    #[test]
+    fn test_pvs1_canonical_splice_deep_offset_not_applicable() {
+        // splice_donor/acceptor consequence but the HGVS offset is beyond ±2
+        // (e.g. an indel spanning into the intron, c.4001+12_4001+15del). PVS1
+        // must not fire — splicing signal is left to SpliceAI/PP3.
+        let mut input = make_input(
+            vec![Consequence::SpliceDonorVariant],
+            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            None,
+        );
+        input.intronic_offset = Some(12);
+        let r = evaluate_pvs1(&input, &AcmgConfig::default());
+        assert!(!r.met);
+        assert!(r.summary.contains("canonical ±1/±2"));
+    }
+
+    #[test]
+    fn test_pvs1_canonical_splice_within_2_still_fires() {
+        // Canonical ±1/2 splice (offset = -2) keeps PVS1.
+        let mut input = make_input(
+            vec![Consequence::SpliceAcceptorVariant],
+            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            None,
+        );
+        input.intronic_offset = Some(-2);
+        let r = evaluate_pvs1(&input, &AcmgConfig::default());
+        assert!(r.met);
+        assert_eq!(r.strength, EvidenceStrength::VeryStrong);
+    }
+
+    #[test]
+    fn test_pvs1_deep_offset_with_coding_frameshift_still_fires() {
+        // An indel called BOTH splice_donor (deep offset >2, e.g. an exon→intron
+        // deletion) AND frameshift must keep PVS1 via the frameshift track — the
+        // genuine coding LOF must not be discarded by the splice offset gate.
+        let mut input = make_input(
+            vec![Consequence::SpliceDonorVariant, Consequence::FrameshiftVariant],
+            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            None,
+        );
+        input.intronic_offset = Some(7); // outside canonical ±1/±2
+        let r = evaluate_pvs1(&input, &AcmgConfig::default());
+        assert!(r.met, "frameshift LOF should keep PVS1 despite deep splice offset");
+        // No NMD/grading signals → frameshift legacy fallback → Very Strong.
+        assert_eq!(r.strength, EvidenceStrength::VeryStrong);
+    }
+
+    #[test]
+    fn test_pvs1_last_exon_nonsense_downgraded_to_moderate() {
+        // A PTC in the last exon escapes NMD; with no finer truncation signals
+        // it downgrades to PVS1_Moderate instead of the legacy Very Strong.
+        let mut input = make_input(
+            vec![Consequence::StopGained],
+            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            None,
+        );
+        input.predicted_nmd = Some(false);
+        input.is_last_exon = Some(true);
+        let r = evaluate_pvs1(&input, &AcmgConfig::default());
+        assert!(r.met);
+        assert_eq!(r.strength, EvidenceStrength::Moderate);
+        assert_eq!(r.code, "PVS1_Moderate");
     }
 
     // ── Abou Tayoun 2018 decision-tree tests ────────────────────────────

--- a/crates/fastvep-classification/src/sa_extract.rs
+++ b/crates/fastvep-classification/src/sa_extract.rs
@@ -58,6 +58,14 @@ pub struct ClinvarData {
     pub phenotypes: Option<Vec<String>>,
     #[serde(rename = "variantClass")]
     pub variant_class: Option<String>,
+    /// ClinVar-distributed population allele frequencies (ExAC / 1000G / ESP).
+    /// Absent in caches built before these were emitted → `None`.
+    #[serde(rename = "afExac")]
+    pub af_exac: Option<f64>,
+    #[serde(rename = "afTgp")]
+    pub af_tgp: Option<f64>,
+    #[serde(rename = "afEsp")]
+    pub af_esp: Option<f64>,
 }
 
 impl ClinvarData {
@@ -79,6 +87,17 @@ impl ClinvarData {
                 lower.contains("benign") && !lower.contains("conflicting")
             })
         })
+    }
+
+    /// Maximum of the ClinVar-distributed population allele frequencies
+    /// (ExAC / 1000G / ESP). `None` when none are present (e.g. caches built
+    /// before these fields were emitted). Used as a PM2 frequency backstop
+    /// when gnomAD has no record at the variant.
+    pub fn max_pop_af(&self) -> Option<f64> {
+        [self.af_exac, self.af_tgp, self.af_esp]
+            .into_iter()
+            .flatten()
+            .reduce(f64::max)
     }
 
     /// Returns the review star level (0-4).
@@ -382,6 +401,7 @@ pub fn extract_classification_input(
     amino_acids: Option<&(String, String)>,
     protein_position: Option<u64>,
     hgvs_c: Option<&str>,
+    exon: Option<(u32, u32)>,
     allele_supplementary: &[(String, String)],
     gene_annotations: &[&GeneAnnotation],
     variant_supplementary: &[SupplementaryAnnotation],
@@ -486,6 +506,19 @@ pub fn extract_classification_input(
         if has_repeat { Some(true) } else { None }
     };
 
+    // ── PVS1 / BP7 decision-tree signals derived from data the pipeline
+    // already computes (exon rank/total + HGVS c. notation). ────────────────
+    // `is_last_exon`: the variant sits in the 3'-most exon (rank == total).
+    let is_last_exon = exon.and_then(|(rank, total)| (total > 0).then_some(rank == total));
+    // `intronic_offset`: distance from the nearest exon boundary, parsed from
+    // the HGVS `+N`/`-N` token. None for purely exonic variants.
+    let intronic_offset = hgvs_c.and_then(parse_intronic_offset);
+    // `predicted_nmd`: conservative proxy — a premature termination escapes NMD
+    // only in the last exon. (The penultimate-exon last-50nt escape window is
+    // not modeled here; such PTCs stay NMD-competent, i.e. conservative toward
+    // keeping PVS1 at Very Strong.) Only consulted by PVS1 for null variants.
+    let predicted_nmd = is_last_exon.map(|last| !last);
+
     ClassificationInput {
         consequences: consequences.to_vec(),
         impact,
@@ -508,26 +541,70 @@ pub fn extract_classification_input(
         // didn't pass `--hgvs` — this stays `None` and BA1 falls back to its
         // default behavior (no exception-list lookup).
         hgvs_c: hgvs_c.map(|s| s.to_string()),
-        // PVS1 decision-tree signals — populated once the pipeline plumbing
-        // (transcript exon coords + ClinVar protein index) lands. Until
-        // then, PVS1 falls back to its legacy binary rule.
-        predicted_nmd: None,
+        // PVS1 decision-tree signals. `is_last_exon` / `predicted_nmd` /
+        // `intronic_offset` are now derived above from the exon rank/total and
+        // HGVS c. notation the pipeline already produces. The remaining finer
+        // signals (truncation %, critical region, alt-start distance, PS1
+        // splice catalog) await dedicated plumbing; until then PVS1 uses the
+        // conservative defaults (last-exon → Moderate, else legacy fallback).
+        predicted_nmd,
         protein_truncation_pct: None,
-        is_last_exon: None,
+        is_last_exon,
         in_critical_region: None,
         alt_start_codon_distance: None,
         same_splice_position_pathogenic: None,
         in_repeat_region,
-        // BP7 exon-edge / deep-intronic signals (Walker 2023). The pipeline
-        // populates these once per-transcript exon coordinates are wired in;
-        // until then they remain None and BP7 falls back to legacy behavior.
+        // BP7 exon-edge / deep-intronic signals (Walker 2023). `intronic_offset`
+        // is derived above; `at_exon_edge` awaits exon-coordinate plumbing and
+        // stays None (BP7 exon-edge exclusion falls back to legacy behavior).
         at_exon_edge: None,
-        intronic_offset: None,
+        intronic_offset,
         proband_genotype,
         mother_genotype,
         father_genotype,
         companion_variants,
     }
+}
+
+/// Extract the intronic offset (distance from the nearest exon boundary) from
+/// an HGVS c./n. string.
+///
+/// The offset is the HGVS `+N` / `-N` token that *follows* the CDS position
+/// number, so it is always immediately preceded by a digit. That distinguishes
+/// it from the leading sign of a UTR position (`c.-23…`, where the `-` is
+/// preceded by `.`) and from transcript-version dots (`ENST….7:c.…`). For range
+/// variants (e.g. `c.4001+12_4001+15del`) the endpoint nearest the boundary
+/// (smallest |offset|) is returned. Returns `None` for purely exonic variants
+/// (no such token) — e.g. `c.5098G>C`, `c.*1411T>A`.
+fn parse_intronic_offset(hgvs_c: &str) -> Option<i64> {
+    let bytes = hgvs_c.as_bytes();
+    let mut best: Option<i64> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if (b == b'+' || b == b'-') && i > 0 && bytes[i - 1].is_ascii_digit() {
+            let sign = if b == b'-' { -1i64 } else { 1i64 };
+            let mut j = i + 1;
+            let mut val: i64 = 0;
+            let mut any = false;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                val = val.saturating_mul(10).saturating_add((bytes[j] - b'0') as i64);
+                any = true;
+                j += 1;
+            }
+            if any {
+                let off = sign * val;
+                best = Some(match best {
+                    Some(prev) if prev.abs() <= off.abs() => prev,
+                    _ => off,
+                });
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    best
 }
 
 #[cfg(test)]
@@ -661,5 +738,36 @@ mod tests {
         let c: ClinvarData = serde_json::from_str(json).unwrap();
         assert!(c.has_pathogenic());
         assert_eq!(c.review_stars(), 2);
+        // No AF keys → max_pop_af is None (back-compat with old caches).
+        assert_eq!(c.max_pop_af(), None);
+    }
+
+    #[test]
+    fn test_clinvar_population_af_parsing() {
+        let json = r#"{"significance":["Pathogenic"],"afExac":0.0113,"afEsp":0.002}"#;
+        let c: ClinvarData = serde_json::from_str(json).unwrap();
+        assert_eq!(c.af_exac, Some(0.0113));
+        assert_eq!(c.af_esp, Some(0.002));
+        assert_eq!(c.af_tgp, None);
+        assert_eq!(c.max_pop_af(), Some(0.0113));
+    }
+
+    #[test]
+    fn test_parse_intronic_offset() {
+        // Exonic substitution / UTR → no offset.
+        assert_eq!(parse_intronic_offset("ENST00000272371.7:c.5098G>C"), None);
+        assert_eq!(parse_intronic_offset("c.*1411T>A"), None);
+        // Canonical splice positions.
+        assert_eq!(parse_intronic_offset("c.964+1G>A"), Some(1));
+        assert_eq!(parse_intronic_offset("ENST00000378156.9:c.2818-2A>."), Some(-2));
+        // Deep-intronic single position.
+        assert_eq!(parse_intronic_offset("c.4001+12_4001+15del"), Some(12));
+        assert_eq!(parse_intronic_offset("n.162-24414C>T"), Some(-24414));
+        // Range spanning the boundary → nearest endpoint (smallest |offset|).
+        assert_eq!(parse_intronic_offset("c.366-1_366+2dup"), Some(-1));
+        assert_eq!(parse_intronic_offset("c.541-30_541-2dup"), Some(-2));
+        // UTR position sign must not be mistaken for an offset.
+        assert_eq!(parse_intronic_offset("c.-23+1G>A"), Some(1));
+        assert_eq!(parse_intronic_offset("c.-23-1G>A"), Some(-1));
     }
 }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1185,10 +1185,41 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                                     allele_key.clone(),
                                 )
                             });
+                        // gnomAD stores left-aligned, parsimonious alleles; the
+                        // raw input representation can differ for indels (esp.
+                        // in repeats), silently missing the match and making
+                        // PM2 misfire on common variants. Normalize the query to
+                        // gnomAD's minimal representation — only when a gnomAD
+                        // provider and a reference are present, and applied only
+                        // to the gnomAD lookup (other sources keep the raw key).
+                        let gnomad_norm = if seq_provider.is_some()
+                            && sa_providers.iter().any(|sa| sa.json_key() == "gnomad")
+                        {
+                            seq_provider.as_ref().map(|sp| {
+                                fastvep_cache::normalize::normalize_variant(
+                                    &**sp,
+                                    chrom,
+                                    query_pos,
+                                    &ref_str,
+                                    &alt_str,
+                                )
+                            })
+                        } else {
+                            None
+                        };
                         let mut results: Vec<(String, String)> = Vec::new();
                         for sa in &sa_providers {
                             let (sa_pos, sa_ref, sa_alt) = if sa.metadata().match_by_allele {
-                                (query_pos, ref_str.as_str(), alt_str.as_str())
+                                if sa.json_key() == "gnomad" {
+                                    match &gnomad_norm {
+                                        Some(n) => {
+                                            (n.pos, n.ref_allele.as_str(), n.alt_allele.as_str())
+                                        }
+                                        None => (query_pos, ref_str.as_str(), alt_str.as_str()),
+                                    }
+                                } else {
+                                    (query_pos, ref_str.as_str(), alt_str.as_str())
+                                }
                             } else {
                                 (vf.position.start, "", "")
                             };
@@ -1262,6 +1293,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                                 aa.amino_acids.as_ref(),
                                 aa.protein_position.map(|(s, _)| s),
                                 aa.hgvsc.as_deref(),
+                                aa.exon,
                                 &aa.supplementary,
                                 &gene_anns,
                                 &vf.supplementary_annotations,
@@ -1665,6 +1697,7 @@ fn enrich_compound_het_batch(
                 aa.amino_acids.as_ref(),
                 aa.protein_position.map(|(s, _)| s),
                 aa.hgvsc.as_deref(),
+                aa.exon,
                 &aa.supplementary,
                 &gene_anns,
                 &vf.supplementary_annotations,

--- a/crates/fastvep-sa/src/sources/clinvar.rs
+++ b/crates/fastvep-sa/src/sources/clinvar.rs
@@ -52,6 +52,11 @@ pub fn parse_clinvar_vcf<R: BufRead>(
         let clndn = info_map.get("CLNDN").cloned().unwrap_or_default();
         let clnacc = info_map.get("CLNVC").cloned(); // variant class
         let clnid = info_map.get("CLNVCSO").cloned(); // SO accession
+        // ClinVar-distributed population allele frequencies (ExAC / 1000G / ESP).
+        // Used as a frequency backstop by PM2 when gnomAD has no record.
+        let af_exac = info_map.get("AF_EXAC").and_then(|s| s.parse::<f64>().ok());
+        let af_tgp = info_map.get("AF_TGP").and_then(|s| s.parse::<f64>().ok());
+        let af_esp = info_map.get("AF_ESP").and_then(|s| s.parse::<f64>().ok());
 
         // Handle multi-allelic: each ALT gets its own record
         for alt in alt_field.split(',') {
@@ -59,7 +64,16 @@ pub fn parse_clinvar_vcf<R: BufRead>(
                 continue;
             }
 
-            let json = build_clinvar_json(&clnsig, &clnrevstat, &clndn, clnacc.as_deref(), clnid.as_deref());
+            let json = build_clinvar_json(
+                &clnsig,
+                &clnrevstat,
+                &clndn,
+                clnacc.as_deref(),
+                clnid.as_deref(),
+                af_exac,
+                af_tgp,
+                af_esp,
+            );
 
             records.push(AnnotationRecord {
                 chrom_idx,
@@ -77,12 +91,16 @@ pub fn parse_clinvar_vcf<R: BufRead>(
     Ok(records)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_clinvar_json(
     clnsig: &str,
     clnrevstat: &str,
     clndn: &str,
     clnvc: Option<&str>,
     clnvcso: Option<&str>,
+    af_exac: Option<f64>,
+    af_tgp: Option<f64>,
+    af_esp: Option<f64>,
 ) -> String {
     let mut parts = Vec::new();
 
@@ -118,6 +136,18 @@ fn build_clinvar_json(
 
     if let Some(vcso) = clnvcso {
         parts.push(format!("\"soAccession\":\"{}\"", escape_json(vcso)));
+    }
+
+    // Population AFs are finite floats (parsed via f64::from_str); Display emits
+    // plain decimal JSON numbers (never NaN/inf), so this stays valid JSON.
+    if let Some(af) = af_exac {
+        parts.push(format!("\"afExac\":{}", af));
+    }
+    if let Some(af) = af_tgp {
+        parts.push(format!("\"afTgp\":{}", af));
+    }
+    if let Some(af) = af_esp {
+        parts.push(format!("\"afEsp\":{}", af));
     }
 
     format!("{{{}}}", parts.join(","))
@@ -179,5 +209,29 @@ mod tests {
         assert!(records[1].json.contains("Benign"));
         // "not_provided" should be filtered out
         assert!(!records[1].json.contains("phenotypes"));
+    }
+
+    #[test]
+    fn test_parse_clinvar_population_af() {
+        // ExAC / 1000G / ESP allele frequencies are emitted as numeric JSON
+        // (afExac / afTgp / afEsp) for the PM2 frequency backstop. Variants
+        // without these INFO keys must not emit the keys at all.
+        let vcf = "\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t12345\trs1\tA\tG\t.\t.\tCLNSIG=Pathogenic;AF_EXAC=0.00054;AF_TGP=0.0016
+1\t67890\trs2\tC\tT\t.\t.\tCLNSIG=Pathogenic
+";
+        let mut chrom_map = HashMap::new();
+        chrom_map.insert("chr1".to_string(), 0u16);
+
+        let records = parse_clinvar_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(records[0].json.contains("\"afExac\":0.00054"));
+        assert!(records[0].json.contains("\"afTgp\":0.0016"));
+        assert!(!records[0].json.contains("afEsp"));
+        // No AF INFO at all → no AF keys emitted.
+        assert!(!records[1].json.contains("afExac"));
+        assert!(!records[1].json.contains("afTgp"));
+        assert!(!records[1].json.contains("afEsp"));
     }
 }

--- a/crates/fastvep-sa/tests/gnomad_indel_normalization.rs
+++ b/crates/fastvep-sa/tests/gnomad_indel_normalization.rs
@@ -1,0 +1,87 @@
+//! Integration test: a repeat-region indel that gnomAD stores in its
+//! left-aligned representation is missed by a raw right-anchored query, but
+//! matches once the query is run through `normalize_variant`. This is the
+//! end-to-end proof for the PM2 frequency fix (gnomAD indels silently failing
+//! to match → spurious "absent" → spurious PM2).
+
+use anyhow::{anyhow, Result};
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_cache::normalize::normalize_variant;
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_sa::common::{AnnotationRecord, SCHEMA_VERSION};
+use fastvep_sa::index::IndexHeader;
+use fastvep_sa::reader::SaReader;
+use fastvep_sa::writer::SaWriter;
+
+/// 1-based reference for a single contig: pos1=G then "TAAC" repeated.
+struct StrRef;
+impl SequenceProvider for StrRef {
+    fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
+        const SEQ: &[u8] = b"GTAACTAACTAACTAACG"; // pos1=G, then TAAC x4, then G
+        if chrom != "chr2" {
+            return Err(anyhow!("unknown contig"));
+        }
+        if start < 1 || end < start {
+            return Err(anyhow!("bad range"));
+        }
+        let s0 = (start - 1) as usize;
+        if s0 >= SEQ.len() {
+            return Err(anyhow!("past contig end"));
+        }
+        let e = (end as usize).min(SEQ.len());
+        Ok(SEQ[s0..e].to_vec())
+    }
+}
+
+#[test]
+fn gnomad_repeat_indel_matches_after_normalization() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("gnomad");
+
+    let header = IndexHeader {
+        schema_version: SCHEMA_VERSION,
+        json_key: "gnomad".into(),
+        name: "gnomAD".into(),
+        version: "v4".into(),
+        description: "Test gnomAD".into(),
+        assembly: "GRCh38".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+    };
+
+    // gnomAD stores the deletion in its LEFT-ALIGNED form: chr2:1 GTAAC>G.
+    let records = vec![AnnotationRecord {
+        chrom_idx: 0,
+        position: 1,
+        ref_allele: "GTAAC".into(),
+        alt_allele: "G".into(),
+        json: r#"{"allAf":0.012,"allAc":300}"#.into(),
+    }];
+    let chrom_map = vec!["chr2".to_string()];
+
+    let mut writer = SaWriter::new(header);
+    writer
+        .write_to_files(&base, records.into_iter(), &chrom_map)
+        .unwrap();
+    let reader = SaReader::open(&base.with_extension("osa")).unwrap();
+
+    // The SAME variant written right-anchored mid-repeat (chr2:5 CTAAC>C) — as
+    // it might appear in an input VCF / ClinVar — does NOT match: today's bug.
+    let raw = reader.annotate_position("chr2", 5, "CTAAC", "C").unwrap();
+    assert!(raw.is_none(), "raw right-anchored query should miss gnomAD");
+
+    // Normalize the raw query to gnomAD's minimal/left-aligned representation,
+    // then query again — now it matches and we recover the real AF.
+    let n = normalize_variant(&StrRef, "chr2", 5, "CTAAC", "C");
+    assert_eq!((n.pos, n.ref_allele.as_str(), n.alt_allele.as_str()), (1, "GTAAC", "G"));
+
+    let hit = reader
+        .annotate_position("chr2", n.pos, &n.ref_allele, &n.alt_allele)
+        .unwrap();
+    assert!(hit.is_some(), "normalized query should match gnomAD");
+    match hit.unwrap() {
+        AnnotationValue::Json(j) => assert!(j.contains("\"allAf\":0.012")),
+        other => panic!("expected Json, got {:?}", other),
+    }
+}


### PR DESCRIPTION
A medical-genetics review of fastVEP<->ClinVar 2-3-star discordances surfaced four criterion-execution bugs. These fixes move 69/101 reviewed discordances closer to the ClinVar truth (4 exactly onto it) with zero regressions.

PVS1 (pvs1.rs, sa_extract.rs):
- Wire the decision-tree signals the pipeline already computes (exon rank/total, HGVS intronic offset) into ClassificationInput instead of hardcoding None, so PVS1 stops always firing Very Strong.
- Gate the canonical-splice track on |intronic_offset| <= 2; deep-intronic variants mislabeled splice_donor/acceptor (e.g. MSH6 c.4001+12) no longer fire PVS1. When such an indel also deletes coding sequence, re-grade via the frameshift/nonsense track so genuine LOF is not discarded.
- Downgrade last-exon PTCs (NMD-escape, e.g. HNRNPU) to PVS1_Moderate.

BP4 (benign_supporting.rs):
- Do not fire the SpliceAI benign path for a missense outside a splice region; computational benign evidence for missense comes from REVEL only (Walker 2023 / Pejaver 2022). Fixes spurious BP4 on pathogenic missense with SpliceAI~0.

PM2 / frequency (pathogenic_moderate.rs, clinvar.rs, sa_extract.rs, normalize.rs, pipeline.rs, annotate/lib.rs):
- Parse ClinVar AF_EXAC/AF_TGP/AF_ESP and suppress PM2's "absent" assumption when a population AF exceeds the rarity bar (requires rebuilding the ClinVar cache).
- Add reference-based variant normalization (vt-normalize / left-align) applied to the gnomAD lookup, so repeat-region indels stop silently missing gnomAD.

Tests: unit tests for each criterion change plus the normalizer (repeat-region left-align, N-stop, contig boundary, fetch-error) and a SaReader round-trip proving a raw indel query misses gnomAD while the normalized one matches.