### PR TITLE
Fix multi-allelic variant type misclassification + improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
       - name: Check libraries and binaries
         run: cargo check --workspace --lib --bins
+
       - name: Run library tests
         run: cargo test --workspace --lib
+
+      - name: Run integration tests
+        run: cargo test --workspace --tests

--- a/crates/fastvep-io/src/vcf.rs
+++ b/crates/fastvep-io/src/vcf.rs
@@ -304,27 +304,45 @@ fn classify_sv_type(svtype: Option<&str>, alts: &[String]) -> VariantType {
 }
 
 /// Classify small variant type from alleles.
+/// For multi-allelic sites, returns the most complex type across all ALT alleles.
 fn classify_small_variant(ref_allele: &Allele, alt_alleles: &[Allele]) -> VariantType {
     if alt_alleles.is_empty() {
         return VariantType::Unknown;
     }
-    let first_alt = &alt_alleles[0];
 
-    match (ref_allele, first_alt) {
-        (Allele::Deletion, Allele::Sequence(_)) => VariantType::Insertion,
-        (Allele::Sequence(_), Allele::Deletion) => VariantType::Deletion,
-        (Allele::Sequence(r), Allele::Sequence(a)) => {
-            if r.len() == 1 && a.len() == 1 {
-                VariantType::Snv
-            } else if r.len() == a.len() {
-                VariantType::Mnv
-            } else {
-                VariantType::Indel
-            }
+    fn type_rank(vt: VariantType) -> u8 {
+        match vt {
+            VariantType::Unknown => 0,
+            VariantType::Snv => 1,
+            VariantType::Mnv => 2,
+            VariantType::Deletion | VariantType::Insertion => 3,
+            VariantType::Indel => 4,
+            _ => 0,
         }
-        (_, Allele::Symbolic(_)) => VariantType::Unknown, // Handled by classify_sv_type
-        _ => VariantType::Unknown,
     }
+
+    let mut best = VariantType::Unknown;
+    for alt in alt_alleles {
+        let vt = match (ref_allele, alt) {
+            (Allele::Deletion, Allele::Sequence(_)) => VariantType::Insertion,
+            (Allele::Sequence(_), Allele::Deletion) => VariantType::Deletion,
+            (Allele::Sequence(r), Allele::Sequence(a)) => {
+                if r.len() == 1 && a.len() == 1 {
+                    VariantType::Snv
+                } else if r.len() == a.len() {
+                    VariantType::Mnv
+                } else {
+                    VariantType::Indel
+                }
+            }
+            (_, Allele::Symbolic(_)) => VariantType::Unknown, // Handled by classify_sv_type
+            _ => VariantType::Unknown,
+        };
+        if type_rank(vt) > type_rank(best) {
+            best = vt;
+        }
+    }
+    best
 }
 
 #[cfg(test)]
@@ -486,5 +504,15 @@ mod tests {
         let line = "chr1\t100\t.\tA\tACG\t.\tPASS\t.";
         let vf = parse_vcf_line(line).unwrap();
         assert_eq!(vf.variant_type, VariantType::Insertion);
+
+        // Mixed multi-allelic: SNV + insertion → must be classified as Indel (most complex)
+        let line = "chr1\t100\t.\tA\tG,ACG\t.\tPASS\t.";
+        let vf = parse_vcf_line(line).unwrap();
+        assert_eq!(vf.variant_type, VariantType::Indel);
+
+        // Multi-allelic SNVs → Snv
+        let line = "chr1\t100\t.\tA\tG,T\t.\tPASS\t.";
+        let vf = parse_vcf_line(line).unwrap();
+        assert_eq!(vf.variant_type, VariantType::Snv);
     }
 }


### PR DESCRIPTION
## Summary

### CODE QUALITY — Bug Fixed

**`classify_small_variant()` only checked the first ALT allele**

For a multi-allelic site like `ref=A, alt=G,ACG`, the function keyed on `alt_alleles[0]` (`G`, a SNV) and returned `VariantType::Snv` — the insertion in the second alt was silently ignored. This causes incorrect routing in the downstream consequence prediction pipeline: the record goes through the SNV path even though it contains an insertion allele.

**Fix:** iterate all ALT alleles and return the most complex type present, using the priority ranking `Indel > Insertion/Deletion > Mnv > Snv > Unknown`.

```rust
// Before (checked only first alt):
let first_alt = &alt_alleles[0];
match (ref_allele, first_alt) { ... }

// After (checks all alts, returns most complex):
for alt in alt_alleles {
    let vt = classify_one(ref_allele, alt);
    if type_rank(vt) > type_rank(best) { best = vt; }
}
```

**Tests added:**
- `ref=A, alt=G,ACG` (SNV + insertion) → `VariantType::Indel` ✓
- `ref=A, alt=G,T` (two SNVs) → `VariantType::Snv` ✓

### PRODUCT — CI Improvements

Enhanced `.github/workflows/ci.yml`:
- Added `dtolnay/rust-toolchain@stable` for reproducible builds (previously relied on pre-installed Rust with no pinned version)
- Added `actions/cache@v4` for Cargo registry and build cache
- Added `cargo test --workspace --tests` step for integration tests (previously only ran lib tests)

## Test plan

- [x] `cargo test --workspace --lib` — 110 tests pass
- [x] `cargo check --workspace --lib --bins` — clean
- [x] New regression tests for mixed multi-allelic classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011t7osUVngbRM4Gc43vAKd1

---
_Generated by [Claude Code](https://claude.ai/code/session_011t7osUVngbRM4Gc43vAKd1)_