### PR TITLE
Fix OMIM/dbSNP correctness bugs, stream phyloP/GERP builds, harden JSON escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ fastvep sa-build --source clinvar --input clinvar.vcf.gz --output clinvar
 # Build gnomAD population frequency database
 fastvep sa-build --source gnomad --input gnomad.genomes.v4.vcf.bgz --output gnomad
 
-# Build PhyloP conservation scores
+# Build PhyloP conservation scores (see docs/ACMG_SETUP.md for how to
+# obtain hg38.phyloP100way.wigFix.gz — UCSC ships it as one file per
+# chromosome, not a single combined download)
 fastvep sa-build --source phylop --input hg38.phyloP100way.wigFix.gz --output phylop
 
 # Build SpliceAI predictions

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -2293,20 +2293,26 @@ where
 /// chrom=...`) and a simple `chrom\tpos\tscore` TSV (which is what we
 /// emit when distilling PhyloP from gnomAD v4 INFO). Detect by peeking
 /// the first non-blank line; everything else falls through to the TSV
-/// parser since it tolerates BED-4 too.
-fn parse_phylop_auto<R: BufRead>(
+/// parser since it tolerates BED-4 too. Streams either format straight
+/// into the writer — PhyloP/GERP are per-base, genome-wide sources
+/// (~3 billion positions for hg38) so buffering them as a Vec first
+/// would exhaust memory long before a real build finishes.
+fn iter_phylop_auto<'a, R: BufRead + 'a>(
     mut reader: R,
-    chrom_to_idx: &HashMap<String, u16>,
-) -> Result<Vec<fastvep_sa::common::AnnotationRecord>> {
+    chrom_to_idx: &'a HashMap<String, u16>,
+) -> Box<dyn Iterator<Item = Result<fastvep_sa::common::AnnotationRecord>> + 'a> {
     let mut peek = [0u8; 16];
-    let n = reader.read(&mut peek)?;
+    let n = match reader.read(&mut peek) {
+        Ok(n) => n,
+        Err(e) => return Box::new(std::iter::once(Err(e).context("Peeking phyloP input"))),
+    };
     let prefix = std::str::from_utf8(&peek[..n]).unwrap_or("");
     let chained = std::io::Cursor::new(peek[..n].to_vec()).chain(reader);
     let buf = io::BufReader::new(chained);
     if prefix.trim_start().starts_with("fixedStep") {
-        fastvep_sa::sources::scores::parse_wigfix(buf, chrom_to_idx)
+        Box::new(fastvep_sa::sources::scores::iter_wigfix(buf, chrom_to_idx))
     } else {
-        fastvep_sa::sources::scores::parse_score_tsv(buf, chrom_to_idx, false)
+        Box::new(fastvep_sa::sources::scores::iter_score_tsv(buf, chrom_to_idx, false))
     }
 }
 
@@ -2526,6 +2532,18 @@ pub fn run_sa_build(
                 |r, m| fastvep_sa::sources::topmed::iter_topmed_vcf(r, m),
             );
         }
+        "phylop" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| iter_phylop_auto(r, m),
+            );
+        }
+        "gerp" | "dann" => {
+            return run_streaming_sa_build(
+                input, output, header, &chrom_map, &chrom_list, show_progress,
+                |r, m| fastvep_sa::sources::scores::iter_score_tsv(r, m, false),
+            );
+        }
         _ => {}
     }
 
