### PR TITLE
sa-build: streaming iterators for dbSNP/TOPMed, progress meter w/ETA gnomAD field detection, dump_sa example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,11 @@ data/
 *.tbi
 *.csi
 
-# Spurious reference files from test runs
+# Supplementary-annotation databases emitted by `sa-build` during test runs
 *.osa
-*.idx
+*.osa.idx
+*.oga
+*.osi
 
 # log files from test runs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@ data/
 # tabix index files cached during remote queries (placed in CWD by htslib)
 *.tbi
 *.csi
+
+# Spurious reference files from test runs
+*.osa
+*.idx
+
+# log files from test runs
+*.log
+*.out

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1276,6 +1277,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1"
 thiserror = "2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "wrap_help"] }
 rayon = "1.10"
 crossbeam = "0.8"
 flate2 = "1"

--- a/crates/fastvep-cli/src/lib.rs
+++ b/crates/fastvep-cli/src/lib.rs
@@ -4,4 +4,5 @@
 //! integration tests in `tests/`. The binary entry point is `src/main.rs`.
 
 pub mod pipeline;
+pub mod progress;
 pub mod webserver;

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -128,6 +128,10 @@ enum Commands {
         /// no per-sample parsing).
         #[arg(long)]
         qc_rules: Option<String>,
+
+        /// Suppress periodic progress output
+        #[arg(long, default_value_t = false)]
+        no_progress: bool,
     },
 
     /// Launch the web interface for interactive variant annotation
@@ -167,6 +171,10 @@ enum Commands {
         /// Output cache file path
         #[arg(short, long)]
         output: String,
+
+        /// Suppress periodic progress output
+        #[arg(long, default_value_t = false)]
+        no_progress: bool,
     },
 
     /// Build a supplementary annotation database (.osa or .osi) from a source file
@@ -205,6 +213,10 @@ enum Commands {
         /// vary by which INFO keys it carries.
         #[arg(long, value_delimiter = ',')]
         info_fields: Vec<String>,
+
+        /// Suppress periodic progress output
+        #[arg(long, default_value_t = false)]
+        no_progress: bool,
     },
 
     /// Filter annotated VEP output
