### PR TITLE
sa-build: parse NCBI dbSNP VCF named by RefSeq accession (#51)

### DIFF
--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -2139,7 +2139,7 @@ fn prescan_vcf_regions(vcf_path: &str, distance: u64) -> Result<Vec<(String, u64
 /// releases — and by most input VCFs we annotate against. The HashMap
 /// resolves both `chr*` and bare forms (plus `MT`/`M`) so source parsers
 /// can hand us either style. See issue #37.
-fn standard_chrom_map() -> (Vec<String>, std::collections::HashMap<String, u16>) {
+fn standard_chrom_map(assembly: &str) -> (Vec<String>, std::collections::HashMap<String, u16>) {
     let chroms: Vec<String> = (1..=22)
         .map(|i| format!("chr{}", i))
         .chain(["chrX", "chrY", "chrM"].iter().map(|s| s.to_string()))
@@ -2160,6 +2160,17 @@ fn standard_chrom_map() -> (Vec<String>, std::collections::HashMap<String, u16>)
     if let Some(&mt_idx) = map.get("chrM") {
         map.insert("MT".to_string(), mt_idx);
         map.insert("chrMT".to_string(), mt_idx);
+    }
+    // RefSeq molecule accessions (`NC_000001.11`). NCBI's dbSNP VCF release
+    // names contigs this way, so without these every record's chromosome misses
+    // the map and zero records are parsed (issue #51). The accession→chromosome
+    // relationship is assembly-specific and non-algorithmic, hence a table.
+    if let Some(accessions) = fastvep_core::refseq_primary_accessions(assembly) {
+        for (acc, chr_name) in accessions {
+            if let Some(&idx) = map.get(*chr_name) {
+                map.insert(acc.to_string(), idx);
+            }
+        }
     }
     (chroms, map)
 }
@@ -2219,7 +2230,7 @@ pub fn run_sa_build(
         };
     }
 
-    let (chrom_list, chrom_map) = standard_chrom_map();
+    let (chrom_list, chrom_map) = standard_chrom_map(assembly);
 
     let header = match source {
         "clinvar" => IndexHeader {
@@ -2424,6 +2435,16 @@ pub fn run_sa_build(
     };
 
     eprintln!("Parsed {} records from {}", records.len(), source);
+    if records.is_empty() {
+        eprintln!(
+            "Warning: 0 records parsed from {} — if the input is non-empty, this \
+             usually means none of its chromosome names matched assembly '{}'. \
+             NCBI releases (e.g. dbSNP) name contigs by RefSeq accession \
+             (NC_000001.11); pass the --assembly (GRCh38 or GRCh37) matching the \
+             build you downloaded.",
+            source, assembly
+        );
+    }
 
     let output_path = Path::new(output);
     let mut writer = SaWriter::new(header);
@@ -2501,7 +2522,7 @@ fn run_custom_vcf_build(
     use fastvep_sa::index::IndexHeader;
     use fastvep_sa::writer::SaWriter;
 
-    let (chrom_list, chrom_map) = standard_chrom_map();
+    let (chrom_list, chrom_map) = standard_chrom_map(assembly);
     let resolved_name = resolve_custom_name(name, input);
     let json_key = resolved_name.clone();
 
@@ -2574,7 +2595,7 @@ fn run_custom_bed_build(
 ) -> Result<()> {
     use fastvep_sa::interval::{IntervalHeader, IntervalIndex};
 
-    let (_chrom_list, chrom_map) = standard_chrom_map();
+    let (_chrom_list, chrom_map) = standard_chrom_map(assembly);
     let resolved_name = resolve_custom_name(name, input);
 
     eprintln!(

--- a/crates/fastvep-core/src/chrom.rs
+++ b/crates/fastvep-core/src/chrom.rs
@@ -82,6 +82,92 @@ pub fn looks_like_refseq_accession(name: &str) -> bool {
         && version.bytes().all(|b| b.is_ascii_digit())
 }
 
+/// Canonical RefSeq molecule accessions for the primary chromosomes of a human
+/// reference assembly, as `(accession, canonical_chr_name)` pairs.
+///
+/// NCBI resources — most notably the dbSNP VCF release (`GCF_000001405.*`) —
+/// name contigs by these accessions (`NC_000001.11`) instead of `1`/`chr1`.
+/// Unlike chr↔bare, the accession has no algorithmic relationship to the
+/// chromosome number, so the mapping is an explicit table. The first 24 entries
+/// are the autosomes + X/Y; the last is the mitochondrion (rCRS, shared by both
+/// assemblies). Returns `None` for an assembly we don't have a table for.
+///
+/// Accepts the common spellings of each assembly (`GRCh38`, `hg38`, `38`,
+/// `b38`, case-insensitively) and tolerates a patch-level suffix
+/// (`GRCh38.p14`), so new NCBI patches keep resolving without a code change.
+pub fn refseq_primary_accessions(assembly: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    let mut a = assembly.trim().to_ascii_lowercase();
+    // Drop a patch-level suffix (`grch38.p14`, `grch38.p15`, …). The primary
+    // chromosome accessions are stable across patches of a given major build,
+    // so matching on the base name avoids enumerating every patch release.
+    if let Some(idx) = a.find(".p") {
+        a.truncate(idx);
+    }
+    match a.as_str() {
+        "grch38" | "hg38" | "38" | "b38" => Some(GRCH38_REFSEQ),
+        "grch37" | "hg19" | "37" | "b37" => Some(GRCH37_REFSEQ),
+        _ => None,
+    }
+}
+
+/// GRCh38 primary-assembly RefSeq accessions (`GCF_000001405.26`–`.40`).
+const GRCH38_REFSEQ: &[(&str, &str)] = &[
+    ("NC_000001.11", "chr1"),
+    ("NC_000002.12", "chr2"),
+    ("NC_000003.12", "chr3"),
+    ("NC_000004.12", "chr4"),
+    ("NC_000005.10", "chr5"),
+    ("NC_000006.12", "chr6"),
+    ("NC_000007.14", "chr7"),
+    ("NC_000008.11", "chr8"),
+    ("NC_000009.12", "chr9"),
+    ("NC_000010.11", "chr10"),
+    ("NC_000011.10", "chr11"),
+    ("NC_000012.12", "chr12"),
+    ("NC_000013.11", "chr13"),
+    ("NC_000014.9", "chr14"),
+    ("NC_000015.10", "chr15"),
+    ("NC_000016.10", "chr16"),
+    ("NC_000017.11", "chr17"),
+    ("NC_000018.10", "chr18"),
+    ("NC_000019.10", "chr19"),
+    ("NC_000020.11", "chr20"),
+    ("NC_000021.9", "chr21"),
+    ("NC_000022.11", "chr22"),
+    ("NC_000023.11", "chrX"),
+    ("NC_000024.10", "chrY"),
+    ("NC_012920.1", "chrM"),
+];
+
+/// GRCh37 primary-assembly RefSeq accessions (`GCF_000001405.13`–`.25`).
+const GRCH37_REFSEQ: &[(&str, &str)] = &[
+    ("NC_000001.10", "chr1"),
+    ("NC_000002.11", "chr2"),
+    ("NC_000003.11", "chr3"),
+    ("NC_000004.11", "chr4"),
+    ("NC_000005.9", "chr5"),
+    ("NC_000006.11", "chr6"),
+    ("NC_000007.13", "chr7"),
+    ("NC_000008.10", "chr8"),
+    ("NC_000009.11", "chr9"),
+    ("NC_000010.10", "chr10"),
+    ("NC_000011.9", "chr11"),
+    ("NC_000012.11", "chr12"),
+    ("NC_000013.10", "chr13"),
+    ("NC_000014.8", "chr14"),
+    ("NC_000015.9", "chr15"),
+    ("NC_000016.9", "chr16"),
+    ("NC_000017.10", "chr17"),
+    ("NC_000018.9", "chr18"),
+    ("NC_000019.9", "chr19"),
+    ("NC_000020.10", "chr20"),
+    ("NC_000021.8", "chr21"),
+    ("NC_000022.10", "chr22"),
+    ("NC_000023.10", "chrX"),
+    ("NC_000024.9", "chrY"),
+    ("NC_012920.1", "chrM"),
+];
+
 /// Bidirectional chromosome synonym table, loaded from a VEP-style
 /// `chr_synonyms.txt`.
 ///
@@ -253,6 +339,33 @@ mod synonym_tests {
     fn single_token_lines_ignored() {
         let syn = ChromSynonyms::parse("17\n\nchr17\n");
         assert!(syn.is_empty());
+    }
+
+    #[test]
+    fn refseq_primary_accessions_cover_both_assemblies() {
+        use super::refseq_primary_accessions;
+
+        for spelling in ["GRCh38", "grch38", "hg38", "38", "b38", "GRCh38.p14", "GRCh38.p15"] {
+            let table = refseq_primary_accessions(spelling).expect("GRCh38 table");
+            assert_eq!(table.len(), 25, "24 chromosomes + MT");
+            assert!(table.contains(&("NC_000001.11", "chr1")));
+            assert!(table.contains(&("NC_000023.11", "chrX")));
+            assert!(table.contains(&("NC_000024.10", "chrY")));
+            assert!(table.contains(&("NC_012920.1", "chrM")));
+        }
+
+        for spelling in ["GRCh37", "hg19", "37", "b37"] {
+            let table = refseq_primary_accessions(spelling).expect("GRCh37 table");
+            assert_eq!(table.len(), 25);
+            // GRCh37 carries the older accession versions.
+            assert!(table.contains(&("NC_000001.10", "chr1")));
+            assert!(table.contains(&("NC_000023.10", "chrX")));
+            // rCRS mitochondrion is shared across both builds.
+            assert!(table.contains(&("NC_012920.1", "chrM")));
+        }
+
+        assert!(refseq_primary_accessions("GRCm39").is_none());
+        assert!(refseq_primary_accessions("").is_none());
     }
 
     #[test]

--- a/crates/fastvep-core/src/lib.rs
+++ b/crates/fastvep-core/src/lib.rs
@@ -4,6 +4,8 @@ mod consequence;
 mod position;
 
 pub use annotation_types::{GeneAnnotation, SupplementaryAnnotation};
-pub use chrom::{chrom_aliases, looks_like_refseq_accession, ChromSynonyms};
+pub use chrom::{
+    chrom_aliases, looks_like_refseq_accession, refseq_primary_accessions, ChromSynonyms,
+};
 pub use consequence::{Consequence, Impact};
 pub use position::{Allele, GenomicPosition, Strand, VariantType};

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -99,7 +99,11 @@ fn parse_info(info: &str) -> HashMap<String, String> {
 }
 
 fn normalize_chrom(chrom: &str) -> String {
-    if chrom.starts_with("chr") {
+    // NCBI's dbSNP VCF names contigs by RefSeq accession (`NC_000001.11`).
+    // Leave those untouched so the lookup hits the accession keys the builder
+    // seeds into the chromosome map; mangling them to `chrNC_000001.11` is what
+    // produced "0 records parsed" (issue #51).
+    if chrom.starts_with("chr") || fastvep_core::looks_like_refseq_accession(chrom) {
         chrom.to_string()
     } else {
         format!("chr{}", chrom)
@@ -132,5 +136,28 @@ mod tests {
         assert_eq!(records[1].position, 10039);
         assert!(records[1].json.contains("rs978760828"));
         assert!(!records[1].json.contains("globalMaf")); // No CAF
+    }
+
+    #[test]
+    fn test_parse_dbsnp_refseq_accessions() {
+        // The real NCBI dbSNP release (GCF_000001405.40) names contigs by
+        // RefSeq accession, not `1`/`chr1`. Regression for issue #51: these
+        // must resolve when the chromosome map carries the accession key.
+        let vcf = "\
+##fileformat=VCFv4.0
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+NC_000001.11\t10019\trs775809821\tTA\tT\t.\t.\tRS=775809821;CAF=0.9998,0.0002
+NC_000023.11\t100\trs1\tA\tG\t.\t.\tRS=1
+";
+        let mut chrom_map = HashMap::new();
+        chrom_map.insert("NC_000001.11".to_string(), 0u16);
+        chrom_map.insert("NC_000023.11".to_string(), 22u16);
+
+        let records = parse_dbsnp_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        assert_eq!(records.len(), 2, "RefSeq-accession contigs were skipped");
+        assert_eq!(records[0].chrom_idx, 0);
+        assert!(records[0].json.contains("rs775809821"));
+        assert_eq!(records[1].chrom_idx, 22);
+        assert!(records[1].json.contains("rs1"));
     }
 }


### PR DESCRIPTION
## Problem

Fixes #51. Building a dbSNP `.osa` from NCBI's release produced **0 records** and an empty database:

```
$ fastvep sa-build --source dbsnp -i GCF_000001405.40.gz -o sa_databases/dbsnp --assembly GRCh38
Parsed 0 records from dbsnp
```

## Root cause

NCBI's dbSNP VCF (`GCF_000001405.*`) names chromosomes by **RefSeq molecule accession** (`NC_000001.11`, `NC_000002.12`, … `NC_012920.1`), not `1`/`chr1`.

- `standard_chrom_map()` only knew the `chr*`/bare/`MT` forms — no accessions.
- `dbsnp::normalize_chrom()` prepended `chr` to anything not already `chr`-prefixed, turning `NC_000001.11` into `chrNC_000001.11`.

So every record missed the chromosome map and was skipped. The codebase deliberately keeps RefSeq mapping out of mechanical alias rules (it's non-algorithmic) and previously only resolved accessions via a `--synonyms` file — which `cache` supports but `sa-build` does not. There was no way for this command to work.

## Fix

- **`fastvep_core::refseq_primary_accessions(assembly)`** — an authoritative GRCh38/GRCh37 accession→chromosome table (24 chromosomes + the shared rCRS mitochondrion). Tolerates patch-level suffixes (`GRCh38.p14`) so new NCBI patches keep resolving without a code change.
- **`standard_chrom_map`** now takes the assembly and seeds those accession keys, each mapped to the canonical chromosome index — so the resulting `.osa` is still keyed canonically and annotates ordinary `chr1`/`1` VCFs.
- **`dbsnp::normalize_chrom`** leaves RefSeq accessions untouched.
- A **zero-records warning** now points at the assembly/accession mismatch instead of silently writing an empty database.

## Testing

- New unit tests: `refseq_primary_accessions_cover_both_assemblies`, `test_parse_dbsnp_refseq_accessions`.
- Full workspace suite green; clippy clean on changed lines.
- **Real-file verification** against a slice of the actual NCBI release (`GCF_000001405.40.gz`): **1,599,339 records parsed** (was 0); `--assembly GRCh38` and `--assembly GRCh38.p14` both work; a `chr1`/`1`-named query VCF resolves rsIDs end-to-end via `--sa-only` annotation.

## Notes / follow-up

- dbSNP is the only built-in source NCBI distributes with RefSeq accessions (ClinVar/gnomAD/COSMIC/1000G/TOPMed ship bare or `chr` names), so only the dbSNP parser needed the accession-aware path.
- Modern dbSNP (b154+) encodes allele frequencies as `FREQ=` rather than the `CAF=` this parser reads, so `globalMaf` is left empty for those builds — a pre-existing limitation, separate from this issue. Happy to add `FREQ=` parsing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)