@@ -2543,11 +2561,6 @@ pub fn run_sa_build(
         "cosmic" => fastvep_sa::sources::cosmic::parse_cosmic_vcf(buf_reader, &chrom_map)?,
         "onekg" | "1000g" => fastvep_sa::sources::onekg::parse_onekg_vcf(buf_reader, &chrom_map)?,
         "mitomap" => fastvep_sa::sources::mitomap::parse_mitomap(buf_reader, &chrom_map)?,
-        // PhyloP supports two on-disk formats: UCSC fixed-step wig and
-        // simple TSV (`chrom\tpos\tscore`). Auto-detect by peeking the
-        // first non-comment byte: wigfix starts with "fixedStep".
-        "phylop" => parse_phylop_auto(buf_reader, &chrom_map)?,
-        "gerp" | "dann" => fastvep_sa::sources::scores::parse_score_tsv(buf_reader, &chrom_map, false)?,
         "revel" => fastvep_sa::sources::revel::parse_revel(buf_reader, &chrom_map, 2)?,
         "primateai" => fastvep_sa::sources::primateai::parse_primateai(buf_reader, &chrom_map)?,
         "dbnsfp" => fastvep_sa::sources::dbnsfp::parse_dbnsfp(buf_reader, &chrom_map)?,

--- a/crates/fastvep-cli/tests/sa_build_oga.rs
+++ b/crates/fastvep-cli/tests/sa_build_oga.rs
@@ -30,11 +30,12 @@ fn sa_build_omim_writes_oga_with_records() {
     let output = tmp.path().join("omim");
 
     // Minimal genemap2.txt fixture — column layout matches the real OMIM
-    // file format (gene symbol at index 5, MIM at index 8, phenotypes at 12).
+    // file format (MIM Number at index 5, Approved Gene Symbol at index 8,
+    // phenotypes at 12). See issue #64: these were previously swapped.
     let fixture = "# Generated\n\
                    # Copyright OMIM\n\
-                   1\tp36.33\t1:10001-20000\tGene1\t\tBRCA1\tprotein\t\t113705\t\t\t\tBreast cancer, 114480 (3), Autosomal dominant; Ovarian cancer, 167000 (3)\n\
-                   1\tp36.33\t1:30001-40000\tGene2\t\tTP53\tprotein\t\t191170\t\t\t\tLi-Fraumeni syndrome 1, 151623 (3), Autosomal dominant\n";
+                   1\tp36.33\t1:10001-20000\tGene1\t\t113705\tprotein\t\tBRCA1\t\t\t\tBreast cancer, 114480 (3), Autosomal dominant; Ovarian cancer, 167000 (3)\n\
+                   1\tp36.33\t1:30001-40000\tGene2\t\t191170\tprotein\t\tTP53\t\t\t\tLi-Fraumeni syndrome 1, 151623 (3), Autosomal dominant\n";
     File::create(&input)
         .unwrap()
         .write_all(fixture.as_bytes())

--- a/crates/fastvep-cli/tests/sa_build_streaming.rs
+++ b/crates/fastvep-cli/tests/sa_build_streaming.rs
@@ -6,7 +6,9 @@
 //!   * a build that fails mid-stream (unsorted input) errors clearly and leaves
 //!     no corrupt partial `.osa`/`.osa.idx` behind.
 
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
 use fastvep_cli::pipeline::run_sa_build;
+use fastvep_sa::reader::SaReader;
 use std::fs;
 
 const GNOMAD_SORTED: &str = "\
@@ -102,4 +104,82 @@ fn streaming_build_detects_gzip_by_magic_bytes_not_extension() {
         plain_osa, gz_osa,
         "gzip-by-magic build must match the plain-text build"
     );
+}
+
+/// PhyloP/GERP are per-base genome-wide sources and must build via the
+/// streaming path (not buffer every position as a `Vec`) — see
+/// `iter_phylop_auto`/`iter_score_tsv`/`iter_wigfix` in fastvep-sa. This
+/// exercises both on-disk formats (wigFix and plain TSV) end to end
+/// through `run_sa_build` and confirms the resulting `.osa` answers
+/// positional queries correctly.
+#[test]
+fn streaming_build_handles_phylop_wigfix_and_gerp_tsv() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let wigfix = "\
+fixedStep chrom=chr1 start=100 step=1
+0.5
+0.75
+-1.25
+fixedStep chrom=chr2 start=50 step=1
+2.0
+";
+    let phylop_src = tmp.path().join("hg38.phyloP100way.wigFix");
+    fs::write(&phylop_src, wigfix).unwrap();
+    let phylop_out = tmp.path().join("phylop");
+    run_sa_build(
+        "phylop",
+        phylop_src.to_str().unwrap(),
+        phylop_out.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let phylop_reader = SaReader::open(&phylop_out.with_extension("osa")).unwrap();
+    let hit = phylop_reader
+        .annotate_position("chr1", 101, "", "")
+        .unwrap()
+        .expect("position 101 on chr1 should have a phyloP score");
+    match hit {
+        AnnotationValue::Positional(v) => assert!(v.contains("0.75"), "unexpected phyloP value: {v}"),
+        other => panic!("expected a positional phyloP value, got {other:?}"),
+    }
+    assert!(
+        phylop_reader
+            .annotate_position("chr2", 50, "", "")
+            .unwrap()
+            .is_some(),
+        "second fixedStep block (chr2) should also be present"
+    );
+
+    let gerp_tsv = "\
+chr1\t100\t1.234
+chr1\t200\t-0.5
+";
+    let gerp_src = tmp.path().join("gerp_scores.tsv");
+    fs::write(&gerp_src, gerp_tsv).unwrap();
+    let gerp_out = tmp.path().join("gerp");
+    run_sa_build(
+        "gerp",
+        gerp_src.to_str().unwrap(),
+        gerp_out.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let gerp_reader = SaReader::open(&gerp_out.with_extension("osa")).unwrap();
+    let hit = gerp_reader
+        .annotate_position("chr1", 100, "", "")
+        .unwrap()
+        .expect("position 100 on chr1 should have a GERP score");
+    match hit {
+        AnnotationValue::Positional(v) => assert!(v.contains("1.234"), "unexpected GERP value: {v}"),
+        other => panic!("expected a positional GERP value, got {other:?}"),
+    }
 }

--- a/crates/fastvep-sa/src/common.rs
+++ b/crates/fastvep-sa/src/common.rs
@@ -123,9 +123,40 @@ pub struct GeneRecord {
 /// data produces invalid JSON that silently corrupts that record for
 /// every downstream `serde_json::from_str` consumer.
 pub fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            // JSON requires every C0 control character (U+0000..=U+001F) to
+            // be escaped; the common ones have short forms above, the rest
+            // (backspace, form feed, vertical tab, NUL, etc.) must go out as
+            // \u00XX or the record is invalid JSON.
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_json_produces_valid_json_for_quotes_backslashes_and_controls() {
+        // A field carrying a quote, a backslash, and assorted control
+        // characters (including ones without a short escape form: backspace,
+        // form feed, vertical tab, NUL) must still round-trip as valid JSON.
+        let raw = "a\"b\\c\n\r\t\x08\x0c\x0b\x00d";
+        let json = format!(r#"{{"v":"{}"}}"#, escape_json(raw));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("escaped string must produce valid JSON");
+        assert_eq!(parsed["v"], raw, "value must survive an escape/parse round-trip unchanged");
+    }
 }

--- a/crates/fastvep-sa/src/common.rs
+++ b/crates/fastvep-sa/src/common.rs
@@ -112,3 +112,20 @@ pub struct GeneRecord {
     /// Pre-serialized JSON annotation string.
     pub json: String,
 }
+
+/// Escape a string for embedding in a hand-built JSON string value.
+///
+/// Source parsers build their `.osa`/`.oga` JSON payloads by hand (not via
+/// `serde_json`) for speed, so any field taken from an upstream file
+/// (gene names, disease descriptions, COSMIC/ClinVar free-text fields,
+/// etc.) must run through this before being interpolated into a `"..."`
+/// value — otherwise a raw `"`, `\`, or control character in the source
+/// data produces invalid JSON that silently corrupts that record for
+/// every downstream `serde_json::from_str` consumer.
+pub fn escape_json(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}

--- a/crates/fastvep-sa/src/sources/clinvar.rs
+++ b/crates/fastvep-sa/src/sources/clinvar.rs
@@ -3,7 +3,7 @@
 //! Parses ClinVar's VCF release to extract clinical significance,
 //! review status, disease names, and accession numbers.
 
-use crate::common::AnnotationRecord;
+use crate::common::{escape_json, AnnotationRecord};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
@@ -179,14 +179,6 @@ fn normalize_chrom(chrom: &str) -> String {
     } else {
         format!("chr{}", chrom)
     }
-}
-
-fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
 }
 
 #[cfg(test)]

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -156,6 +156,15 @@ where
                     .or_insert_with(|| v.sig.clone());
             }
 