@@ -253,6 +265,7 @@ fn main() -> Result<()> {
             gene_list,
             explicit_alleles,
             qc_rules,
+            no_progress,
         } => {
             pipeline::run_annotate(pipeline::AnnotateConfig {
                 input,
@@ -275,10 +288,11 @@ fn main() -> Result<()> {
                 gene_list,
                 explicit_alleles,
                 qc_rules,
+                show_progress: !no_progress,
             })?;
         }
-        Commands::Cache { gff3, fasta, synonyms, output } => {
-            pipeline::run_cache_build(&gff3, fasta.as_deref(), synonyms.as_deref(), &output)?;
+        Commands::Cache { gff3, fasta, synonyms, output, no_progress } => {
+            pipeline::run_cache_build(&gff3, fasta.as_deref(), synonyms.as_deref(), &output, !no_progress)?;
         }
         Commands::Web { port, gff3, fasta } => {
             webserver::run_server(port, gff3, fasta)?;
@@ -290,6 +304,7 @@ fn main() -> Result<()> {
             assembly,
             name,
             info_fields,
+            no_progress,
         } => {
             pipeline::run_sa_build(
                 &source,
@@ -298,6 +313,7 @@ fn main() -> Result<()> {
                 &assembly,
                 name.as_deref(),
                 &info_fields,
+                !no_progress,
             )?;
         }
         Commands::Filter {

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -17,7 +17,7 @@ use fastvep_io::vcf::VcfParser;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, BufRead, BufWriter, Read, Write};
+use std::io::{self, BufRead, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -2179,6 +2179,36 @@ fn standard_chrom_map(assembly: &str) -> (Vec<String>, std::collections::HashMap
     (chroms, map)
 }
 
+/// Open an `sa-build` input file and transparently decompress gzip/bgzip.
+///
+/// Detection is by the gzip magic bytes (`0x1f 0x8b`) first, falling back to the
+/// `.gz`/`.bgz` extension — mirroring `wrap_maybe_gzip_reader` on the annotate
+/// path so a bgzipped source with a non-standard name (e.g. `gnomad.sites.vcf`)
+/// still decodes instead of silently parsing to zero records. The file is
+/// seekable, so we sniff and rewind rather than chaining the peeked bytes.
+///
+/// When `byte_counter` is supplied the raw (still-compressed) file is wrapped in
+/// a `CountingReader` *before* decompression, so progress reflects compressed
+/// bytes consumed against the on-disk file size.
+fn open_sa_input(input: &str, byte_counter: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>) -> Result<Box<dyn io::Read>> {
+    let mut file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
+    let mut magic = [0u8; 2];
+    let n = file.read(&mut magic)?;
+    file.seek(SeekFrom::Start(0))?;
+    let is_gzip =
+        (n == 2 && magic == [0x1f, 0x8b]) || input.ends_with(".gz") || input.ends_with(".bgz");
+
+    let raw: Box<dyn io::Read> = match byte_counter {
+        Some(bytes) => Box::new(crate::progress::CountingReader { inner: file, bytes }),
+        None => Box::new(file),
+    };
+    if is_gzip {
+        Ok(Box::new(MultiGzDecoder::new(raw)))
+    } else {
+        Ok(raw)
+    }
+}
+
 /// Stream a coordinate-sorted source VCF straight into the .osa writer without
 /// buffering every record in memory (issue #55: gnomAD/TOPMed/dbSNP releases
 /// carry 100M+ records). The input is wrapped in a `CountingReader` so the
@@ -2212,16 +2242,7 @@ where
 
     let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
     let byte_counter = Arc::new(AtomicU64::new(0));
-    let file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
-    let counting = crate::progress::CountingReader {
-        inner: file,
-        bytes: Arc::clone(&byte_counter),
-    };
-    let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-        Box::new(flate2::read::MultiGzDecoder::new(counting))
-    } else {
-        Box::new(counting)
-    };
+    let reader = open_sa_input(input, Some(Arc::clone(&byte_counter)))?;
     let buf_reader = io::BufReader::new(reader);
 
     let mut meter = if show_progress && file_size > 0 {
@@ -2499,14 +2520,7 @@ pub fn run_sa_build(
         _ => {}
     }
 
-    let file = File::open(input)
-        .with_context(|| format!("Opening input file: {}", input))?;
-    let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-        Box::new(flate2::read::MultiGzDecoder::new(file))
-    } else {
-        Box::new(file)
-    };
-    let buf_reader = io::BufReader::new(reader);
+    let buf_reader = io::BufReader::new(open_sa_input(input, None)?);
 
     eprintln!(
         "INFO  ProgressMeter - Parsing '{}': {} -> {}",

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -87,9 +87,12 @@ pub struct AnnotateConfig {
     /// Path to a QC rules TOML file. When set, tab output gains a
     /// `QC_CLASS` column.
     pub qc_rules: Option<String>,
+    /// Show periodic progress output.
+    pub show_progress: bool,
 }
 
 pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
+    eprintln!("Annotating: {} -> {}", config.input, config.output);
     let sa_only = config.sa_only;
     if sa_only {
         if config.sa_dir.is_none() {
@@ -541,7 +544,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
     }
 
     // Process variants in batches for parallel annotation
-    let mut count = 0u64;
+    let mut meter = crate::progress::ProgressMeter::new(config.show_progress);
     let mut first_json = true;
 
     loop {
@@ -1373,7 +1376,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
             }
         }
 
-        count += batch.len() as u64;
+        meter.update_n(batch.len() as u64);
     } // end batch loop
 
     // Close JSON array
@@ -1382,7 +1385,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
     }
 
     writer.flush()?;
-    eprintln!("Annotated {} variants", count);
+    meter.finish();
 
     Ok(())
 }
@@ -1904,6 +1907,7 @@ pub fn run_cache_build(
     fasta_path: Option<&str>,
     synonyms_path: Option<&str>,
     output_path: &str,
+    show_progress: bool,
 ) -> Result<()> {
     if gff3_paths.is_empty() {
         return Err(anyhow::anyhow!("`fastvep cache` requires at least one --gff3"));
@@ -2007,7 +2011,7 @@ pub fn run_cache_build(
         }
 
         let sp = FastaSequenceProvider::new(reader);
-        let mut built = 0usize;
+        let mut meter = crate::progress::ProgressMeter::new(show_progress);
         for tr in &mut transcripts {
             if tr.is_coding() {
                 if let Err(e) = tr.build_sequences(|chrom, start, end| {
@@ -2016,11 +2020,11 @@ pub fn run_cache_build(
                 }) {
                     eprintln!("Warning: could not build sequences for {}: {}", tr.stable_id, e);
                 } else {
-                    built += 1;
+                    meter.update();
                 }
             }
         }
-        eprintln!("Built sequences for {} coding transcripts", built);
+        meter.finish();
     } else if synonyms_path.is_some() {
         eprintln!(
             "Warning: --synonyms has no effect without --fasta; chromosome names are kept as-is from the GFF3."
@@ -2204,6 +2208,7 @@ pub fn run_sa_build(
     assembly: &str,
     name: Option<&str>,
     info_fields: &[String],
+    show_progress: bool,
 ) -> Result<()> {
     use fastvep_sa::index::IndexHeader;
     use fastvep_sa::writer::SaWriter;
@@ -2381,7 +2386,155 @@ pub fn run_sa_build(
         ),
     };
 
-    eprintln!("Building {} .osa from: {}", source, input);
+    eprintln!("Building {} .osa: {} -> {}", source, input, Path::new(output).with_extension("osa").display());
+
+    if source == "spliceai" {
+        let output_path = Path::new(output);
+        let mut writer = SaWriter::new(header);
+        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
+        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let file = File::open(input)
+            .with_context(|| format!("Opening input file: {}", input))?;
+        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
+        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
+            Box::new(flate2::read::MultiGzDecoder::new(counting))
+        } else {
+            Box::new(counting)
+        };
+        let buf_reader = io::BufReader::new(reader);
+        let mut meter = if show_progress && file_size > 0 {
+            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
+        } else {
+            crate::progress::ProgressMeter::new(show_progress)
+        };
+        let records = fastvep_sa::sources::spliceai::iter_spliceai_vcf(buf_reader, &chrom_map)
+            .map(|record| {
+                if record.is_ok() {
+                    meter.update();
+                }
+                record
+            });
+        writer.write_results_to_files(output_path, records, &chrom_list)?;
+        meter.finish();
+        eprintln!(
+            "Wrote: {} and {}",
+            output_path.with_extension("osa").display(),
+            output_path.with_extension("osa.idx").display()
+        );
+
+        return Ok(());
+    }
+
+    if source == "gnomad" {
+        let output_path = Path::new(output);
+        let mut writer = SaWriter::new(header);
+        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
+        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let file = File::open(input)
+            .with_context(|| format!("Opening input file: {}", input))?;
+        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
+        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
+            Box::new(flate2::read::MultiGzDecoder::new(counting))
+        } else {
+            Box::new(counting)
+        };
+        let buf_reader = io::BufReader::new(reader);
+        let mut meter = if show_progress && file_size > 0 {
+            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
+        } else {
+            crate::progress::ProgressMeter::new(show_progress)
+        };
+        let records = fastvep_sa::sources::gnomad::iter_gnomad_vcf(buf_reader, &chrom_map)
+            .map(|record| {
+                if record.is_ok() {
+                    meter.update();
+                }
+                record
+            });
+        writer.write_results_to_files(output_path, records, &chrom_list)?;
+        meter.finish();
+        eprintln!(
+            "Wrote: {} and {}",
+            output_path.with_extension("osa").display(),
+            output_path.with_extension("osa.idx").display()
+        );
+
+        return Ok(());
+    }
+
+    if source == "dbsnp" {
+        let output_path = Path::new(output);
+        let mut writer = SaWriter::new(header);
+        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
+        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let file = File::open(input)
+            .with_context(|| format!("Opening input file: {}", input))?;
+        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
+        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
+            Box::new(flate2::read::MultiGzDecoder::new(counting))
+        } else {
+            Box::new(counting)
+        };
+        let buf_reader = io::BufReader::new(reader);
+        let mut meter = if show_progress && file_size > 0 {
+            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
+        } else {
+            crate::progress::ProgressMeter::new(show_progress)
+        };
+        let records = fastvep_sa::sources::dbsnp::iter_dbsnp_vcf(buf_reader, &chrom_map)
+            .map(|record| {
+                if record.is_ok() {
+                    meter.update();
+                }
+                record
+            });
+        writer.write_results_to_files(output_path, records, &chrom_list)?;
+        meter.finish();
+        eprintln!(
+            "Wrote: {} and {}",
+            output_path.with_extension("osa").display(),
+            output_path.with_extension("osa.idx").display()
+        );
+
+        return Ok(());
+    }
+
+    if source == "topmed" {
+        let output_path = Path::new(output);
+        let mut writer = SaWriter::new(header);
+        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
+        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let file = File::open(input)
+            .with_context(|| format!("Opening input file: {}", input))?;
+        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
+        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
+            Box::new(flate2::read::MultiGzDecoder::new(counting))
+        } else {
+            Box::new(counting)
+        };
+        let buf_reader = io::BufReader::new(reader);
+        let mut meter = if show_progress && file_size > 0 {
+            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
+        } else {
+            crate::progress::ProgressMeter::new(show_progress)
+        };
+        let records = fastvep_sa::sources::topmed::iter_topmed_vcf(buf_reader, &chrom_map)
+            .map(|record| {
+                if record.is_ok() {
+                    meter.update();
+                }
+                record
+            });
+        writer.write_results_to_files(output_path, records, &chrom_list)?;
+        meter.finish();
+        eprintln!(
+            "Wrote: {} and {}",
+            output_path.with_extension("osa").display(),
+            output_path.with_extension("osa.idx").display()
+        );
+
+        return Ok(());
+    }
 
     let file = File::open(input)
         .with_context(|| format!("Opening input file: {}", input))?;
@@ -2392,36 +2545,17 @@ pub fn run_sa_build(
     };
     let buf_reader = io::BufReader::new(reader);
 
-    if source == "spliceai" {
-        let output_path = Path::new(output);
-        let mut writer = SaWriter::new(header);
-        let mut record_count = 0usize;
-        let records = fastvep_sa::sources::spliceai::iter_spliceai_vcf(buf_reader, &chrom_map)
-            .map(|record| {
-                if record.is_ok() {
-                    record_count += 1;
-                }
-                record
-            });
-        writer.write_results_to_files(output_path, records, &chrom_list)?;
-
-        eprintln!("Parsed {} records from {}", record_count, source);
-        eprintln!(
-            "Wrote: {} and {}",
-            output_path.with_extension("osa").display(),
-            output_path.with_extension("osa.idx").display()
-        );
-
-        return Ok(());
-    }
+    eprintln!(
+        "INFO  ProgressMeter - Parsing '{}': {} -> {}",
+        source, input,
+        Path::new(output).with_extension("osa").display()
+    );
+    let t_parse = std::time::Instant::now();
 
     let records = match source {
         "clinvar" => fastvep_sa::sources::clinvar::parse_clinvar_vcf(buf_reader, &chrom_map)?,
-        "gnomad" => fastvep_sa::sources::gnomad::parse_gnomad_vcf(buf_reader, &chrom_map)?,
-        "dbsnp" => fastvep_sa::sources::dbsnp::parse_dbsnp_vcf(buf_reader, &chrom_map)?,
         "cosmic" => fastvep_sa::sources::cosmic::parse_cosmic_vcf(buf_reader, &chrom_map)?,
         "onekg" | "1000g" => fastvep_sa::sources::onekg::parse_onekg_vcf(buf_reader, &chrom_map)?,
-        "topmed" => fastvep_sa::sources::topmed::parse_topmed_vcf(buf_reader, &chrom_map)?,
         "mitomap" => fastvep_sa::sources::mitomap::parse_mitomap(buf_reader, &chrom_map)?,
         // PhyloP supports two on-disk formats: UCSC fixed-step wig and
         // simple TSV (`chrom\tpos\tscore`). Auto-detect by peeking the
@@ -2434,7 +2568,7 @@ pub fn run_sa_build(
         _ => unreachable!(),
     };
 
-    eprintln!("Parsed {} records from {}", records.len(), source);
+    let n = records.len() as u64;
     if records.is_empty() {
         eprintln!(
             "Warning: 0 records parsed from {} — if the input is non-empty, this \
@@ -2445,11 +2579,22 @@ pub fn run_sa_build(
             source, assembly
         );
     }
+    eprintln!(
+        "INFO  ProgressMeter - Parsed {} records in {:.1} min. Writing ...",
+        crate::progress::fmt_count(n),
+        t_parse.elapsed().as_secs_f64() / 60.0
+    );
 
     let output_path = Path::new(output);
+    let t_write = std::time::Instant::now();
     let mut writer = SaWriter::new(header);
     writer.write_to_files(output_path, records.into_iter(), &chrom_list)?;
 
+    eprintln!(
+        "INFO  ProgressMeter - Done. Wrote {} records in {:.1} min.",
+        crate::progress::fmt_count(n),
+        t_write.elapsed().as_secs_f64() / 60.0
+    );
     eprintln!(
         "Wrote: {} and {}",
         output_path.with_extension("osa").display(),
@@ -3038,6 +3183,7 @@ mod custom_source_tests {
             "GRCh38",
             Some("mydb"),
             &["MY_SCORE".to_string()],
+            false,
         )
         .unwrap();
 
@@ -3081,6 +3227,7 @@ mod custom_source_tests {
             "GRCh38",
             Some("myregions"),
             &[],
+            false,
         )
         .unwrap();
 
@@ -3192,6 +3339,7 @@ mod custom_source_tests {
             "GRCh38",
             None,
             &[],
+            false,
         )
         .expect_err("must error on unknown source");
         let msg = format!("{}", err);

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -2179,6 +2179,86 @@ fn standard_chrom_map(assembly: &str) -> (Vec<String>, std::collections::HashMap
     (chroms, map)
 }
 
+/// Stream a coordinate-sorted source VCF straight into the .osa writer without
+/// buffering every record in memory (issue #55: gnomAD/TOPMed/dbSNP releases
+/// carry 100M+ records). The input is wrapped in a `CountingReader` so the
+/// `ProgressMeter` can report byte-based % done + ETA for gz/bgz inputs whose
+/// compressed size is known; plain or size-unknown inputs fall back to the
+/// records-only meter.
+///
+/// `make_iter` adapts the (already gz-decoded) reader into a source-specific
+/// streaming iterator; all callers must yield records in `(chrom_idx, position)`
+/// order because the writer streams blocks and rejects out-of-order input.
+fn run_streaming_sa_build<'a, I>(
+    input: &str,
+    output: &str,
+    header: fastvep_sa::index::IndexHeader,
+    chrom_map: &'a std::collections::HashMap<String, u16>,
+    chrom_list: &[String],
+    show_progress: bool,
+    make_iter: impl FnOnce(
+        io::BufReader<Box<dyn io::Read>>,
+        &'a std::collections::HashMap<String, u16>,
+    ) -> I,
+) -> Result<()>
+where
+    I: Iterator<Item = Result<fastvep_sa::common::AnnotationRecord>>,
+{
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    let output_path = Path::new(output);
+    let mut writer = fastvep_sa::writer::SaWriter::new(header);
+
+    let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
+    let byte_counter = Arc::new(AtomicU64::new(0));
+    let file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
+    let counting = crate::progress::CountingReader {
+        inner: file,
+        bytes: Arc::clone(&byte_counter),
+    };
+    let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
+        Box::new(flate2::read::MultiGzDecoder::new(counting))
+    } else {
+        Box::new(counting)
+    };
+    let buf_reader = io::BufReader::new(reader);
+
+    let mut meter = if show_progress && file_size > 0 {
+        crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
+    } else {
+        crate::progress::ProgressMeter::new(show_progress)
+    };
+
+    let records = make_iter(buf_reader, chrom_map).map(|record| {
+        if record.is_ok() {
+            meter.update();
+        }
+        record
+    });
+
+    // The streaming writer creates and fills the .osa incrementally, so a
+    // mid-stream failure (a parse error, or the writer's own out-of-order
+    // `bail!`) leaves a truncated .osa and never writes the .idx. The old
+    // buffer-then-write path parsed everything first and so left nothing behind
+    // on failure; preserve that contract by removing the partial artifacts
+    // rather than leaving a corrupt half-built database on disk.
+    if let Err(e) = writer.write_results_to_files(output_path, records, chrom_list) {
+        let _ = std::fs::remove_file(output_path.with_extension("osa"));
+        let _ = std::fs::remove_file(output_path.with_extension("osa.idx"));
+        return Err(e);
+    }
+
+    meter.finish();
+    eprintln!(
+        "Wrote: {} and {}",
+        output_path.with_extension("osa").display(),
+        output_path.with_extension("osa.idx").display()
+    );
+
+    Ok(())
+}
+
 /// PhyloP comes in two on-disk formats: UCSC fixed-step wig (`fixedStep
 /// chrom=...`) and a simple `chrom\tpos\tscore` TSV (which is what we
 /// emit when distilling PhyloP from gnomAD v4 INFO). Detect by peeking
@@ -2388,152 +2468,35 @@ pub fn run_sa_build(
 
     eprintln!("Building {} .osa: {} -> {}", source, input, Path::new(output).with_extension("osa").display());
 
-    if source == "spliceai" {
-        let output_path = Path::new(output);
-        let mut writer = SaWriter::new(header);
-        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
-        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let file = File::open(input)
-            .with_context(|| format!("Opening input file: {}", input))?;
-        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
-        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-            Box::new(flate2::read::MultiGzDecoder::new(counting))
-        } else {
-            Box::new(counting)
-        };
-        let buf_reader = io::BufReader::new(reader);
-        let mut meter = if show_progress && file_size > 0 {
-            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
-        } else {
-            crate::progress::ProgressMeter::new(show_progress)
-        };
-        let records = fastvep_sa::sources::spliceai::iter_spliceai_vcf(buf_reader, &chrom_map)
-            .map(|record| {
-                if record.is_ok() {
-                    meter.update();
-                }
-                record
-            });
-        writer.write_results_to_files(output_path, records, &chrom_list)?;
-        meter.finish();
-        eprintln!(
-            "Wrote: {} and {}",
-            output_path.with_extension("osa").display(),
-            output_path.with_extension("osa.idx").display()
-        );
-
-        return Ok(());
-    }
-
-    if source == "gnomad" {
-        let output_path = Path::new(output);
-        let mut writer = SaWriter::new(header);
-        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
-        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let file = File::open(input)
-            .with_context(|| format!("Opening input file: {}", input))?;
-        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
-        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-            Box::new(flate2::read::MultiGzDecoder::new(counting))
-        } else {
-            Box::new(counting)
-        };
-        let buf_reader = io::BufReader::new(reader);
-        let mut meter = if show_progress && file_size > 0 {
-            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
-        } else {
-            crate::progress::ProgressMeter::new(show_progress)
-        };
-        let records = fastvep_sa::sources::gnomad::iter_gnomad_vcf(buf_reader, &chrom_map)
-            .map(|record| {
-                if record.is_ok() {
-                    meter.update();
-                }
-                record
-            });
-        writer.write_results_to_files(output_path, records, &chrom_list)?;
-        meter.finish();
-        eprintln!(
-            "Wrote: {} and {}",
-            output_path.with_extension("osa").display(),
-            output_path.with_extension("osa.idx").display()
-        );
-
-        return Ok(());
-    }
-
-    if source == "dbsnp" {
-        let output_path = Path::new(output);
-        let mut writer = SaWriter::new(header);
-        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
-        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let file = File::open(input)
-            .with_context(|| format!("Opening input file: {}", input))?;
-        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
-        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-            Box::new(flate2::read::MultiGzDecoder::new(counting))
-        } else {
-            Box::new(counting)
-        };
-        let buf_reader = io::BufReader::new(reader);
-        let mut meter = if show_progress && file_size > 0 {
-            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
-        } else {
-            crate::progress::ProgressMeter::new(show_progress)
-        };
-        let records = fastvep_sa::sources::dbsnp::iter_dbsnp_vcf(buf_reader, &chrom_map)
-            .map(|record| {
-                if record.is_ok() {
-                    meter.update();
-                }
-                record
-            });
-        writer.write_results_to_files(output_path, records, &chrom_list)?;
-        meter.finish();
-        eprintln!(
-            "Wrote: {} and {}",
-            output_path.with_extension("osa").display(),
-            output_path.with_extension("osa.idx").display()
-        );
-
-        return Ok(());
-    }
-
-    if source == "topmed" {
-        let output_path = Path::new(output);
-        let mut writer = SaWriter::new(header);
-        let file_size = std::fs::metadata(input).map(|m| m.len()).unwrap_or(0);
-        let byte_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let file = File::open(input)
-            .with_context(|| format!("Opening input file: {}", input))?;
-        let counting = crate::progress::CountingReader { inner: file, bytes: std::sync::Arc::clone(&byte_counter) };
-        let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
-            Box::new(flate2::read::MultiGzDecoder::new(counting))
-        } else {
-            Box::new(counting)
-        };
-        let buf_reader = io::BufReader::new(reader);
-        let mut meter = if show_progress && file_size > 0 {
-            crate::progress::ProgressMeter::with_progress(true, file_size, byte_counter)
-        } else {
-            crate::progress::ProgressMeter::new(show_progress)
-        };
-        let records = fastvep_sa::sources::topmed::iter_topmed_vcf(buf_reader, &chrom_map)
-            .map(|record| {
-                if record.is_ok() {
-                    meter.update();
-                }
-                record
-            });
-        writer.write_results_to_files(output_path, records, &chrom_list)?;
-        meter.finish();
-        eprintln!(
-            "Wrote: {} and {}",
-            output_path.with_extension("osa").display(),
-            output_path.with_extension("osa.idx").display()
-        );
-
-        return Ok(());
+    // Large, coordinate-sorted population/score sources stream straight into
+    // the writer instead of buffering every record (issue #55). They share one
+    // helper that differs only in which per-source iterator adapts the reader.
+    match source {
+        "spliceai" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| fastvep_sa::sources::spliceai::iter_spliceai_vcf(r, m),
+            );
+        }
+        "gnomad" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| fastvep_sa::sources::gnomad::iter_gnomad_vcf(r, m),
+            );
+        }
+        "dbsnp" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| fastvep_sa::sources::dbsnp::iter_dbsnp_vcf(r, m),
+            );
+        }
+        "topmed" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| fastvep_sa::sources::topmed::iter_topmed_vcf(r, m),
+            );
+        }
+        _ => {}
     }
 
     let file = File::open(input)

--- a/crates/fastvep-cli/src/progress.rs
+++ b/crates/fastvep-cli/src/progress.rs
@@ -123,6 +123,12 @@ impl ProgressMeter {
         if !self.enabled {
             return;
         }
+        // The gz decoder can stop a few trailing compressed bytes short of EOF,
+        // so the final byte-based row would otherwise read e.g. 99.9% / ETA>0.
+        // Pin the counter to the full size so the closing line reads 100% / 0.
+        if let Some(ref counter) = self.bytes_read {
+            counter.store(self.total_bytes, Ordering::Relaxed);
+        }
         self.print_row();
         let elapsed_min = self.start.elapsed().as_secs_f64() / 60.0;
         eprintln!(

--- a/crates/fastvep-cli/src/progress.rs
+++ b/crates/fastvep-cli/src/progress.rs
@@ -1,0 +1,160 @@
+use std::io::{self, Read};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::Instant;
+
+const REPORT_INTERVAL_SECS: f64 = 10.0;
+
+/// Wraps any `Read` and counts bytes consumed, accessible via a shared `Arc<AtomicU64>`.
+pub struct CountingReader<R: Read> {
+    pub inner: R,
+    pub bytes: Arc<AtomicU64>,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+pub struct ProgressMeter {
+    enabled: bool,
+    start: Instant,
+    last_report: Instant,
+    pub records: u64,
+    header_printed: bool,
+    total_bytes: u64,
+    bytes_read: Option<Arc<AtomicU64>>,
+}
+
+impl ProgressMeter {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            start: Instant::now(),
+            last_report: Instant::now(),
+            records: 0,
+            header_printed: false,
+            total_bytes: 0,
+            bytes_read: None,
+        }
+    }
+
+    /// Like `new`, but also tracks byte-based progress for ETA output.
+    /// `total_bytes` is the compressed file size; `bytes_read` is a counter
+    /// updated by a `CountingReader` wrapping the underlying file.
+    pub fn with_progress(enabled: bool, total_bytes: u64, bytes_read: Arc<AtomicU64>) -> Self {
+        Self {
+            enabled,
+            start: Instant::now(),
+            last_report: Instant::now(),
+            records: 0,
+            header_printed: false,
+            total_bytes,
+            bytes_read: Some(bytes_read),
+        }
+    }
+
+    pub fn update(&mut self) {
+        self.update_n(1);
+    }
+
+    pub fn update_n(&mut self, n: u64) {
+        if !self.enabled {
+            return;
+        }
+        self.records += n;
+        if self.last_report.elapsed().as_secs_f64() >= REPORT_INTERVAL_SECS {
+            self.print_row();
+        }
+    }
+
+    fn has_eta(&self) -> bool {
+        self.total_bytes > 0 && self.bytes_read.is_some()
+    }
+
+    fn print_row(&mut self) {
+        if !self.header_printed {
+            if self.has_eta() {
+                eprintln!(
+                    "INFO  ProgressMeter -  {:>13}   {:>20}   {:>14}   {:>7}   {:>9}",
+                    "Elapsed (min)", "Records Processed", "Records/Min", "% Done", "ETA (min)"
+                );
+            } else {
+                eprintln!(
+                    "INFO  ProgressMeter -  {:>13}   {:>20}   {:>14}",
+                    "Elapsed (min)", "Records Processed", "Records/Min"
+                );
+            }
+            self.header_printed = true;
+        }
+
+        let elapsed_min = self.start.elapsed().as_secs_f64() / 60.0;
+        let rpm = if elapsed_min > 0.0 { self.records as f64 / elapsed_min } else { 0.0 };
+
+        if let Some(ref counter) = self.bytes_read {
+            let done_frac = counter.load(Ordering::Relaxed) as f64 / self.total_bytes as f64;
+            let pct = done_frac * 100.0;
+            let eta_min = if done_frac > 0.0 { elapsed_min * (1.0 / done_frac - 1.0) } else { 0.0 };
+            eprintln!(
+                "INFO  ProgressMeter -  {:>13.1}   {:>20}   {:>14.1}   {:>6.1}%   {:>9.1}",
+                elapsed_min,
+                fmt_count(self.records),
+                rpm,
+                pct,
+                eta_min,
+            );
+        } else {
+            eprintln!(
+                "INFO  ProgressMeter -  {:>13.1}   {:>20}   {:>14.1}",
+                elapsed_min,
+                fmt_count(self.records),
+                rpm
+            );
+        }
+        self.last_report = Instant::now();
+    }
+
+    pub fn finish(mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.print_row();
+        let elapsed_min = self.start.elapsed().as_secs_f64() / 60.0;
+        eprintln!(
+            "INFO  ProgressMeter - Done. Processed {} records in {:.1} min.",
+            fmt_count(self.records),
+            elapsed_min
+        );
+    }
+}
+
+pub fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_count_commas() {
+        assert_eq!(fmt_count(0), "0");
+        assert_eq!(fmt_count(999), "999");
+        assert_eq!(fmt_count(1_000), "1,000");
+        assert_eq!(fmt_count(1_234_567), "1,234,567");
+        assert_eq!(fmt_count(1_000_000_000), "1,000,000,000");
+    }
+}