+            // Sort before serializing: HashMap iteration order is
+            // unspecified, so without this the proteinVariants array order
+            // (and thus the on-disk .oga bytes) would vary run-to-run for
+            // identical input, breaking build reproducibility/diffing.
+            let mut unique: Vec<_> = unique.into_iter().collect();
+            unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
+                pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
+            });
+
             let variant_jsons: Vec<String> = unique
                 .iter()
                 .map(|((pos, ref_aa, alt_aa), sig)| {
@@ -252,6 +261,15 @@ where
                     .entry((v.pos, v.ref_aa.clone(), v.alt_aa.clone()))
                     .or_insert_with(|| v.sig.clone());
             }
+            // Sort before serializing: HashMap iteration order is
+            // unspecified, so without this the proteinVariants array order
+            // (and thus the on-disk .oga bytes) would vary run-to-run for
+            // identical input, breaking build reproducibility/diffing.
+            let mut unique: Vec<_> = unique.into_iter().collect();
+            unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
+                pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
+            });
+
             let variant_jsons: Vec<String> = unique
                 .iter()
                 .map(|((pos, ref_aa, alt_aa), sig)| {
@@ -449,5 +467,42 @@ mod tests {
         assert!(brca1.json.contains("\"refAa\":\"D\""));
         assert!(brca1.json.contains("\"altAa\":\"H\""));
         assert!(brca1.json.contains("\"sig\":\"Pathogenic\""));
+    }
+
+    #[test]
+    fn test_parse_clinvar_protein_variant_order_is_deterministic() {
+        // A gene with several distinct protein variants must always
+        // serialize proteinVariants in the same (sorted-by-position) order
+        // regardless of HashMap iteration order — otherwise the .oga bytes
+        // would vary run-to-run for identical input.
+        let header = "#AlleleID\tType\tName\tGeneID\tGeneSymbol\tHGNC_ID\tClinicalSignificance\tClinSigSimple\tLastEvaluated\tRS# (dbSNP)\tnsv/esv (dbVar)\tRCVaccession\tPhenotypeIDS\tPhenotypeList\tOrigin\tOriginSimple\tAssembly\tChromosomeAccession\tChromosome\tStart\tStop\tReferenceAllele\tAlternateAllele\tCytogenetic\tReviewStatus\tNumberSubmitters\tGuidelines\tTestedInGTR\tOtherIDs\tSubmitterCategories\tVariationID\tPositionVCF\tReferenceAlleleVCF\tAlternateAlleleVCF\tSomaticClinicalImpact\tSomaticClinicalImpactLastEvaluated\tReviewStatusClinicalImpact\tOncogenicity\tOncogenicityLastEvaluated\tReviewStatusOncogenicity";
+        let mut rows = vec![header.to_string()];
+        // Deliberately out of position order in the input.
+        for (variation_id, pos_aa) in [(1, "p.Arg175His"), (2, "p.Gly245Ser"), (3, "p.Cys135Tyr"), (4, "p.Arg273Cys")] {
+            rows.push(format!(
+                "{vid}\tsingle nucleotide variant\tNM_000546.6(TP53):c.1A>T ({pos_aa})\t7157\tTP53\tHGNC:11998\tPathogenic\t1\t-\t-\t-\tRCV000\t-\t-\tgermline\tgermline\tGRCh38\tNC_000017.11\t17\t1\t1\tG\tA\t17p13.1\tcriteria provided, multiple submitters, no conflicts\t5\t-\t-\t-\t1\t{vid}\t1\tG\tA\t-\t-\t-\t-\t-\t-",
+                vid = variation_id,
+                pos_aa = pos_aa,
+            ));
+        }
+        let data = rows.join("\n") + "\n";
+
+        let first = parse_clinvar_protein_vcf(data.as_bytes()).unwrap();
+        let second = parse_clinvar_protein_vcf(data.as_bytes()).unwrap();
+        assert_eq!(
+            first[0].json, second[0].json,
+            "identical input must produce byte-identical proteinVariants ordering across runs"
+        );
+
+        let tp53 = first.iter().find(|r| r.gene_symbol == "TP53").unwrap();
+        let pos_135 = tp53.json.find("\"pos\":135").unwrap();
+        let pos_175 = tp53.json.find("\"pos\":175").unwrap();
+        let pos_245 = tp53.json.find("\"pos\":245").unwrap();
+        let pos_273 = tp53.json.find("\"pos\":273").unwrap();
+        assert!(
+            pos_135 < pos_175 && pos_175 < pos_245 && pos_245 < pos_273,
+            "proteinVariants must be sorted by position: {}",
+            tp53.json
+        );
     }
 }

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -17,6 +17,42 @@ struct ProteinVariant {
     sig: String,
 }
 
+/// Serialize one gene's protein variants into a `GeneRecord`.
+///
+/// Dedups by `(pos, ref_aa, alt_aa)`, then sorts before serializing: HashMap
+/// iteration order is unspecified, so without the sort the `proteinVariants`
+/// array order (and thus the on-disk `.oga` bytes) would vary run-to-run for
+/// identical input, breaking build reproducibility/diffing. Shared by both the
+/// VCF and variant_summary parse paths so the two stay byte-for-byte identical.
+fn serialize_gene_record(gene: String, variants: &[ProteinVariant]) -> GeneRecord {
+    let mut unique: HashMap<(u64, String, String), String> = HashMap::new();
+    for v in variants {
+        unique
+            .entry((v.pos, v.ref_aa.clone(), v.alt_aa.clone()))
+            .or_insert_with(|| v.sig.clone());
+    }
+
+    let mut unique: Vec<_> = unique.into_iter().collect();
+    unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
+        pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
+    });
+
+    let variant_jsons: Vec<String> = unique
+        .iter()
+        .map(|((pos, ref_aa, alt_aa), sig)| {
+            format!(
+                r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"}}"#,
+                pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig)
+            )
+        })
+        .collect();
+
+    GeneRecord {
+        gene_symbol: gene,
+        json: format!(r#"{{"proteinVariants":[{}]}}"#, variant_jsons.join(",")),
+    }
+}
+
 /// Parse a ClinVar source (VCF or variant_summary.txt.gz) and produce
 /// gene-level records of pathogenic/likely-pathogenic missense variants
 /// indexed by protein position. Auto-detects format from the header line:
@@ -147,41 +183,7 @@ where
     // Convert to GeneRecords
     let mut records: Vec<GeneRecord> = gene_variants
         .into_iter()
-        .map(|(gene, variants)| {
-            // Deduplicate by (pos, ref_aa, alt_aa)
-            let mut unique: HashMap<(u64, String, String), String> = HashMap::new();
-            for v in &variants {
-                unique
-                    .entry((v.pos, v.ref_aa.clone(), v.alt_aa.clone()))
-                    .or_insert_with(|| v.sig.clone());
-            }
-
-            // Sort before serializing: HashMap iteration order is
-            // unspecified, so without this the proteinVariants array order
-            // (and thus the on-disk .oga bytes) would vary run-to-run for
-            // identical input, breaking build reproducibility/diffing.
-            let mut unique: Vec<_> = unique.into_iter().collect();
-            unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
-                pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
-            });
-
-            let variant_jsons: Vec<String> = unique
-                .iter()
-                .map(|((pos, ref_aa, alt_aa), sig)| {
-                    format!(
-                        r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"}}"#,
-                        pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig)
-                    )
-                })
-                .collect();
-
-            let json = format!(r#"{{"proteinVariants":[{}]}}"#, variant_jsons.join(","));
-
-            GeneRecord {
-                gene_symbol: gene,
-                json,
-            }
-        })
+        .map(|(gene, variants)| serialize_gene_record(gene, &variants))
         .collect();
 
     records.sort_by(|a, b| a.gene_symbol.cmp(&b.gene_symbol));
@@ -254,37 +256,7 @@ where
 
     let mut records: Vec<GeneRecord> = gene_variants
         .into_iter()
-        .map(|(gene, variants)| {
-            let mut unique: HashMap<(u64, String, String), String> = HashMap::new();
-            for v in &variants {
-                unique
-                    .entry((v.pos, v.ref_aa.clone(), v.alt_aa.clone()))
-                    .or_insert_with(|| v.sig.clone());
-            }
-            // Sort before serializing: HashMap iteration order is
-            // unspecified, so without this the proteinVariants array order
-            // (and thus the on-disk .oga bytes) would vary run-to-run for
-            // identical input, breaking build reproducibility/diffing.
-            let mut unique: Vec<_> = unique.into_iter().collect();
-            unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
-                pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
-            });
-
-            let variant_jsons: Vec<String> = unique
-                .iter()
-                .map(|((pos, ref_aa, alt_aa), sig)| {
-                    format!(
-                        r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"}}"#,
-                        pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig)
-                    )
-                })
-                .collect();
-            let json = format!(r#"{{"proteinVariants":[{}]}}"#, variant_jsons.join(","));
-            GeneRecord {
-                gene_symbol: gene,
-                json,
-            }
-        })
+        .map(|(gene, variants)| serialize_gene_record(gene, &variants))
         .collect();
     records.sort_by(|a, b| a.gene_symbol.cmp(&b.gene_symbol));
     Ok(records)

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -3,7 +3,7 @@
 //! Parses ClinVar VCF to extract protein-level data for pathogenic/likely-pathogenic
 //! missense variants, enabling PS1, PM5, and PM1 (hotspot) ACMG criteria evaluation.
 
-use crate::common::GeneRecord;
+use crate::common::{escape_json, GeneRecord};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
@@ -170,7 +170,7 @@ where
                 .map(|((pos, ref_aa, alt_aa), sig)| {
                     format!(
                         r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"}}"#,
-                        pos, ref_aa, alt_aa, sig
+                        pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig)
                     )
                 })
                 .collect();
@@ -275,7 +275,7 @@ where
                 .map(|((pos, ref_aa, alt_aa), sig)| {
                     format!(
                         r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"}}"#,
-                        pos, ref_aa, alt_aa, sig
+                        pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig)
                     )
                 })
                 .collect();

--- a/crates/fastvep-sa/src/sources/cosmic.rs
+++ b/crates/fastvep-sa/src/sources/cosmic.rs
@@ -54,11 +54,15 @@ pub fn parse_cosmic_vcf<R: BufRead>(
             if !id.is_empty() && id != "." {
                 parts.push(format!("\"id\":\"{}\"", escape_json(id)));
             }
-            if !gene.is_empty() {
+            if !gene.is_empty() && gene != "." {
                 parts.push(format!("\"gene\":\"{}\"", escape_json(&gene)));
             }
-            if !cnt.is_empty() {
-                parts.push(format!("\"count\":{}", cnt));
+            // CNT is written unquoted, so it must be a validated integer —
+            // the VCF missing-value sentinel "." (or any other garbage)
+            // would otherwise land in the JSON as a bare, unquoted token
+            // and break every downstream serde_json::from_str on this record.
+            if let Ok(count) = cnt.parse::<u64>() {
+                parts.push(format!("\"count\":{}", count));
             }
 
             records.push(AnnotationRecord {
@@ -116,5 +120,23 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&records[0].json)
             .expect("COSMIC record must be valid JSON even with quotes/backslashes in GENE");
         assert_eq!(parsed["gene"], "WEIRD\"GENE\\NAME");
+    }
+
+    #[test]
+    fn test_parse_cosmic_missing_value_sentinel_is_omitted_not_emitted_raw() {
+        // GENE="." (unmapped/intergenic) and CNT="." (missing count) are
+        // VCF's missing-value sentinel, not real values. GENE="." must not
+        // be stored as a literal gene symbol, and CNT="." must not be
+        // written unquoted into JSON (which would make it invalid).
+        let vcf = "#header\n1\t10001\tCOSV123\tA\tG\t.\t.\tGENE=.;CNT=.\n";
+        let mut m = HashMap::new();
+        m.insert("chr1".into(), 0u16);
+        let records = parse_cosmic_vcf(vcf.as_bytes(), &m).unwrap();
+        assert_eq!(records.len(), 1);
+        let json = &records[0].json;
+        let _parsed: serde_json::Value =
+            serde_json::from_str(json).expect("record must still be valid JSON: {json}");
+        assert!(!json.contains("gene"), "GENE=. must be omitted: {json}");
+        assert!(!json.contains("count"), "CNT=. must be omitted: {json}");
     }
 }

--- a/crates/fastvep-sa/src/sources/cosmic.rs
+++ b/crates/fastvep-sa/src/sources/cosmic.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracts somatic mutation data from COSMIC's coding mutations file.
 
-use crate::common::AnnotationRecord;
+use crate::common::{escape_json, AnnotationRecord};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
@@ -52,10 +52,10 @@ pub fn parse_cosmic_vcf<R: BufRead>(
 
             let mut parts = Vec::new();
             if !id.is_empty() && id != "." {
-                parts.push(format!("\"id\":\"{}\"", id));
+                parts.push(format!("\"id\":\"{}\"", escape_json(id)));
             }
             if !gene.is_empty() {
-                parts.push(format!("\"gene\":\"{}\"", gene));
+                parts.push(format!("\"gene\":\"{}\"", escape_json(&gene)));
             }
             if !cnt.is_empty() {
                 parts.push(format!("\"count\":{}", cnt));
@@ -102,5 +102,19 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert!(records[0].json.contains("COSV123"));
         assert!(records[0].json.contains("TP53"));
+    }
+
+    #[test]
+    fn test_parse_cosmic_escapes_gene_field_for_valid_json() {
+        // A GENE value containing a double quote or backslash must not
+        // produce invalid JSON in the .osa record.
+        let vcf = "#header\n1\t10001\tCOSV123\tA\tG\t.\t.\tGENE=WEIRD\"GENE\\NAME;CNT=1\n";
+        let mut m = HashMap::new();
+        m.insert("chr1".into(), 0u16);
+        let records = parse_cosmic_vcf(vcf.as_bytes(), &m).unwrap();
+        assert_eq!(records.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&records[0].json)
+            .expect("COSMIC record must be valid JSON even with quotes/backslashes in GENE");
+        assert_eq!(parsed["gene"], "WEIRD\"GENE\\NAME");
     }
 }

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -73,17 +73,17 @@ impl<R: BufRead> Iterator for DbsnpRecordIter<'_, R> {
             let alt_field = fields[4];
             let info = fields[7];
 
+            let info_map = parse_info(info);
+
             let rs_id = if id.starts_with("rs") {
                 id.to_string()
             } else {
-                let info_map = parse_info(info);
                 match info_map.get("RS") {
                     Some(rs) => format!("rs{}", rs),
                     None => continue,
                 }
             };
 
-            let info_map = parse_info(info);
             // dbSNP's CAF is `ref_freq,alt1_freq,alt2_freq,...` in ALT order
             // (i.e. index i+1 is the frequency for the i-th ALT); index it
             // per-alt below rather than once, or every ALT past the first in

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -84,15 +84,21 @@ impl<R: BufRead> Iterator for DbsnpRecordIter<'_, R> {
             };
 
             let info_map = parse_info(info);
-            let freq = info_map.get("CAF").and_then(|caf| {
-                let parts: Vec<&str> = caf.split(',').collect();
-                parts.get(1).and_then(|s| s.parse::<f64>().ok())
-            });
+            // dbSNP's CAF is `ref_freq,alt1_freq,alt2_freq,...` in ALT order
+            // (i.e. index i+1 is the frequency for the i-th ALT); index it
+            // per-alt below rather than once, or every ALT past the first in
+            // a multi-allelic record gets the first ALT's frequency.
+            let caf_parts: Option<Vec<&str>> =
+                info_map.get("CAF").map(|caf| caf.split(',').collect());
 
-            for alt in alt_field.split(',') {
+            for (i, alt) in alt_field.split(',').enumerate() {
                 if alt == "." || alt == "*" {
                     continue;
                 }
+                let freq = caf_parts
+                    .as_ref()
+                    .and_then(|parts| parts.get(i + 1))
+                    .and_then(|s| s.parse::<f64>().ok());
                 let mut parts = vec![format!("\"id\":\"{}\"", rs_id)];
                 if let Some(f) = freq {
                     parts.push(format!("\"globalMaf\":{:.6e}", f));
@@ -170,6 +176,28 @@ mod tests {
         assert_eq!(records[1].position, 10039);
         assert!(records[1].json.contains("rs978760828"));
         assert!(!records[1].json.contains("globalMaf")); // No CAF
+    }
+
+    #[test]
+    fn test_parse_dbsnp_multiallelic_caf_indexed_per_alt() {
+        // CAF=ref_freq,alt1_freq,alt2_freq — each ALT must get its own
+        // frequency, not the first ALT's frequency repeated for every ALT.
+        let vcf = "\
+##fileformat=VCFv4.0
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t10019\trs1\tA\tC,T\t.\t.\tRS=1;CAF=0.90,0.08,0.02
+";
+        let mut chrom_map = HashMap::new();
+        chrom_map.insert("chr1".to_string(), 0u16);
+
+        let records = parse_dbsnp_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        assert_eq!(records.len(), 2);
+
+        let c = records.iter().find(|r| r.alt_allele == "C").unwrap();
+        assert!(c.json.contains("8.000000e-2"), "C should get CAF index 1 (0.08): {}", c.json);
+
+        let t = records.iter().find(|r| r.alt_allele == "T").unwrap();
+        assert!(t.json.contains("2.000000e-2"), "T should get CAF index 2 (0.02), not C's frequency: {}", t.json);
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/mitomap.rs
+++ b/crates/fastvep-sa/src/sources/mitomap.rs
@@ -1,6 +1,6 @@
 //! MitoMap mitochondrial variant parser.
 
-use crate::common::AnnotationRecord;
+use crate::common::{escape_json, AnnotationRecord};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
@@ -44,10 +44,6 @@ pub fn parse_mitomap<R: BufRead>(
     }
     records.sort_by_key(|r| r.position);
     Ok(records)
-}
-
-fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]

--- a/crates/fastvep-sa/src/sources/omim.rs
+++ b/crates/fastvep-sa/src/sources/omim.rs
@@ -16,7 +16,7 @@
 //! `has_dominant_inheritance()` and as a disease-gene fallback when
 //! gnomAD constraints don't cross the LOF threshold.
 
-use crate::common::GeneRecord;
+use crate::common::{escape_json, GeneRecord};
 use anyhow::{Context, Result};
 use std::io::BufRead;
 
@@ -82,12 +82,6 @@ pub fn parse_omim_genemap<R: BufRead>(reader: R) -> Result<Vec<GeneRecord>> {
     }
 
     Ok(records)
-}
-
-fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
 }
 
 #[cfg(test)]

--- a/crates/fastvep-sa/src/sources/omim.rs
+++ b/crates/fastvep-sa/src/sources/omim.rs
@@ -22,9 +22,9 @@ use std::io::BufRead;
 
 /// Parse OMIM genemap2.txt into GeneRecords.
 ///
-/// Format: tab-separated with columns including:
-/// - Column 5: Gene Symbols (may have comma-separated aliases)
-/// - Column 8: MIM Number
+/// Format: tab-separated (0-indexed columns) with columns including:
+/// - Column 5: MIM Number
+/// - Column 8: Approved Gene Symbol (may be blank for phenotype/QTL-only rows)
 /// - Column 12: Phenotypes (semicolon-separated, each with MIM and inheritance)
 pub fn parse_omim_genemap<R: BufRead>(reader: R) -> Result<Vec<GeneRecord>> {
     let mut records = Vec::new();
@@ -40,8 +40,8 @@ pub fn parse_omim_genemap<R: BufRead>(reader: R) -> Result<Vec<GeneRecord>> {
             continue;
         }
 
-        let gene_symbols = fields[5]; // Approved Gene Symbol
-        let mim_number = fields[5 + 3]; // MIM Number (column 8, 0-indexed)
+        let mim_number = fields[5]; // MIM Number
+        let gene_symbols = fields[8]; // Approved Gene Symbol
 
         // Use the primary (first) gene symbol
         let gene_symbol = gene_symbols.split(',').next().unwrap_or("").trim();
@@ -96,15 +96,31 @@ mod tests {
 
     #[test]
     fn test_parse_omim() {
-        // Simplified genemap2 format
+        // Real genemap2.txt column layout (0-indexed):
+        // 0 Chromosome | 1 Genomic Position Start | 2 Genomic Position End |
+        // 3 Cyto Location | 4 Computed Cyto Location | 5 MIM Number |
+        // 6 Gene/Locus And Other Related Symbols | 7 Gene Name |
+        // 8 Approved Gene Symbol | 9 Entrez Gene ID | 10 Ensembl Gene ID |
+        // 11 Comments | 12 Phenotypes | 13 Mouse Gene Symbol/ID
         let data = "# Generated\n\
                      # Copyright OMIM\n\
-                     1\tp36.33\t1:10001-20000\tGene1\t\tBRCA1\tprotein\t\t113705\t\t\t\tBreast cancer, 114480 (3), Autosomal dominant; Ovarian cancer, 167000 (3)\n";
+                     chr17\t43044295\t43125483\t17q21.31\t\t113705\tBRCA1,RNF53\tBreast cancer 1, early onset\tBRCA1\t672\tENSG00000012048\t\tBreast cancer, 114480 (3), Autosomal dominant; Ovarian cancer, 167000 (3)\t\n";
 
         let records = parse_omim_genemap(data.as_bytes()).unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].gene_symbol, "BRCA1");
         assert!(records[0].json.contains("113705"));
         assert!(records[0].json.contains("Breast cancer"));
+    }
+
+    #[test]
+    fn test_parse_omim_skips_rows_without_approved_symbol() {
+        // QTL/phenotype-only rows have no Approved Gene Symbol (column 8)
+        // but do have MIM Number and aliases; they should be skipped rather
+        // than mis-keyed under an alias or MIM number.
+        let data = "chr1\t1\t27600000\t1p36\t\t612367\tALPQTL2\tAlkaline phosphatase, plasma level of, QTL 2\t\t100196914\t\t\t\t\n";
+
+        let records = parse_omim_genemap(data.as_bytes()).unwrap();
+        assert!(records.is_empty());
     }
 }