--- a/crates/fastvep-cli/tests/cache_synonyms.rs
+++ b/crates/fastvep-cli/tests/cache_synonyms.rs
@@ -49,6 +49,7 @@ fn merged_cache_with_synonyms_canonicalizes_to_fasta_names() {
         Some(fa.to_str().unwrap()),
         Some(syn.to_str().unwrap()),
         out.to_str().unwrap(),
+        false,
     )
     .expect("merged cache build should succeed with a synonyms file");
 
@@ -85,6 +86,7 @@ fn refseq_unresolved_without_synonyms_but_build_still_succeeds() {
         Some(fa.to_str().unwrap()),
         None,
         out.to_str().unwrap(),
+        false,
     )
     .expect("build should not fail just because one contig is unresolved");
 

--- a/crates/fastvep-cli/tests/sa_build_oga.rs
+++ b/crates/fastvep-cli/tests/sa_build_oga.rs
@@ -4,6 +4,7 @@
 //! `run_sa_build` (the same entrypoint the CLI uses), and reads the resulting
 //! database back to confirm the round-trip.
 
+use fastvep_cache::annotation::AnnotationProvider;
 use fastvep_cli::pipeline::{run_annotate, run_sa_build, AnnotateConfig};
 use fastvep_sa::gene::GeneIndex;
 use std::fs::{self, File};
@@ -46,6 +47,7 @@ fn sa_build_omim_writes_oga_with_records() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -90,6 +92,7 @@ TP53\tENST00000269305\t0\t25.1\t0.00\t0.05\t0.9999\t5.67\t-0.34
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -129,6 +132,7 @@ BRCA1\tENST00000357654\t0\t50.2\t0.00\t0.03\t1.0000\t3.45\t0.12
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -163,6 +167,7 @@ fn sa_build_clinvar_protein_writes_oga_with_records() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -203,6 +208,7 @@ fn sa_build_unknown_source_errors_with_full_supported_list() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .expect_err("must error on unknown source");
     let msg = format!("{}", err);
@@ -233,6 +239,7 @@ fn annotate_vcf_emits_spliceai_from_fastsa() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -257,6 +264,7 @@ fn annotate_vcf_emits_spliceai_from_fastsa() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -321,6 +329,7 @@ chr1\t26011\t2.71
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
     run_sa_build(
@@ -330,6 +339,7 @@ chr1\t26011\t2.71
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -354,6 +364,7 @@ chr1\t26011\t2.71
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -407,6 +418,7 @@ fn annotate_vcf_replaces_existing_fastvep_info() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -431,6 +443,7 @@ fn annotate_vcf_replaces_existing_fastvep_info() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -469,6 +482,7 @@ fn annotate_vcf_emits_fastsa_projection_for_gnomad() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -493,6 +507,7 @@ fn annotate_vcf_emits_fastsa_projection_for_gnomad() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -534,6 +549,7 @@ fn annotate_tab_emits_fastsa_columns_for_clinvar_and_gnomad() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -558,6 +574,7 @@ fn annotate_tab_emits_fastsa_columns_for_clinvar_and_gnomad() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -639,6 +656,7 @@ fn write_clinvar_fixture(tmp: &std::path::Path) {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 }
@@ -675,6 +693,7 @@ fn sa_only_vcf_omits_csq_and_default_pipeline() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -735,6 +754,7 @@ fn sa_only_tab_emits_minimal_columns() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -798,6 +818,7 @@ fn sa_only_json_omits_transcript_consequences() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -888,6 +909,7 @@ fn sa_only_requires_sa_dir() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .expect_err("--sa-only without --sa-dir must error");
     assert!(
@@ -930,6 +952,7 @@ fn sa_only_multi_allelic_emits_per_alt_rows_with_independent_sa_columns() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -954,6 +977,7 @@ fn sa_only_multi_allelic_emits_per_alt_rows_with_independent_sa_columns() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1024,6 +1048,7 @@ fn sa_only_strips_preexisting_csq_from_input_info() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1093,6 +1118,7 @@ fn sa_only_strips_csq_when_in_middle_of_info_field() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1153,6 +1179,7 @@ fn intergenic_variant_with_sa_dir_in_default_mode_emits_fv_clinvar() {
         "GRCh38",
         None,
         &[],
+        false,
     )
     .unwrap();
 
@@ -1177,6 +1204,7 @@ fn intergenic_variant_with_sa_dir_in_default_mode_emits_fv_clinvar() {
         gene_list: None,
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1236,6 +1264,7 @@ fn annotate_tab_gene_list_filters_to_panel_genes() {
         gene_list: Some(panel.to_string_lossy().into_owned()),
         explicit_alleles: false,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1287,6 +1316,7 @@ fn annotate_tab_explicit_alleles_inserts_ref_column() {
         gene_list: None,
         explicit_alleles: true,
         qc_rules: None,
+        show_progress: false,
     })
     .unwrap();
 
@@ -1370,6 +1400,7 @@ min_dp = 8
         gene_list: None,
         explicit_alleles: false,
         qc_rules: Some(qc_rules_path.to_string_lossy().into_owned()),
+        show_progress: false,
     })
     .unwrap();
 
@@ -1406,3 +1437,4 @@ min_dp = 8
         row_30k
     );
 }
+

--- a/crates/fastvep-cli/tests/sa_build_streaming.rs
+++ b/crates/fastvep-cli/tests/sa_build_streaming.rs
@@ -1,0 +1,105 @@
+//! Regression tests for the streaming `.osa` builder (issue #55 / PR #54).
+//!
+//! These guard behaviors that the streaming path changed relative to the old
+//! buffer-then-sort builder:
+//!   * gzip/bgzip inputs are detected by magic bytes, not just by extension;
+//!   * a build that fails mid-stream (unsorted input) errors clearly and leaves
+//!     no corrupt partial `.osa`/`.osa.idx` behind.
+
+use fastvep_cli::pipeline::run_sa_build;
+use std::fs;
+
+const GNOMAD_SORTED: &str = "\
+##fileformat=VCFv4.2
+##INFO=<ID=AF,Number=A,Type=Float,Description=\"af\">
+##INFO=<ID=AN,Number=1,Type=Integer,Description=\"an\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t100\t.\tA\tG\t.\tPASS\tAF=0.01;AN=1000
+chr1\t200\t.\tC\tT\t.\tPASS\tAF=0.02;AN=1000
+chr2\t150\t.\tG\tA\t.\tPASS\tAF=0.3;AN=1000
+";
+
+const GNOMAD_UNSORTED: &str = "\
+##fileformat=VCFv4.2
+##INFO=<ID=AF,Number=A,Type=Float,Description=\"af\">
+##INFO=<ID=AN,Number=1,Type=Integer,Description=\"an\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t500\t.\tA\tG\t.\tPASS\tAF=0.01;AN=1000
+chr1\t100\t.\tC\tT\t.\tPASS\tAF=0.02;AN=1000
+";
+
+fn gzip(data: &str) -> Vec<u8> {
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(data.as_bytes()).unwrap();
+    enc.finish().unwrap()
+}
+
+#[test]
+fn streaming_build_rejects_unsorted_input_and_leaves_no_partial_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("gnomad.vcf");
+    let out = tmp.path().join("db");
+    fs::write(&src, GNOMAD_UNSORTED).unwrap();
+
+    let err = run_sa_build(
+        "gnomad",
+        src.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .expect_err("unsorted input must fail the streaming build");
+
+    let msg = err.to_string();
+    assert!(msg.contains("not sorted"), "unexpected error: {msg}");
+    assert!(
+        msg.contains("bcftools sort") || msg.contains("chr1..chr22"),
+        "sort error should tell the user how to fix it: {msg}"
+    );
+
+    // The streaming writer fills the .osa incrementally, so a mid-stream failure
+    // must not leave a truncated database (or a stale index) on disk.
+    assert!(
+        !out.with_extension("osa").exists(),
+        "partial .osa must be removed when the build fails"
+    );
+    assert!(
+        !out.with_extension("osa.idx").exists(),
+        "no .osa.idx should be left behind when the build fails"
+    );
+}
+
+#[test]
+fn streaming_build_detects_gzip_by_magic_bytes_not_extension() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Identical content: one plain .vcf, one gzip-compressed but deliberately
+    // named .vcf (no .gz/.bgz extension) — mimicking a locally renamed release.
+    let plain = tmp.path().join("plain.vcf");
+    let misnamed = tmp.path().join("misnamed.vcf");
+    fs::write(&plain, GNOMAD_SORTED).unwrap();
+    fs::write(&misnamed, gzip(GNOMAD_SORTED)).unwrap();
+
+    let out_plain = tmp.path().join("plain_db");
+    let out_gz = tmp.path().join("gz_db");
+    run_sa_build("gnomad", plain.to_str().unwrap(), out_plain.to_str().unwrap(), "GRCh38", None, &[], false).unwrap();
+    run_sa_build("gnomad", misnamed.to_str().unwrap(), out_gz.to_str().unwrap(), "GRCh38", None, &[], false).unwrap();
+
+    // Magic-byte detection must transparently decompress the misnamed gzip, so
+    // both builds produce byte-identical databases. Before the fix the gzip
+    // bytes were read raw and the build silently produced an empty database.
+    let plain_osa = fs::read(out_plain.with_extension("osa")).unwrap();
+    let gz_osa = fs::read(out_gz.with_extension("osa")).unwrap();
+    assert!(
+        plain_osa.len() > 10,
+        "build should contain records beyond the 10-byte header"
+    );
+    assert_eq!(
+        plain_osa, gz_osa,
+        "gzip-by-magic build must match the plain-text build"
+    );
+}