--- a/crates/fastvep-sa/src/sources/omim.rs
+++ b/crates/fastvep-sa/src/sources/omim.rs
@@ -53,8 +53,12 @@ pub fn parse_omim_genemap<R: BufRead>(reader: R) -> Result<Vec<GeneRecord>> {
 
         let mut parts = Vec::new();
 
-        if !mim_number.is_empty() && mim_number != "." {
-            parts.push(format!("\"mimNumber\":{}", mim_number));
+        // MIM Number is emitted unquoted as a JSON number, so it must be a
+        // validated integer — a blank, "." sentinel, or any non-numeric junk
+        // in column 5 would otherwise land in the JSON as a bare token and
+        // break every downstream serde_json::from_str on this record.
+        if let Ok(mim) = mim_number.parse::<u64>() {
+            parts.push(format!("\"mimNumber\":{}", mim));
         }
 
         if !phenotypes_raw.is_empty() && phenotypes_raw != "." {
@@ -116,5 +120,21 @@ mod tests {
 
         let records = parse_omim_genemap(data.as_bytes()).unwrap();
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn test_parse_omim_non_numeric_mim_produces_valid_json() {
+        // mimNumber is emitted unquoted, so a non-numeric column-5 value must
+        // be dropped rather than written as a bare token (which would make the
+        // record invalid JSON). The record should still be emitted from its
+        // phenotypes, just without a mimNumber field.
+        let data = "chr17\t1\t2\t17q21.31\t\tNOTANUMBER\tBRCA1\tBreast cancer 1\tBRCA1\t672\tENSG0\t\tBreast cancer, 114480 (3), Autosomal dominant\t\n";
+
+        let records = parse_omim_genemap(data.as_bytes()).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].gene_symbol, "BRCA1");
+        assert!(!records[0].json.contains("mimNumber"), "non-numeric MIM must be omitted: {}", records[0].json);
+        // The emitted JSON must be parseable.
+        let _: serde_json::Value = serde_json::from_str(&records[0].json).expect("record must be valid JSON");
     }
 }

--- a/crates/fastvep-sa/src/sources/scores.rs
+++ b/crates/fastvep-sa/src/sources/scores.rs
@@ -3,79 +3,110 @@
 //! These parsers produce positional AnnotationRecords where the JSON is
 //! just the numeric score value as a string. The SaWriter stores them
 //! as positional annotations (match_by_allele=false, is_positional=true).
+//!
+//! PhyloP/GERP are per-base, genome-wide sources (~3 billion positions for
+//! hg38) — denser than any VCF-based source. Use `iter_score_tsv` /
+//! `iter_wigfix` for streaming builds; `parse_score_tsv` / `parse_wigfix`
+//! buffer everything in memory and are retained for tests and small inputs.
 
 use crate::common::AnnotationRecord;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
 
-/// Parse a tab-separated score file (chrom, pos, score) into AnnotationRecords.
+/// Stream a tab-separated score file (chrom, pos, score) as `AnnotationRecord`s
+/// without buffering the whole file in memory.
 ///
 /// Supports formats like:
 /// - BED-like: `chr1\t12345\t12346\t2.345`  (4 columns: chrom, start, end, score)
 /// - Simple:   `chr1\t12345\t2.345`          (3 columns: chrom, pos, score)
 ///
 /// Positions are 0-based in BED format (converted to 1-based internally)
-/// or 1-based in simple format. Set `zero_based` accordingly.
+/// or 1-based in simple format. Set `zero_based` accordingly. The input must
+/// already be sorted by chromosome and position.
+pub fn iter_score_tsv<R: BufRead>(
+    reader: R,
+    chrom_to_idx: &HashMap<String, u16>,
+    zero_based: bool,
+) -> ScoreTsvIter<'_, R> {
+    ScoreTsvIter { lines: reader.lines(), chrom_to_idx, zero_based }
+}
+
+pub struct ScoreTsvIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    zero_based: bool,
+}
+
+impl<R: BufRead> Iterator for ScoreTsvIter<'_, R> {
+    type Item = Result<AnnotationRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let line = match self.lines.next()? {
+                Ok(l) => l,
+                Err(e) => return Some(Err(e).context("Reading score TSV line")),
+            };
+            if line.starts_with('#') || line.starts_with("track") || line.is_empty() {
+                continue;
+            }
+
+            let fields: Vec<&str> = line.split('\t').collect();
+
+            let (chrom_str, pos_str, score_str) = match fields.len() {
+                // BED 4-column: chrom, start (0-based), end, score
+                4.. => (fields[0], fields[1], fields[3]),
+                // Simple 3-column: chrom, pos, score
+                3 => (fields[0], fields[1], fields[2]),
+                _ => continue,
+            };
+
+            let chrom = normalize_chrom(chrom_str);
+            let chrom_idx = match self.chrom_to_idx.get(&chrom) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+
+            let pos: u32 = match pos_str.parse::<u32>() {
+                Ok(p) => {
+                    if self.zero_based { p + 1 } else { p }
+                }
+                Err(_) => continue,
+            };
+
+            let score: f64 = match score_str.trim().parse() {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            return Some(Ok(AnnotationRecord {
+                chrom_idx,
+                position: pos,
+                ref_allele: String::new(),
+                alt_allele: String::new(),
+                json: format_score(score),
+            }));
+        }
+    }
+}
+
+/// Parse a tab-separated score file into sorted `AnnotationRecord`s.
+///
+/// Loads all records into memory — suitable for tests and small inputs.
+/// For genome-wide sources use `iter_score_tsv` via the pipeline instead.
 pub fn parse_score_tsv<R: BufRead>(
     reader: R,
     chrom_to_idx: &HashMap<String, u16>,
     zero_based: bool,
 ) -> Result<Vec<AnnotationRecord>> {
-    let mut records = Vec::new();
-
-    for line in reader.lines() {
-        let line = line.context("Reading score TSV line")?;
-        if line.starts_with('#') || line.starts_with("track") || line.is_empty() {
-            continue;
-        }
-
-        let fields: Vec<&str> = line.split('\t').collect();
-
-        let (chrom_str, pos_str, score_str) = match fields.len() {
-            // BED 4-column: chrom, start (0-based), end, score
-            4.. => (fields[0], fields[1], fields[3]),
-            // Simple 3-column: chrom, pos, score
-            3 => (fields[0], fields[1], fields[2]),
-            _ => continue,
-        };
-
-        let chrom = normalize_chrom(chrom_str);
-        let chrom_idx = match chrom_to_idx.get(&chrom) {
-            Some(&idx) => idx,
-            None => continue,
-        };
-
-        let pos: u32 = match pos_str.parse::<u32>() {
-            Ok(p) => {
-                if zero_based { p + 1 } else { p }
-            }
-            Err(_) => continue,
-        };
-
-        // Validate score is a number
-        let score: f64 = match score_str.trim().parse() {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        // Format score compactly
-        let json = format_score(score);
-
-        records.push(AnnotationRecord {
-            chrom_idx,
-            position: pos,
-            ref_allele: String::new(),
-            alt_allele: String::new(),
-            json,
-        });
-    }
-
+    let mut records: Vec<_> =
+        iter_score_tsv(reader, chrom_to_idx, zero_based).collect::<Result<_>>()?;
     records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
     Ok(records)
 }
 
-/// Parse a UCSC wiggle fixed-step (wigFix) file into AnnotationRecords.
+/// Stream a UCSC wiggle fixed-step (wigFix) file as `AnnotationRecord`s
+/// without buffering the whole file in memory.
 ///
 /// Format:
 /// ```text
@@ -84,58 +115,85 @@ pub fn parse_score_tsv<R: BufRead>(
 /// -0.002
 /// ...
 /// ```
+///
+/// The input must already be sorted by chromosome (all standard UCSC
+/// per-chromosome releases are; concatenating them in chromosome order
+/// preserves this).
+pub fn iter_wigfix<R: BufRead>(reader: R, chrom_to_idx: &HashMap<String, u16>) -> WigFixIter<'_, R> {
+    WigFixIter { lines: reader.lines(), chrom_to_idx, current_chrom_idx: None, current_pos: 0, step: 1 }
+}
+
+pub struct WigFixIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    current_chrom_idx: Option<u16>,
+    current_pos: u32,
+    step: u32,
+}
+
+impl<R: BufRead> Iterator for WigFixIter<'_, R> {
+    type Item = Result<AnnotationRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let line = match self.lines.next()? {
+                Ok(l) => l,
+                Err(e) => return Some(Err(e).context("Reading wigFix line")),
+            };
+
+            if line.starts_with("fixedStep") {
+                // Parse header: fixedStep chrom=chr1 start=10001 step=1
+                let mut chrom = None;
+                let mut start = None;
+                self.step = 1;
+
+                for part in line.split_whitespace().skip(1) {
+                    if let Some((key, val)) = part.split_once('=') {
+                        match key {
+                            "chrom" => chrom = Some(normalize_chrom(val)),
+                            "start" => start = val.parse().ok(),
+                            "step" => self.step = val.parse().unwrap_or(1),
+                            _ => {}
+                        }
+                    }
+                }
+
+                self.current_chrom_idx = chrom.as_ref().and_then(|c| self.chrom_to_idx.get(c)).copied();
+                self.current_pos = start.unwrap_or(1);
+                continue;
+            }
+
+            if line.starts_with('#') || line.starts_with("track") || line.is_empty() {
+                continue;
+            }
+
+            if let Some(chrom_idx) = self.current_chrom_idx {
+                let pos = self.current_pos;
+                self.current_pos += self.step;
+                if let Ok(score) = line.trim().parse::<f64>() {
+                    return Some(Ok(AnnotationRecord {
+                        chrom_idx,
+                        position: pos,
+                        ref_allele: String::new(),
+                        alt_allele: String::new(),
+                        json: format_score(score),
+                    }));
+                }
+                continue;
+            }
+        }
+    }
+}
+
+/// Parse a UCSC wiggle fixed-step (wigFix) file into sorted AnnotationRecords.
+///
+/// Loads all records into memory — suitable for tests and small inputs.
+/// For genome-wide builds use `iter_wigfix` via the pipeline instead.
 pub fn parse_wigfix<R: BufRead>(
     reader: R,
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
-    let mut records = Vec::new();
-    let mut current_chrom_idx: Option<u16> = None;
-    let mut current_pos: u32 = 0;
-    let mut step: u32 = 1;
-
-    for line in reader.lines() {
-        let line = line.context("Reading wigFix line")?;
-
-        if line.starts_with("fixedStep") {
-            // Parse header: fixedStep chrom=chr1 start=10001 step=1
-            let mut chrom = None;
-            let mut start = None;
-            step = 1;
-
-            for part in line.split_whitespace().skip(1) {
-                if let Some((key, val)) = part.split_once('=') {
-                    match key {
-                        "chrom" => chrom = Some(normalize_chrom(val)),
-                        "start" => start = val.parse().ok(),
-                        "step" => step = val.parse().unwrap_or(1),
-                        _ => {}
-                    }
-                }
-            }
-
-            current_chrom_idx = chrom.as_ref().and_then(|c| chrom_to_idx.get(c)).copied();
-            current_pos = start.unwrap_or(1);
-            continue;
-        }
-
-        if line.starts_with('#') || line.starts_with("track") || line.is_empty() {
-            continue;
-        }
-
-        if let Some(chrom_idx) = current_chrom_idx {
-            if let Ok(score) = line.trim().parse::<f64>() {
-                records.push(AnnotationRecord {
-                    chrom_idx,
-                    position: current_pos,
-                    ref_allele: String::new(),
-                    alt_allele: String::new(),
-                    json: format_score(score),
-                });
-            }
-            current_pos += step;
-        }
-    }
-
+    let mut records: Vec<_> = iter_wigfix(reader, chrom_to_idx).collect::<Result<_>>()?;
     records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
     Ok(records)
 }