--- a/crates/fastvep-sa/examples/dump_sa.rs
+++ b/crates/fastvep-sa/examples/dump_sa.rs
@@ -47,7 +47,15 @@ fn dump_with_index(path: &PathBuf, idx_path: &PathBuf, max_records: Option<u64>)
     'outer: for chrom in chroms {
         for br in &idx.chromosomes[chrom] {
             let off = br.file_offset as usize;
-            let data = &mmap[off + 4..off + 4 + br.compressed_len as usize];
+            let data = mmap
+                .get(off + 4..off + 4 + br.compressed_len as usize)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "block at offset {} extends past end of {} — truncated/partial .osa?",
+                        off,
+                        path.display()
+                    )
+                })?;
             let entries = SaBlock::decompress(data)?;
             for entry in entries {
                 println!(

--- a/crates/fastvep-sa/examples/dump_sa.rs
+++ b/crates/fastvep-sa/examples/dump_sa.rs
@@ -1,0 +1,115 @@
+//! Dump records from a .osa file to stdout as tab-separated values.
+//! Usage: cargo run --release -p fastvep-sa --example dump_sa -- <file.osa> [max_records]
+//!
+//! If the .osa.idx index file does not exist (e.g. the build is still in
+//! progress), the file is scanned sequentially and chromosome names are
+//! reported as "?".
+
+use anyhow::Result;
+use fastvep_sa::block::SaBlock;
+use fastvep_sa::index::SaIndex;
+use memmap2::Mmap;
+use std::env;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let path: PathBuf = args
+        .next()
+        .expect("usage: dump_sa <file.osa> [max_records]")
+        .into();
+    let max_records: Option<u64> = args.next().and_then(|s| s.parse().ok());
+
+    let idx_path = path.with_extension("osa.idx");
+
+    println!("chrom\tpos\tref\talt\tjson");
+
+    if idx_path.exists() {
+        dump_with_index(&path, &idx_path, max_records)
+    } else {
+        eprintln!("note: no index found — scanning sequentially, chromosome names will be '?'");
+        dump_sequential(&path, max_records)
+    }
+}
+
+fn dump_with_index(path: &PathBuf, idx_path: &PathBuf, max_records: Option<u64>) -> Result<()> {
+    let mut idx_file = File::open(idx_path)?;
+    let idx = SaIndex::read_from(&mut idx_file)?;
+    let data_file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&data_file)? };
+
+    let mut chroms: Vec<&String> = idx.chromosomes.keys().collect();
+    chroms.sort_by(|a, b| chrom_sort_key(a).cmp(&chrom_sort_key(b)));
+
+    let mut printed = 0u64;
+    'outer: for chrom in chroms {
+        for br in &idx.chromosomes[chrom] {
+            let off = br.file_offset as usize;
+            let data = &mmap[off + 4..off + 4 + br.compressed_len as usize];
+            let entries = SaBlock::decompress(data)?;
+            for entry in entries {
+                println!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    chrom, entry.position, entry.ref_allele, entry.alt_allele, entry.json
+                );
+                printed += 1;
+                if max_records.map_or(false, |m| printed >= m) {
+                    break 'outer;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn dump_sequential(path: &PathBuf, max_records: Option<u64>) -> Result<()> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+
+    // Skip 8-byte magic + 2-byte schema version
+    let mut header = [0u8; 10];
+    reader.read_exact(&mut header)?;
+
+    let mut printed = 0u64;
+    let mut len_buf = [0u8; 4];
+    loop {
+        match reader.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e.into()),
+        }
+        let compressed_len = u32::from_le_bytes(len_buf) as usize;
+        let mut compressed = vec![0u8; compressed_len];
+        reader.read_exact(&mut compressed)?;
+
+        let entries = SaBlock::decompress(&compressed)?;
+        for entry in entries {
+            println!(
+                "?\t{}\t{}\t{}\t{}",
+                entry.position, entry.ref_allele, entry.alt_allele, entry.json
+            );
+            printed += 1;
+            if max_records.map_or(false, |m| printed >= m) {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn chrom_sort_key(c: &str) -> (u8, u32, &str) {
+    let name = c.strip_prefix("chr").unwrap_or(c);
+    if let Ok(n) = name.parse::<u32>() {
+        (0, n, "")
+    } else {
+        let order: u8 = match name {
+            "X" => 1,
+            "Y" => 2,
+            "M" | "MT" => 3,
+            _ => 4,
+        };
+        (order, 0, name)
+    }
+}

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -1,89 +1,123 @@
 //! dbSNP VCF parser for building .osa annotation files.
 //!
 //! Parses dbSNP's VCF release to extract RS IDs and global MAF.
+//!
+//! The full NCBI dbSNP VCF contains ~800 million records. Use
+//! `iter_dbsnp_vcf` for streaming builds; `parse_dbsnp_vcf` is retained for
+//! tests and small inputs.
 
 use crate::common::AnnotationRecord;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::io::BufRead;
 
-/// Parse a dbSNP VCF and produce sorted `AnnotationRecord`s.
-pub fn parse_dbsnp_vcf<R: BufRead>(
+/// Stream a coordinate-sorted dbSNP VCF as `AnnotationRecord`s without
+/// buffering the whole file in memory.
+///
+/// The input must already be sorted by chromosome and position (all standard
+/// NCBI dbSNP releases are).
+pub fn iter_dbsnp_vcf<'a, R: BufRead>(
     reader: R,
-    chrom_to_idx: &HashMap<String, u16>,
-) -> Result<Vec<AnnotationRecord>> {
-    let mut records = Vec::new();
+    chrom_to_idx: &'a HashMap<String, u16>,
+) -> DbsnpRecordIter<'a, R> {
+    DbsnpRecordIter {
+        lines: reader.lines(),
+        chrom_to_idx,
+        pending: VecDeque::new(),
+    }
+}
 
-    for line in reader.lines() {
-        let line = line.context("Reading dbSNP VCF line")?;
-        if line.starts_with('#') {
-            continue;
-        }
+pub struct DbsnpRecordIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    pending: VecDeque<AnnotationRecord>,
+}
 
-        let fields: Vec<&str> = line.splitn(9, '\t').collect();
-        if fields.len() < 8 {
-            continue;
-        }
+impl<R: BufRead> Iterator for DbsnpRecordIter<'_, R> {
+    type Item = Result<AnnotationRecord>;
 
-        let chrom = normalize_chrom(fields[0]);
-        let chrom_idx = match chrom_to_idx.get(&chrom) {
-            Some(&idx) => idx,
-            None => continue,
-        };
-
-        let pos: u32 = match fields[1].parse() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let id = fields[2];
-        let ref_allele = fields[3].to_string();
-        let alt_field = fields[4];
-        let info = fields[7];
-
-        // Extract RS ID
-        let rs_id = if id.starts_with("rs") {
-            id.to_string()
-        } else {
-            // Try INFO field
-            let info_map = parse_info(info);
-            match info_map.get("RS") {
-                Some(rs) => format!("rs{}", rs),
-                None => continue, // Skip if no RS ID
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(record) = self.pending.pop_front() {
+                return Some(Ok(record));
             }
-        };
 
-        // Parse global MAF if available
-        let info_map = parse_info(info);
-        let freq = info_map
-            .get("CAF")
-            .and_then(|caf| {
-                // CAF format: ref_freq,alt1_freq,alt2_freq,...
+            let line = match self.lines.next()? {
+                Ok(l) => l,
+                Err(e) => return Some(Err(e).context("Reading dbSNP VCF line")),
+            };
+
+            if line.starts_with('#') {
+                continue;
+            }
+
+            let fields: Vec<&str> = line.splitn(9, '\t').collect();
+            if fields.len() < 8 {
+                continue;
+            }
+
+            let chrom = normalize_chrom(fields[0]);
+            let chrom_idx = match self.chrom_to_idx.get(&chrom) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+
+            let pos: u32 = match fields[1].parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let id = fields[2];
+            let ref_allele = fields[3].to_string();
+            let alt_field = fields[4];
+            let info = fields[7];
+
+            let rs_id = if id.starts_with("rs") {
+                id.to_string()
+            } else {
+                let info_map = parse_info(info);
+                match info_map.get("RS") {
+                    Some(rs) => format!("rs{}", rs),
+                    None => continue,
+                }
+            };
+
+            let info_map = parse_info(info);
+            let freq = info_map.get("CAF").and_then(|caf| {
                 let parts: Vec<&str> = caf.split(',').collect();
                 parts.get(1).and_then(|s| s.parse::<f64>().ok())
             });
 
-        for alt in alt_field.split(',') {
-            if alt == "." || alt == "*" {
-                continue;
+            for alt in alt_field.split(',') {
+                if alt == "." || alt == "*" {
+                    continue;
+                }
+                let mut parts = vec![format!("\"id\":\"{}\"", rs_id)];
+                if let Some(f) = freq {
+                    parts.push(format!("\"globalMaf\":{:.6e}", f));
+                }
+                self.pending.push_back(AnnotationRecord {
+                    chrom_idx,
+                    position: pos,
+                    ref_allele: ref_allele.clone(),
+                    alt_allele: alt.to_string(),
+                    json: format!("{{{}}}", parts.join(",")),
+                });
             }
-
-            let mut parts = vec![format!("\"id\":\"{}\"", rs_id)];
-            if let Some(f) = freq {
-                parts.push(format!("\"globalMaf\":{:.6e}", f));
-            }
-            let json = format!("{{{}}}", parts.join(","));
-
-            records.push(AnnotationRecord {
-                chrom_idx,
-                position: pos,
-                ref_allele: ref_allele.clone(),
-                alt_allele: alt.to_string(),
-                json,
-            });
         }
     }
+}
 
+/// Parse a dbSNP VCF and produce sorted `AnnotationRecord`s.
+///
+/// Loads all records into memory — suitable for tests and small inputs.
+/// For the full NCBI release use `iter_dbsnp_vcf` via the pipeline instead.
+pub fn parse_dbsnp_vcf<R: BufRead>(
+    reader: R,
+    chrom_to_idx: &HashMap<String, u16>,
+) -> Result<Vec<AnnotationRecord>> {
+    let mut records: Vec<_> = iter_dbsnp_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
     records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
     Ok(records)
 }

--- a/crates/fastvep-sa/src/sources/gnomad.rs
+++ b/crates/fastvep-sa/src/sources/gnomad.rs
@@ -3,17 +3,23 @@
 //! Parses gnomAD's sites-only VCF to extract allele frequencies
 //! per population, allele counts, and homozygote counts.
 //!
-//! Auto-detects the INFO field-naming convention used by the input. gnomAD
-//! v2.1 / v3 / v4.0 (exomes, genomes) use bare `AF` / `AC` / `AN` /
-//! `nhomalt` with `AF_<pop>` for population subsets. The v4.1 *joint*
-//! release (`gnomad.joint.v4.1.sites.*.vcf.bgz`) instead exposes
-//! `AF_joint` / `AC_joint` / `AN_joint` / `nhomalt_joint` and
-//! `AF_joint_<pop>` for per-population frequencies. We pick the scheme by
-//! scanning `##INFO=<ID=...>` header lines.
+//! Auto-detects the INFO field-naming convention used by the input:
+//!
+//! | Release | Top-level | Per-population |
+//! |---------|-----------|----------------|
+//! | v2.x (exomes/genomes) | `AF` / `AC` / `AN` / `nhomalt` | `AF_afr` (underscore) |
+//! | v3.x (genomes)        | `AF` / `AC` / `AN` / `nhomalt` | none at top level (only subset-qualified, e.g. `AF-non_neuro-afr`) |
+//! | v4.0/v4.1 (exomes/genomes) | `AF` / `AC` / `AN` / `nhomalt` | `AF_afr` (underscore) |
+//! | v4.1 joint            | `AF_joint` / `AC_joint` / `AN_joint` / `nhomalt_joint` | `AF_joint_afr` |
+//!
+//! Some locally-processed files expose simple per-population fields with a
+//! hyphen separator (`AF-afr`). The parser detects and handles this case.
+//!
+//! We pick the scheme by scanning `##INFO=<ID=...>` header lines.
 
 use crate::common::AnnotationRecord;
 use anyhow::{Context, Result};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::BufRead;
 
 /// Population keys to extract from gnomAD VCF INFO field. Covers both
@@ -67,14 +73,23 @@ impl FieldNames {
 /// Pick a field-naming scheme based on which INFO IDs the VCF header
 /// declares. Prefer standard names when present; fall back to the joint
 /// names if the standard `AF` is absent but `AF_joint` is declared.
+///
+/// Some locally-processed files may use a hyphen separator for per-population
+/// fields (`AF-afr`) rather than the standard underscore (`AF_afr`). We
+/// detect this by checking whether any `AF-<pop>` field appears in the header.
 fn detect_field_names(info_ids: &HashSet<String>) -> FieldNames {
     if info_ids.contains("AF") {
-        FieldNames::standard()
+        let mut names = FieldNames::standard();
+        if POPULATIONS
+            .iter()
+            .any(|p| info_ids.contains(&format!("AF-{p}")))
+        {
+            names.af_pop_template = "AF-{}".into();
+        }
+        names
     } else if info_ids.contains("AF_joint") {
         FieldNames::joint()
     } else {
-        // Nothing declared — default to standard so behavior is unchanged
-        // for malformed or header-less inputs.
         FieldNames::standard()
     }
 }
@@ -136,87 +151,122 @@ fn parse_info_id(line: &str) -> Option<&str> {
 }
 
 /// Parse a gnomAD sites-only VCF and produce sorted `AnnotationRecord`s.
+///
+/// Collects all records into memory and sorts. For genome-scale VCFs use
+/// `iter_gnomad_vcf` instead, which streams one block at a time.
 pub fn parse_gnomad_vcf<R: BufRead>(
     reader: R,
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
-    let mut records = Vec::new();
-    let mut info_ids: HashSet<String> = HashSet::new();
-    let mut field_names = FieldNames::standard();
-    let mut header_done = false;
+    let mut records: Vec<_> = iter_gnomad_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
+    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    Ok(records)
+}
 
-    for line in reader.lines() {
-        let line = line.context("Reading gnomAD VCF line")?;
-        if line.starts_with('#') {
-            if let Some(id) = parse_info_id(&line) {
-                info_ids.insert(id.to_string());
+/// Stream a coordinate-sorted gnomAD VCF as `AnnotationRecord`s without
+/// buffering the whole file in memory.
+///
+/// The input must already be sorted by chromosome and position (all standard
+/// gnomAD releases are). The writer will detect and error on out-of-order
+/// records.
+pub fn iter_gnomad_vcf<'a, R: BufRead>(
+    reader: R,
+    chrom_to_idx: &'a HashMap<String, u16>,
+) -> GnomadRecordIter<'a, R> {
+    GnomadRecordIter {
+        lines: reader.lines(),
+        chrom_to_idx,
+        pending: VecDeque::new(),
+        info_ids: HashSet::new(),
+        field_names: None,
+    }
+}
+
+pub struct GnomadRecordIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    pending: VecDeque<AnnotationRecord>,
+    info_ids: HashSet<String>,
+    field_names: Option<FieldNames>,
+}
+
+impl<R: BufRead> Iterator for GnomadRecordIter<'_, R> {
+    type Item = Result<AnnotationRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(record) = self.pending.pop_front() {
+                return Some(Ok(record));
             }
-            continue;
-        }
 
-        // First data line: finalize the field-naming choice.
-        if !header_done {
-            field_names = detect_field_names(&info_ids);
-            header_done = true;
-        }
+            let line = match self.lines.next()? {
+                Ok(l) => l,
+                Err(e) => return Some(Err(e).context("Reading gnomAD VCF line")),
+            };
 
-        let fields: Vec<&str> = line.splitn(9, '\t').collect();
-        if fields.len() < 8 {
-            continue;
-        }
-
-        let chrom = normalize_chrom(fields[0]);
-        let chrom_idx = match chrom_to_idx.get(&chrom) {
-            Some(&idx) => idx,
-            None => continue,
-        };
-
-        let pos: u32 = match fields[1].parse() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let ref_allele = fields[3].to_string();
-        let alt_field = fields[4];
-        let info = fields[7];
-
-        let info_map = parse_info(info);
-
-        // Handle multi-allelic: split allele-specific fields by comma
-        let alts: Vec<&str> = alt_field.split(',').collect();
-        let all_afs = split_info_values(info_map.get(&field_names.af).map(|s| s.as_str()));
-        let all_ans = split_info_values(info_map.get(&field_names.an).map(|s| s.as_str()));
-        let all_acs = split_info_values(info_map.get(&field_names.ac).map(|s| s.as_str()));
-        let all_nhomalt =
-            split_info_values(info_map.get(&field_names.nhomalt).map(|s| s.as_str()));
-
-        for (i, alt) in alts.iter().enumerate() {
-            if *alt == "." || *alt == "*" {
+            if line.starts_with('#') {
+                if let Some(id) = parse_info_id(&line) {
+                    self.info_ids.insert(id.to_string());
+                }
                 continue;
             }
 
-            let json = build_gnomad_json(
-                all_afs.get(i).map(|s| s.as_str()),
-                all_ans.first().map(|s| s.as_str()), // AN is typically single-valued
-                all_acs.get(i).map(|s| s.as_str()),
-                all_nhomalt.get(i).map(|s| s.as_str()),
-                &info_map,
-                i,
-                &field_names,
-            );
+            if self.field_names.is_none() {
+                self.field_names = Some(detect_field_names(&self.info_ids));
+            }
+            let field_names = self.field_names.as_ref().unwrap();
 
-            records.push(AnnotationRecord {
-                chrom_idx,
-                position: pos,
-                ref_allele: ref_allele.clone(),
-                alt_allele: alt.to_string(),
-                json,
-            });
+            let fields: Vec<&str> = line.splitn(9, '\t').collect();
+            if fields.len() < 8 {
+                continue;
+            }
+
+            let chrom = normalize_chrom(fields[0]);
+            let chrom_idx = match self.chrom_to_idx.get(&chrom) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+
+            let pos: u32 = match fields[1].parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let ref_allele = fields[3].to_string();
+            let alt_field = fields[4];
+            let info = fields[7];
+
+            let info_map = parse_info(info);
+            let alts: Vec<&str> = alt_field.split(',').collect();
+            let all_afs = split_info_values(info_map.get(&field_names.af).map(|s| s.as_str()));
+            let all_ans = split_info_values(info_map.get(&field_names.an).map(|s| s.as_str()));
+            let all_acs = split_info_values(info_map.get(&field_names.ac).map(|s| s.as_str()));
+            let all_nhomalt =
+                split_info_values(info_map.get(&field_names.nhomalt).map(|s| s.as_str()));
+
+            for (i, alt) in alts.iter().enumerate() {
+                if *alt == "." || *alt == "*" {
+                    continue;
+                }
+                let json = build_gnomad_json(
+                    all_afs.get(i).map(|s| s.as_str()),
+                    all_ans.first().map(|s| s.as_str()),
+                    all_acs.get(i).map(|s| s.as_str()),
+                    all_nhomalt.get(i).map(|s| s.as_str()),
+                    &info_map,
+                    i,
+                    field_names,
+                );
+                self.pending.push_back(AnnotationRecord {
+                    chrom_idx,
+                    position: pos,
+                    ref_allele: ref_allele.clone(),
+                    alt_allele: alt.to_string(),
+                    json,
+                });
+            }
         }
     }
-
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
-    Ok(records)
 }
 
 fn build_gnomad_json(
@@ -396,6 +446,20 @@ chr1\t20000\t.\tC\tT,A\t.\tPASS\tAF_joint=0.01,0.005;AN_joint=140000;AC_joint=14
         ids.insert("AF_joint".into());
         let names = detect_field_names(&ids);
         assert_eq!(names.af, "AF");
+    }
+
+    #[test]
+    fn test_detect_field_names_hyphen_separator() {
+        // Some locally-processed files use AF-afr (hyphen) instead of the standard AF_afr.
+        let mut ids = HashSet::new();
+        ids.insert("AF".into());
+        ids.insert("AN".into());
+        ids.insert("AF-afr".into());
+        ids.insert("AF-nfe".into());
+        let names = detect_field_names(&ids);
+        assert_eq!(names.af, "AF");
+        assert_eq!(names.pop_key("afr"), "AF-afr");
+        assert_eq!(names.pop_key("nfe"), "AF-nfe");
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/topmed.rs
+++ b/crates/fastvep-sa/src/sources/topmed.rs
@@ -1,74 +1,147 @@
 //! TOPMed population frequency parser.
+//!
+//! The full TOPMed freeze VCF contains ~450 million records. Use
+//! `iter_topmed_vcf` for streaming builds; `parse_topmed_vcf` is retained for
+//! tests and small inputs.
 
 use crate::common::AnnotationRecord;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::io::BufRead;
 
-/// Parse a TOPMed freeze VCF into sorted AnnotationRecords.
+/// Stream a coordinate-sorted TOPMed VCF as `AnnotationRecord`s without
+/// buffering the whole file in memory.
+///
+/// The input must already be sorted by chromosome and position (all standard
+/// TOPMed freeze releases are).
+pub fn iter_topmed_vcf<'a, R: BufRead>(
+    reader: R,
+    chrom_to_idx: &'a HashMap<String, u16>,
+) -> TopmedRecordIter<'a, R> {
+    TopmedRecordIter {
+        lines: reader.lines(),
+        chrom_to_idx,
+        pending: VecDeque::new(),
+    }
+}
+
+pub struct TopmedRecordIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    pending: VecDeque<AnnotationRecord>,
+}
+
+impl<R: BufRead> Iterator for TopmedRecordIter<'_, R> {
+    type Item = Result<AnnotationRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(record) = self.pending.pop_front() {
+                return Some(Ok(record));
+            }
+
+            let line = match self.lines.next()? {
+                Ok(l) => l,
+                Err(e) => return Some(Err(e).context("Reading TOPMed VCF line")),
+            };
+
+            if line.starts_with('#') {
+                continue;
+            }
+
+            let fields: Vec<&str> = line.splitn(9, '\t').collect();
+            if fields.len() < 8 {
+                continue;
+            }
+
+            let chrom = normalize_chrom(fields[0]);
+            let chrom_idx = match self.chrom_to_idx.get(&chrom) {
+                Some(&i) => i,
+                None => continue,
+            };
+            let pos: u32 = match fields[1].parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let ref_allele = fields[3].to_string();
+            let alt_field = fields[4];
+            let info = fields[7];
+            let info_map = parse_info(info);
+
+            let alts: Vec<&str> = alt_field.split(',').collect();
+            let all_afs = split_vals(info_map.get("AF").map(|s| s.as_str()));
+            let all_acs = split_vals(info_map.get("AC").map(|s| s.as_str()));
+
+            for (i, alt) in alts.iter().enumerate() {
+                if *alt == "." || *alt == "*" {
+                    continue;
+                }
+                let mut parts = Vec::new();
+                if let Some(af) = all_afs.get(i).and_then(|s| s.parse::<f64>().ok()) {
+                    parts.push(format!("\"allAf\":{:.6e}", af));
+                }
+                if let Some(ac) = all_acs.get(i) {
+                    parts.push(format!("\"allAc\":{}", ac));
+                }
+                if let Some(an) = info_map.get("AN") {
+                    parts.push(format!("\"allAn\":{}", an));
+                }
+                if parts.is_empty() {
+                    continue;
+                }
+                self.pending.push_back(AnnotationRecord {
+                    chrom_idx,
+                    position: pos,
+                    ref_allele: ref_allele.clone(),
+                    alt_allele: alt.to_string(),
+                    json: format!("{{{}}}", parts.join(",")),
+                });
+            }
+        }
+    }
+}
+
+/// Parse a TOPMed freeze VCF into sorted `AnnotationRecord`s.
+///
+/// Loads all records into memory — suitable for tests and small inputs.
+/// For the full TOPMed release use `iter_topmed_vcf` via the pipeline instead.
 pub fn parse_topmed_vcf<R: BufRead>(
     reader: R,
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
-    let mut records = Vec::new();
-
-    for line in reader.lines() {
-        let line = line.context("Reading TOPMed VCF")?;
-        if line.starts_with('#') { continue; }
-        let fields: Vec<&str> = line.splitn(9, '\t').collect();
-        if fields.len() < 8 { continue; }
-
-        let chrom = normalize_chrom(fields[0]);
-        let chrom_idx = match chrom_to_idx.get(&chrom) { Some(&i) => i, None => continue };
-        let pos: u32 = match fields[1].parse() { Ok(p) => p, Err(_) => continue };
-        let ref_allele = fields[3].to_string();
-        let alt_field = fields[4];
-        let info = fields[7];
-        let info_map = parse_info(info);
-
-        let alts: Vec<&str> = alt_field.split(',').collect();
-        let all_afs = split_vals(info_map.get("AF").map(|s| s.as_str()));
-        let all_acs = split_vals(info_map.get("AC").map(|s| s.as_str()));
-
-        for (i, alt) in alts.iter().enumerate() {
-            if *alt == "." || *alt == "*" { continue; }
-            let mut parts = Vec::new();
-            if let Some(af) = all_afs.get(i).and_then(|s| s.parse::<f64>().ok()) {
-                parts.push(format!("\"allAf\":{:.6e}", af));
-            }
-            if let Some(ac) = all_acs.get(i) {
-                parts.push(format!("\"allAc\":{}", ac));
-            }
-            if let Some(an) = info_map.get("AN") {
-                parts.push(format!("\"allAn\":{}", an));
-            }
-            if parts.is_empty() { continue; }
-            records.push(AnnotationRecord {
-                chrom_idx, position: pos,
-                ref_allele: ref_allele.clone(), alt_allele: alt.to_string(),
-                json: format!("{{{}}}", parts.join(",")),
-            });
-        }
-    }
+    let mut records: Vec<_> = iter_topmed_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
     records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
     Ok(records)
 }
 
 fn parse_info(info: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
-    for p in info.split(';') { if let Some((k, v)) = p.split_once('=') { m.insert(k.into(), v.into()); } }
+    for p in info.split(';') {
+        if let Some((k, v)) = p.split_once('=') {
+            m.insert(k.into(), v.into());
+        }
+    }
     m
 }
+
 fn split_vals(v: Option<&str>) -> Vec<String> {
-    v.map(|s| s.split(',').map(|x| x.to_string()).collect()).unwrap_or_default()
+    v.map(|s| s.split(',').map(|x| x.to_string()).collect())
+        .unwrap_or_default()
 }
+
 fn normalize_chrom(c: &str) -> String {
-    if c.starts_with("chr") { c.to_string() } else { format!("chr{}", c) }
+    if c.starts_with("chr") {
+        c.to_string()
+    } else {
+        format!("chr{}", c)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_parse_topmed() {
         let vcf = "#h\nchr1\t100\t.\tA\tG\t.\t.\tAF=0.05;AC=500;AN=10000\n";

--- a/crates/fastvep-sa/src/writer.rs
+++ b/crates/fastvep-sa/src/writer.rs
@@ -92,7 +92,9 @@ impl SaWriter {
         if let Some((last_chrom, last_pos)) = self.last_key {
             if (record.chrom_idx, record.position) < (last_chrom, last_pos) {
                 anyhow::bail!(
-                    "SA records are not sorted: previous chrom_idx={}, position={}; current chrom_idx={}, position={}",
+                    "SA records are not sorted: previous chrom_idx={}, position={}; current chrom_idx={}, position={}. \
+                     The streaming .osa builder requires input sorted by chromosome (chr1..chr22,X,Y,M) then position \
+                     — sort the source file (e.g. `bcftools sort` / `sort -k1,1 -k2,2n`) and rebuild.",
                     last_chrom,
                     last_pos,
                     record.chrom_idx,

--- a/crates/fastvep-sa/src/writer.rs
+++ b/crates/fastvep-sa/src/writer.rs
@@ -7,7 +7,7 @@
 use crate::block::{BlockEntry, SaBlock};
 use crate::common::{AnnotationRecord, DEFAULT_BLOCK_SIZE, OSA_MAGIC, SCHEMA_VERSION};
 use crate::index::{BlockRef, IndexHeader, SaIndex};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
@@ -172,12 +172,14 @@ impl SaWriter {
         let data_path = base_path.with_extension("osa");
         let idx_path = base_path.with_extension("osa.idx");
 
-        let data_file = std::fs::File::create(&data_path)?;
+        let data_file = std::fs::File::create(&data_path)
+            .with_context(|| format!("Creating output file {} (does the output directory exist?)", data_path.display()))?;
         let mut data_writer = BufWriter::new(data_file);
         self.write_all(&mut data_writer, records, chrom_map)?;
         data_writer.flush()?;
 
-        let idx_file = std::fs::File::create(&idx_path)?;
+        let idx_file = std::fs::File::create(&idx_path)
+            .with_context(|| format!("Creating index file {}", idx_path.display()))?;
         let mut idx_writer = BufWriter::new(idx_file);
         self.write_index(&mut idx_writer)?;
         idx_writer.flush()?;
@@ -195,12 +197,14 @@ impl SaWriter {
         let data_path = base_path.with_extension("osa");
         let idx_path = base_path.with_extension("osa.idx");
 
-        let data_file = std::fs::File::create(&data_path)?;
+        let data_file = std::fs::File::create(&data_path)
+            .with_context(|| format!("Creating output file {} (does the output directory exist?)", data_path.display()))?;
         let mut data_writer = BufWriter::new(data_file);
         self.write_all_results(&mut data_writer, records, chrom_map)?;
         data_writer.flush()?;
 
-        let idx_file = std::fs::File::create(&idx_path)?;
+        let idx_file = std::fs::File::create(&idx_path)
+            .with_context(|| format!("Creating index file {}", idx_path.display()))?;
         let mut idx_writer = BufWriter::new(idx_file);
         self.write_index(&mut idx_writer)?;
         idx_writer.flush()?;


### PR DESCRIPTION
- dbSNP and TOPMed parsers converted to streaming iterators (iter_dbsnp_vcf, iter_topmed_vcf) to avoid loading 100 million+ records into RAM; pipeline uses these with a CountingReader for byte-accurate progress tracking
- Progress meter gains ETA and % done columns when compressed file size is known (gz/bgz inputs); falls back to 3-column output otherwise
- gnomAD parser detects hyphen-separated AF fields (AF-afr) used by some locally-processed files alongside standard underscore fields (AF_afr)
- dump_sa example decodes a .osa file to TSV; falls back to sequential scan without chromosome names if the .osa.idx has not yet been written (e.g. mid-build)
- clap wrap_help feature enabled for terminal-width-aware help formatting

Lots of help from Claude.  Still needs more testing