--- a/data/benchmark/sa_sources/clingen_gdv_to_oga.py
+++ b/data/benchmark/sa_sources/clingen_gdv_to_oga.py
@@ -18,8 +18,11 @@ Includes only `Definitive`, `Strong`, `Moderate` ClinGen classifications
 Relationship`) to align with the SVI-recommended evidence threshold.
 
 Output is tab-separated with 13 columns matching the subset
-`parse_omim_genemap` reads (col 5: gene symbol, col 8: identifier,
-col 12: phenotype list joined with ";").
+`parse_omim_genemap` reads (col 5: MIM number / identifier, col 8:
+Approved Gene Symbol, col 12: phenotype list joined with ";") — this
+must match the real genemap2.txt column layout, since that's what
+`parse_omim_genemap` parses (see issue #64: these two columns were
+previously swapped in both the parser and this script).
 """
 
 import csv
@@ -63,12 +66,12 @@ def main():
         # starting with '#'.
         out.write(
             "# Synthetic genemap2 from ClinGen Gene-Disease Validity\n"
-            "# col5=gene_symbol, col8=mim_proxy (always 0), col12=phenotypes\n"
+            "# col5=mim_proxy (always 0), col8=gene_symbol, col12=phenotypes\n"
         )
         for gene, phenotypes in sorted(by_gene.items()):
             cols = [""] * 13
-            cols[5] = gene
-            cols[8] = "0"  # MIM proxy; classifier only checks col 12 non-emptiness
+            cols[5] = "0"  # MIM proxy; classifier only checks col 12 non-emptiness
+            cols[8] = gene
             cols[12] = "; ".join(phenotypes)
             out.write("\t".join(cols) + "\n")
 

--- a/docs/ACMG_SETUP.md
+++ b/docs/ACMG_SETUP.md
@@ -181,7 +181,15 @@ fastvep sa-build --source phylop -i hg38.phyloP100way.wigFix.gz -o phylop --asse
 # 1. Download from https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/
 #    Convert to TSV: chrom, pos, score (one row per position)
 
-# 2. Build
+# 2. Build. Like phyloP, GERP (and DANN) is a per-base genome-wide source and
+#    streams straight into the index, so the TSV must already be sorted by
+#    CHROMOSOME in fastvep's internal order — chr1..chr22, then X, Y, M — and by
+#    position within each chromosome, or the build aborts with a "not sorted"
+#    error. A naive `sort -k1,1 -k2,2n` orders chromosomes LEXICOGRAPHICALLY
+#    (chr1, chr10, chr11, ..., chr2, ...) and is rejected; `sort -V` is closer
+#    but still misplaces chrM (before chrX). Safest is to emit/sort one file per
+#    chromosome and concatenate them in the order above (as with phyloP):
+#      for c in $(seq 1 22) X Y M; do sort -k2,2n "chr${c}.tsv"; done > gerp_scores.tsv
 fastvep sa-build --source gerp -i gerp_scores.tsv -o gerp --assembly GRCh38
 ```
 

--- a/docs/ACMG_SETUP.md
+++ b/docs/ACMG_SETUP.md
@@ -155,9 +155,19 @@ for c in $(seq 1 22) X Y M; do
   wget "https://hgdownload.cse.ucsc.edu/goldenpath/hg38/phyloP100way/hg38.100way.phyloP100way/chr${c}.phyloP100way.wigFix.gz"
 done
 
-# 2. Concatenate into a single multi-member gzip stream (fastvep reads gzip
-#    with MultiGzDecoder, so this is safe and avoids decompressing to disk)
-cat chr*.phyloP100way.wigFix.gz > hg38.phyloP100way.wigFix.gz
+# 2. Concatenate IN NUMERIC CHROMOSOME ORDER into a single multi-member
+#    gzip stream (fastvep reads gzip with MultiGzDecoder, so concatenating
+#    compressed members is safe and avoids decompressing to disk).
+#    IMPORTANT: `cat chr*.phyloP100way.wigFix.gz` sorts lexicographically
+#    (chr1, chr10, chr11, ..., chr2, chr20, ...), NOT in chromosome order —
+#    sa-build streams this file straight into the annotation index and
+#    requires it sorted by chromosome, so a lexicographic glob will build
+#    successfully but silently misorder chr2..chr9 and abort with a "not
+#    sorted" error. Reuse the same ordered loop as the download step:
+: > hg38.phyloP100way.wigFix.gz
+for c in $(seq 1 22) X Y M; do
+  cat "chr${c}.phyloP100way.wigFix.gz" >> hg38.phyloP100way.wigFix.gz
+done
 
 # 3. Build
 fastvep sa-build --source phylop -i hg38.phyloP100way.wigFix.gz -o phylop --assembly GRCh38

--- a/docs/ACMG_SETUP.md
+++ b/docs/ACMG_SETUP.md
@@ -149,10 +149,17 @@ fastvep sa-build --source dbnsfp -i dbNSFP4.5a.zip -o dbnsfp --assembly GRCh38
 Used by BP7 (conservation tier — `phylop_conserved` defaults to 2.0). The pre-PR1 PP3/BP4 consensus path that consumed PhyloP was removed; PhyloP is still surfaced in `details.phylop` for transparency. Position-level, not allele-level.
 
 ```bash
-# 1. Download (UCSC)
-wget https://hgdownload.cse.ucsc.edu/goldenpath/hg38/phyloP100way/hg38.phyloP100way.wigFix.gz
+# 1. Download (UCSC) — UCSC no longer publishes a single combined wigFix for
+#    hg38; scores are split one file per chromosome under hg38.100way.phyloP100way/
+for c in $(seq 1 22) X Y M; do
+  wget "https://hgdownload.cse.ucsc.edu/goldenpath/hg38/phyloP100way/hg38.100way.phyloP100way/chr${c}.phyloP100way.wigFix.gz"
+done
 
-# 2. Build
+# 2. Concatenate into a single multi-member gzip stream (fastvep reads gzip
+#    with MultiGzDecoder, so this is safe and avoids decompressing to disk)
+cat chr*.phyloP100way.wigFix.gz > hg38.phyloP100way.wigFix.gz
+
+# 3. Build
 fastvep sa-build --source phylop -i hg38.phyloP100way.wigFix.gz -o phylop --assembly GRCh38
 ```
 


### PR DESCRIPTION
## Summary

Health-check pass over `crates/fastvep-sa` and the `sa-build` pipeline. Two issues from the open-issue backlog, plus several latent correctness/reproducibility/memory bugs surfaced while auditing sibling source parsers.

**Highest-value fix:** #64 — `FV_OMIM` was silently empty for every variant. `parse_omim_genemap` read the gene symbol and MIM number from swapped `genemap2.txt` columns, so no gene symbol ever matched at annotation time despite `sa-build` reporting success. The existing integration test fixture had the *same* swapped layout baked in (its own comment even asserted the wrong columns), so it passed despite testing the bug's behavior — fixed both the parser and the fixture, with a new regression test for rows lacking an Approved Gene Symbol.

### Fixes
- **#64** — OMIM genemap2.txt gene symbol / MIM number column swap (`crates/fastvep-sa/src/sources/omim.rs`)
- **#62** — broken UCSC phyloP100way download URL in `docs/ACMG_SETUP.md` (UCSC now ships one file per chromosome, not a single combined download)
- **dbSNP multi-allelic MAF bug** — `CAF` is `ref_freq,alt1_freq,alt2_freq,...` in ALT order, but `globalMaf` was computed once from index 1 before the per-ALT loop, so every ALT past the first in a multi-allelic record got the first ALT's frequency. Same bug class as #64.
- **Missing JSON escaping** — COSMIC's `GENE`/`id` fields were interpolated into hand-built JSON with no escaping (unlike every sibling parser), so a `"`/`\` in a gene name silently produced invalid JSON in the `.osa`. Consolidated three inconsistent `escape_json` copies (mitomap/omim/clinvar) into one shared, complete implementation in `common.rs`.
- **Non-deterministic ClinVar-protein output** — `proteinVariants` was serialized straight from `HashMap` iteration order (unspecified), so two builds of the same `variant_summary.txt` could produce byte-different `.oga` files. Now sorted by `(pos, refAa, altAa)` before serializing.
- **PhyloP/GERP/DANN sa-build buffered the whole file in memory** — these are per-base, genome-wide sources (~3B positions for hg38), an order of magnitude denser than any VCF-based source; the VCF sources already got streaming treatment in #55 but these two were missed, and a real build would exhaust memory long before completing. Added `iter_score_tsv`/`iter_wigfix` streaming iterators and routed them through the existing `run_streaming_sa_build` helper.

### Testing
- Added/updated unit tests for every fix above (OMIM column layout, dbSNP multi-allelic CAF indexing, COSMIC escaping via `serde_json` round-trip, ClinVar-protein ordering determinism)
- Added an integration test exercising the streaming phyloP (wigFix) and GERP (TSV) build paths end-to-end through `run_sa_build`, reading back via `SaReader`
- `cargo test --workspace --lib` and `--tests`: all green (147+ tests across the workspace, no regressions)

## Test plan
- [x] `cargo test --workspace --lib`
- [x] `cargo test --workspace --tests`
- [x] Manual review of the OMIM fixture bug (confirmed real genemap2.txt column order from the issue report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBw9urSCvVafV9aSSkeQ5f)_