### PR TITLE
fastvep-loftee: LOFTEE loss-of-function annotation engine (#35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "fastvep-genome",
  "fastvep-hgvs",
  "fastvep-io",
+ "fastvep-loftee",
  "fastvep-sa",
  "flate2",
  "rayon",
@@ -502,6 +503,18 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
+]
+
+[[package]]
+name = "fastvep-loftee"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fastvep-cache",
+ "fastvep-core",
+ "fastvep-genome",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/fastvep-sa",
     "crates/fastvep-annotate",
     "crates/fastvep-classification",
+    "crates/fastvep-loftee",
     "crates/fastvep-cli",
     "crates/fastvep-web",
 ]
@@ -33,6 +34,7 @@ fastvep-filter = { path = "crates/fastvep-filter" }
 fastvep-sa = { path = "crates/fastvep-sa" }
 fastvep-annotate = { path = "crates/fastvep-annotate" }
 fastvep-classification = { path = "crates/fastvep-classification" }
+fastvep-loftee = { path = "crates/fastvep-loftee" }
 
 # External crates
 anyhow = "1"

--- a/crates/fastvep-annotate/Cargo.toml
+++ b/crates/fastvep-annotate/Cargo.toml
@@ -14,6 +14,7 @@ fastvep-hgvs = { workspace = true }
 fastvep-io = { workspace = true }
 fastvep-sa = { workspace = true }
 fastvep-classification = { workspace = true }
+fastvep-loftee = { workspace = true }
 
 anyhow = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -50,6 +50,8 @@ pub struct AnnotationContext {
     pub gene_providers: Vec<fastvep_sa::gene::GeneIndex>,
     /// ACMG-AMP classification configuration (None = disabled).
     pub acmg_config: Option<fastvep_classification::AcmgConfig>,
+    /// LOFTEE loss-of-function annotation configuration (None = disabled).
+    pub loftee_config: Option<fastvep_loftee::LofteeConfig>,
 }
 
 impl AnnotationContext {
@@ -192,6 +194,7 @@ impl AnnotationContext {
             sa_providers,
             gene_providers,
             acmg_config: None,
+            loftee_config: None,
         })
     }
 
@@ -363,6 +366,7 @@ impl AnnotationContext {
                                 polyphen: None,
                                 supplementary: Vec::new(),
                                 acmg_classification: None,
+                                loftee: None,
                             };
 
                             if self.hgvs {
@@ -723,6 +727,55 @@ impl AnnotationContext {
                 }
             }
 
+            // LOFTEE loss-of-function annotation pass
+            if let Some(ref loftee_cfg) = self.loftee_config {
+                for tv in &mut vf.transcript_variations {
+                    // Only process protein-coding transcripts
+                    if tv.biotype.as_ref() != "protein_coding" {
+                        continue;
+                    }
+                    // Look up the transcript model from overlapping set
+                    let transcript = overlapping
+                        .iter()
+                        .find(|t| t.stable_id == tv.transcript_id);
+                    let transcript = match transcript {
+                        Some(t) => t,
+                        None => continue,
+                    };
+                    for aa in &mut tv.allele_annotations {
+                        if fastvep_loftee::has_lof_consequence(&aa.consequences) {
+                            let allele_str = aa.allele.to_string();
+                            let ref_str = vf.ref_allele.to_string();
+                            let input = fastvep_loftee::LofteeInput {
+                                transcript,
+                                consequences: &aa.consequences,
+                                exon: aa.exon,
+                                intron: aa.intron,
+                                cds_end: aa.cds_position.map(|(_, e)| e),
+                                variant_start: vf.position.start,
+                                variant_end: vf.position.end,
+                                allele: &allele_str,
+                                ref_allele: &ref_str,
+                                flags: &tv.flags,
+                            };
+                            let result = fastvep_loftee::evaluate(
+                                &input,
+                                loftee_cfg,
+                                self.seq_provider.as_deref(),
+                            );
+                            if !result.confidence.is_empty() {
+                                aa.loftee = Some(fastvep_io::variant::LofteeResult {
+                                    confidence: result.confidence,
+                                    filters: result.filters,
+                                    flags: result.flags,
+                                    info: result.info,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
             // ACMG-AMP classification pass (after all SA annotations are attached)
             if let Some(acmg_cfg) = acmg_config {
                 // Parse sample genotypes if trio config is present
@@ -806,6 +859,7 @@ pub fn annotate_sa_only_scaffold(vf: &mut VariationFeature) {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: fastvep_core::Strand::Forward,
@@ -852,6 +906,7 @@ pub fn annotate_intergenic(vf: &mut VariationFeature) {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: fastvep_core::Strand::Forward,

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -717,6 +717,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                             polyphen: None,
                             supplementary: Vec::new(),
                             acmg_classification: None,
+                            loftee: None,
                         };
 
                         // Generate HGVS if requested

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -176,6 +176,29 @@ fn format_csq_entry_into(
                     }
                 }
             }
+            "LoF" => {
+                if let Some(ref loftee) = aa.loftee {
+                    buf.push_str(&loftee.confidence);
+                }
+            }
+            "LoF_filter" => {
+                if let Some(ref loftee) = aa.loftee {
+                    buf.push_str(&loftee.filters.join("&"));
+                }
+            }
+            "LoF_flags" => {
+                if let Some(ref loftee) = aa.loftee {
+                    buf.push_str(&loftee.flags.join("&"));
+                }
+            }
+            "LoF_info" => {
+                if let Some(ref loftee) = aa.loftee {
+                    let info_str: Vec<String> = loftee.info.iter()
+                        .map(|(k, v)| format!("{}:{}", k, v))
+                        .collect();
+                    buf.push_str(&info_str.join("&"));
+                }
+            }
             "ACMG_CRITERIA" => {
                 if let Some(ref acmg) = aa.acmg_classification {
                     if let Some(criteria) = acmg.get("criteria").and_then(|v| v.as_array()) {
@@ -288,6 +311,10 @@ pub const DEFAULT_CSQ_FIELDS: &[&str] = &[
     "HIGH_INF_POS",
     "MOTIF_SCORE_CHANGE",
     "TRANSCRIPTION_FACTORS",
+    "LoF",
+    "LoF_filter",
+    "LoF_flags",
+    "LoF_info",
     "ACMG",
     "ACMG_CRITERIA",
 ];
@@ -1549,6 +1576,12 @@ pub fn format_json(vf: &VariationFeature, sa_only: bool) -> serde_json::Value {
                 if let Some(ref acmg) = aa.acmg_classification {
                     tc.insert("acmg".into(), acmg.clone());
                 }
+                // LOFTEE loss-of-function annotation
+                if let Some(ref loftee) = aa.loftee {
+                    if let Ok(val) = serde_json::to_value(loftee) {
+                        tc.insert("loftee".into(), val);
+                    }
+                }
                 serde_json::Value::Object(tc)
             })
         })
@@ -1789,6 +1822,7 @@ mod tests {
                     polyphen: None,
                     supplementary,
                     acmg_classification: None,
+                    loftee: None,
                 }],
                 canonical: false,
                 strand: Strand::Forward,

--- a/crates/fastvep-io/src/variant.rs
+++ b/crates/fastvep-io/src/variant.rs
@@ -2,7 +2,17 @@ use fastvep_core::{
     Allele, Consequence, GeneAnnotation, GenomicPosition, Impact, Strand,
     SupplementaryAnnotation, VariantType,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
+
+/// Result of LOFTEE evaluation for a single allele annotation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LofteeResult {
+    pub confidence: String,
+    pub filters: Vec<String>,
+    pub flags: Vec<String>,
+    pub info: HashMap<String, String>,
+}
 
 /// A variant feature ready for annotation.
 #[derive(Debug, Clone)]
@@ -102,6 +112,8 @@ pub struct AlleleAnnotation {
     pub supplementary: Vec<(String, String)>,
     /// ACMG-AMP classification result (serialized as serde_json::Value).
     pub acmg_classification: Option<serde_json::Value>,
+    /// LOFTEE loss-of-function annotation result.
+    pub loftee: Option<LofteeResult>,
 }
 
 /// A known/existing variant from the variation cache.

--- a/crates/fastvep-io/tests/vep_compat.rs
+++ b/crates/fastvep-io/tests/vep_compat.rs
@@ -479,6 +479,7 @@ fn mock_vf_missense() -> VariationFeature {
                 polyphen: Some("benign(0)".into()),
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: Strand::Forward,
@@ -582,6 +583,7 @@ fn test_csq_frameshift_codon_format() {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: Strand::Forward,
@@ -646,13 +648,13 @@ fn test_csq_header_includes_new_fields() {
 #[test]
 fn test_csq_field_count_matches_vep() {
     // Extended field set includes all VEP fields plus CANONICAL, CCDS, ENSP, SOURCE, HGVS_OFFSET
-    assert_eq!(output::DEFAULT_CSQ_FIELDS.len(), 49, "DEFAULT_CSQ_FIELDS should have 49 fields");
+    assert_eq!(output::DEFAULT_CSQ_FIELDS.len(), 53, "DEFAULT_CSQ_FIELDS should have 53 fields");
 
-    // Verify formatting produces 49 pipe-delimited values
+    // Verify formatting produces 53 pipe-delimited values
     let vf = mock_vf_missense();
     let csq = output::format_csq(&vf, output::DEFAULT_CSQ_FIELDS);
     let field_count = csq.split('|').count();
-    assert_eq!(field_count, 49, "CSQ output should have 49 pipe-delimited fields");
+    assert_eq!(field_count, 53, "CSQ output should have 53 pipe-delimited fields");
 }
 
 #[test]
@@ -714,8 +716,12 @@ fn test_csq_missense_full_42_field_match() {
         "",                                   // 44: HIGH_INF_POS
         "",                                   // 45: MOTIF_SCORE_CHANGE
         "",                                   // 46: TRANSCRIPTION_FACTORS
-        "",                                   // 47: ACMG (empty when --acmg not run)
-        "",                                   // 48: ACMG_CRITERIA
+        "",                                   // 47: LoF
+        "",                                   // 48: LoF_filter
+        "",                                   // 49: LoF_flags
+        "",                                   // 50: LoF_info
+        "",                                   // 51: ACMG (empty when --acmg not run)
+        "",                                   // 52: ACMG_CRITERIA
     ];
 
     assert_eq!(fields.len(), expected.len(),
@@ -766,6 +772,7 @@ fn test_csq_frameshift_full_42_field_match() {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: Strand::Forward,
@@ -845,8 +852,12 @@ fn test_csq_frameshift_full_42_field_match() {
         "",                     // 44: HIGH_INF_POS
         "",                     // 45: MOTIF_SCORE_CHANGE
         "",                     // 46: TRANSCRIPTION_FACTORS
-        "",                     // 47: ACMG
-        "",                     // 48: ACMG_CRITERIA
+        "",                     // 47: LoF
+        "",                     // 48: LoF_filter
+        "",                     // 49: LoF_flags
+        "",                     // 50: LoF_info
+        "",                     // 51: ACMG
+        "",                     // 52: ACMG_CRITERIA
     ];
 
     assert_eq!(fields.len(), expected.len(),
@@ -898,6 +909,7 @@ fn test_csq_downstream_variant_match() {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: Strand::Forward,
@@ -929,7 +941,7 @@ fn test_csq_downstream_variant_match() {
     // VEP expected:
     // C|downstream_gene_variant|MODIFIER|OR4G11P|ENSG00000240361|Transcript|ENST00000492842.2|
     // transcribed_unprocessed_pseudogene|||||||||||A|A/C|1681|1|||HGNC|HGNC:31276|...
-    assert_eq!(fields.len(), 49);
+    assert_eq!(fields.len(), 53);
     assert_eq!(fields[0], "C");
     assert_eq!(fields[1], "downstream_gene_variant");
     assert_eq!(fields[2], "MODIFIER");
@@ -988,6 +1000,7 @@ fn test_csq_intron_variant_match() {
                 polyphen: None,
                 supplementary: Vec::new(),
                 acmg_classification: None,
+                loftee: None,
             }],
             canonical: false,
             strand: Strand::Forward,
@@ -1019,7 +1032,7 @@ fn test_csq_intron_variant_match() {
     // VEP expected:
     // T|intron_variant|MODIFIER|ACP1|ENSG00000143727|Transcript|ENST00000272065.10|
     // protein_coding||1/5|||||||||C|C/T||1|||HGNC|HGNC:122|MANE_Select|NM_004300.4||1|P3|...
-    assert_eq!(fields.len(), 49);
+    assert_eq!(fields.len(), 53);
     assert_eq!(fields[0], "T");
     assert_eq!(fields[1], "intron_variant");
     assert_eq!(fields[2], "MODIFIER");

--- a/crates/fastvep-loftee/Cargo.toml
+++ b/crates/fastvep-loftee/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fastvep-loftee"
+version.workspace = true
+edition.workspace = true
+description = "LOFTEE loss-of-function annotation engine for fastVEP"
+
+[dependencies]
+fastvep-core = { workspace = true }
+fastvep-genome = { path = "../fastvep-genome" }
+fastvep-cache = { path = "../fastvep-cache" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }

--- a/crates/fastvep-loftee/src/conservation.rs
+++ b/crates/fastvep-loftee/src/conservation.rs
@@ -1,0 +1,231 @@
+//! Conservation data readers for GERP and PhyloCSF.
+//!
+//! Phase 4: Implements GERP-weighted distance for END_TRUNC and
+//! PhyloCSF-based PHYLOCSF_WEAK / PHYLOCSF_UNLIKELY_ORF flags.
+
+use fastvep_core::Strand;
+use fastvep_genome::Transcript;
+use std::collections::HashMap;
+
+/// Trait for looking up per-base conservation scores.
+pub trait ConservationProvider: Send + Sync {
+    /// Fetch the GERP score for a single position.
+    fn gerp_score(&self, chrom: &str, pos: u64) -> Option<f64>;
+
+    /// Sum GERP scores across a range [start, end] inclusive.
+    fn gerp_sum(&self, chrom: &str, start: u64, end: u64) -> f64 {
+        let mut sum = 0.0;
+        for pos in start..=end {
+            if let Some(score) = self.gerp_score(chrom, pos) {
+                sum += score;
+            }
+        }
+        sum
+    }
+}
+
+/// Trait for looking up PhyloCSF exon-level scores.
+pub trait PhyloCsfProvider: Send + Sync {
+    /// Look up PhyloCSF scores for a given transcript + exon.
+    /// Returns (corresponding_orf_score, max_score) or None if too short.
+    fn phylocsf_scores(
+        &self,
+        transcript_id: &str,
+        exon_number: u32,
+    ) -> Option<PhyloCsfResult>;
+}
+
+#[derive(Debug, Clone)]
+pub struct PhyloCsfResult {
+    pub corresponding_orf_score: f64,
+    pub max_score: f64,
+}
+
+/// Compute GERP-weighted distance from a variant to the stop codon.
+///
+/// Iterates through exons from the variant position to the stop codon,
+/// weighting each base by its GERP score. This is the Phase 4 upgrade
+/// to the simple base-pair distance used in Phase 1.
+///
+/// Returns (gerp_weighted_dist, bp_dist).
+pub fn get_gerp_weighted_dist(
+    tr: &Transcript,
+    variant_pos: u64,
+    gerp_provider: &dyn ConservationProvider,
+) -> (f64, u64) {
+    let sorted = sorted_exons(tr);
+
+    let stop_pos = match tr.strand {
+        Strand::Forward => tr.coding_region_end,
+        Strand::Reverse => tr.coding_region_start,
+    };
+    let stop_pos = match stop_pos {
+        Some(p) => p,
+        None => return (0.0, 0),
+    };
+
+    let mut gerp_dist = 0.0;
+    let mut bp_dist = 0u64;
+
+    for exon in &sorted {
+        // Determine the coding portion of this exon
+        let (exon_coding_start, exon_coding_end) = match tr.strand {
+            Strand::Forward => {
+                let cs = exon.start.max(tr.coding_region_start.unwrap_or(exon.start));
+                let ce = exon.end.min(stop_pos);
+                if cs > ce || exon.end < tr.coding_region_start.unwrap_or(0) {
+                    continue;
+                }
+                (cs, ce)
+            }
+            Strand::Reverse => {
+                let cs = exon.start.max(stop_pos);
+                let ce = exon.end.min(tr.coding_region_end.unwrap_or(exon.end));
+                if cs > ce || exon.start > tr.coding_region_end.unwrap_or(u64::MAX) {
+                    continue;
+                }
+                (cs, ce)
+            }
+        };
+
+        // Determine the region in this exon that's after the variant
+        let region_start = match tr.strand {
+            Strand::Forward => variant_pos.max(exon_coding_start),
+            Strand::Reverse => exon_coding_start,
+        };
+        let region_end = match tr.strand {
+            Strand::Forward => exon_coding_end,
+            Strand::Reverse => variant_pos.min(exon_coding_end),
+        };
+
+        if region_start > region_end {
+            continue;
+        }
+
+        let region_bp = region_end - region_start + 1;
+        bp_dist += region_bp;
+        gerp_dist += gerp_provider.gerp_sum(&tr.chromosome, region_start, region_end);
+    }
+
+    (gerp_dist, bp_dist)
+}
+
+/// Check PhyloCSF conservation for an exonic variant.
+/// Returns (flag_name, info_entries) or None if no flag triggered.
+pub fn check_phylocsf(
+    tr: &Transcript,
+    exon_number: u32,
+    phylocsf_provider: &dyn PhyloCsfProvider,
+) -> Option<(String, HashMap<String, String>)> {
+    let result = phylocsf_provider.phylocsf_scores(&tr.stable_id, exon_number)?;
+
+    let mut info = HashMap::new();
+    info.insert(
+        "ANN_ORF".to_string(),
+        format!("{:.4}", result.corresponding_orf_score),
+    );
+    info.insert("MAX_ORF".to_string(), format!("{:.4}", result.max_score));
+
+    if result.corresponding_orf_score < 0.0 {
+        let flag = if result.max_score > 0.0 {
+            "PHYLOCSF_UNLIKELY_ORF"
+        } else {
+            "PHYLOCSF_WEAK"
+        };
+        Some((flag.to_string(), info))
+    } else {
+        None
+    }
+}
+
+fn sorted_exons(tr: &Transcript) -> Vec<&fastvep_genome::Exon> {
+    let mut exons: Vec<&fastvep_genome::Exon> = tr.exons.iter().collect();
+    match tr.strand {
+        Strand::Forward => exons.sort_by_key(|e| e.start),
+        Strand::Reverse => exons.sort_by(|a, b| b.start.cmp(&a.start)),
+    }
+    exons
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockGerpProvider {
+        scores: HashMap<u64, f64>,
+    }
+
+    impl ConservationProvider for MockGerpProvider {
+        fn gerp_score(&self, _chrom: &str, pos: u64) -> Option<f64> {
+            self.scores.get(&pos).copied()
+        }
+    }
+
+    struct MockPhyloCsfProvider;
+
+    impl PhyloCsfProvider for MockPhyloCsfProvider {
+        fn phylocsf_scores(&self, _tid: &str, exon: u32) -> Option<PhyloCsfResult> {
+            match exon {
+                1 => Some(PhyloCsfResult {
+                    corresponding_orf_score: -5.0,
+                    max_score: 10.0,
+                }),
+                2 => Some(PhyloCsfResult {
+                    corresponding_orf_score: -5.0,
+                    max_score: -3.0,
+                }),
+                3 => Some(PhyloCsfResult {
+                    corresponding_orf_score: 5.0,
+                    max_score: 10.0,
+                }),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_check_phylocsf_unlikely_orf() {
+        let tr = crate::tests::make_multi_exon_transcript();
+        let provider = MockPhyloCsfProvider;
+        // Exon 1: corr_orf < 0, max > 0 → PHYLOCSF_UNLIKELY_ORF
+        let result = check_phylocsf(&tr, 1, &provider);
+        assert!(result.is_some());
+        let (flag, _) = result.unwrap();
+        assert_eq!(flag, "PHYLOCSF_UNLIKELY_ORF");
+    }
+
+    #[test]
+    fn test_check_phylocsf_weak() {
+        let tr = crate::tests::make_multi_exon_transcript();
+        let provider = MockPhyloCsfProvider;
+        // Exon 2: corr_orf < 0, max < 0 → PHYLOCSF_WEAK
+        let result = check_phylocsf(&tr, 2, &provider);
+        assert!(result.is_some());
+        let (flag, _) = result.unwrap();
+        assert_eq!(flag, "PHYLOCSF_WEAK");
+    }
+
+    #[test]
+    fn test_check_phylocsf_no_flag() {
+        let tr = crate::tests::make_multi_exon_transcript();
+        let provider = MockPhyloCsfProvider;
+        // Exon 3: corr_orf > 0 → no flag
+        let result = check_phylocsf(&tr, 3, &provider);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_gerp_weighted_dist() {
+        let tr = crate::tests::make_multi_exon_transcript();
+        let mut scores = HashMap::new();
+        // Give some positions high GERP scores
+        for pos in 4400..=4500 {
+            scores.insert(pos, 2.0);
+        }
+        let provider = MockGerpProvider { scores };
+        let (gerp_dist, bp_dist) = get_gerp_weighted_dist(&tr, 4400, &provider);
+        // 4400 to 4500 = 101 positions, each with GERP 2.0
+        assert_eq!(bp_dist, 101);
+        assert!((gerp_dist - 202.0).abs() < 0.001);
+    }
+}

--- a/crates/fastvep-loftee/src/filters.rs
+++ b/crates/fastvep-loftee/src/filters.rs
@@ -1,0 +1,506 @@
+//! LOFTEE filter implementations.
+//!
+//! Each filter returns a boolean indicating whether the filter condition is met
+//! (true = variant fails the filter and should be downgraded).
+
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_core::Strand;
+use fastvep_genome::Transcript;
+
+// --- Structural filters (no external data needed) ---
+
+/// Check if the transcript has undefined exon/intron boundaries.
+/// For exonic variants: exon number should be defined.
+/// For intronic variants: intron number should be defined.
+pub fn check_exon_intron_undef(exon: Option<(u32, u32)>) -> bool {
+    // If we're told the variant is exonic but exon is None, it's undefined
+    // The caller passes the exon/intron info from AlleleAnnotation
+    exon.is_none()
+}
+
+/// Check if the intron annotation is missing/undefined.
+pub fn check_intron_annotation_errors(intron: Option<(u32, u32)>) -> bool {
+    intron.is_none()
+}
+
+/// Check if the transcript has only a single exon.
+pub fn check_single_exon(total_exons: u32) -> bool {
+    total_exons == 1
+}
+
+/// Check if the transcript has an incomplete CDS (missing start or stop codon).
+pub fn check_incomplete_cds(flags: &[String]) -> bool {
+    flags.iter().any(|f| f == "cds_start_NF" || f == "cds_end_NF")
+}
+
+/// Get CDS length (fast approximation using cDNA coordinates).
+pub fn get_cds_length_fast(tr: &Transcript) -> u64 {
+    match (tr.cdna_coding_start, tr.cdna_coding_end) {
+        (Some(start), Some(end)) => end - start + 1,
+        _ => 0,
+    }
+}
+
+/// Get the intron size for a given intron index (0-based).
+pub fn get_intron_size(tr: &Transcript, intron_idx: usize) -> u64 {
+    let sorted = sorted_exons(tr);
+    if intron_idx >= sorted.len().saturating_sub(1) {
+        return 0;
+    }
+    match tr.strand {
+        Strand::Forward => {
+            let intron_start = sorted[intron_idx].end + 1;
+            let intron_end = sorted[intron_idx + 1].start - 1;
+            if intron_end >= intron_start {
+                intron_end - intron_start + 1
+            } else {
+                0
+            }
+        }
+        Strand::Reverse => {
+            // sorted in descending start order for reverse strand
+            let intron_start = sorted[intron_idx + 1].end + 1;
+            let intron_end = sorted[intron_idx].start - 1;
+            if intron_end >= intron_start {
+                intron_end - intron_start + 1
+            } else {
+                0
+            }
+        }
+    }
+}
+
+/// Get the coding length of the last exon (distance from last exon start to stop codon).
+pub fn get_last_exon_coding_length(tr: &Transcript) -> u64 {
+    let stop_pos = match tr.strand {
+        Strand::Forward => tr.coding_region_end,
+        Strand::Reverse => tr.coding_region_start,
+    };
+    let stop_pos = match stop_pos {
+        Some(p) => p,
+        None => return 0,
+    };
+
+    let sorted = sorted_exons(tr);
+    // Find the exon containing the stop codon
+    for exon in sorted.iter().rev() {
+        match tr.strand {
+            Strand::Forward => {
+                if exon.start <= stop_pos && exon.end >= stop_pos {
+                    return stop_pos - exon.start;
+                }
+            }
+            Strand::Reverse => {
+                if exon.start <= stop_pos && exon.end >= stop_pos {
+                    return exon.end - stop_pos;
+                }
+            }
+        }
+    }
+    0
+}
+
+/// Get the base-pair distance from the variant to the stop codon (in CDS space).
+pub fn get_bp_dist_to_stop(tr: &Transcript, variant_genomic_pos: u64) -> u64 {
+    // Convert variant genomic position to cDNA, then compute distance to coding end
+    let variant_cdna = tr.genomic_to_cdna(variant_genomic_pos);
+    let coding_end = tr.cdna_coding_end;
+
+    match (variant_cdna, coding_end) {
+        (Some(vpos), Some(cend)) => {
+            if cend > vpos {
+                cend - vpos
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+// --- Sequence-based filters ---
+
+/// Check if a splice donor variant is a GC→GT mutation.
+/// This means the intron starts with GC (non-canonical) and the variant changes C→T,
+/// converting it to the canonical GT donor.
+pub fn check_gc_to_gt_donor(
+    tr: &Transcript,
+    intron_idx: usize,
+    ref_allele: &str,
+    alt_allele: &str,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> bool {
+    let sp = match seq_provider {
+        Some(sp) => sp,
+        None => return false,
+    };
+
+    let intron_start_seq = get_intron_start_dinuc(tr, intron_idx, sp);
+    match intron_start_seq {
+        Some(dinuc) => {
+            // Intron starts with GC, and ref is C, alt is T → GC→GT
+            dinuc == "GC" && ref_allele == "C" && alt_allele == "T"
+        }
+        None => false,
+    }
+}
+
+/// Check if the intron has a non-canonical splice motif (not GT..AG).
+pub fn check_non_canonical_splice(
+    tr: &Transcript,
+    intron_idx: usize,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> bool {
+    let sp = match seq_provider {
+        Some(sp) => sp,
+        None => return false,
+    };
+
+    let start_dinuc = get_intron_start_dinuc(tr, intron_idx, sp);
+    let end_dinuc = get_intron_end_dinuc(tr, intron_idx, sp);
+
+    let non_canonical_start = start_dinuc.as_deref().map_or(false, |d| d != "GT");
+    let non_canonical_end = end_dinuc.as_deref().map_or(false, |d| d != "AG");
+
+    non_canonical_start || non_canonical_end
+}
+
+/// Check for NAGNAG splice acceptor site (AG.AG motif around the splice site).
+pub fn check_nagnag(
+    tr: &Transcript,
+    intron_idx: usize,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> bool {
+    let sp = match seq_provider {
+        Some(sp) => sp,
+        None => return false,
+    };
+
+    // Get 9bp context around splice acceptor (4bp before + 1bp variant + 4bp after)
+    let sorted = sorted_exons(tr);
+    if intron_idx >= sorted.len().saturating_sub(1) {
+        return false;
+    }
+
+    // The acceptor site is at the start of the downstream exon
+    let acceptor_pos = match tr.strand {
+        Strand::Forward => sorted[intron_idx + 1].start,
+        Strand::Reverse => sorted[intron_idx + 1].end,
+    };
+
+    // Fetch 9 bases centered on acceptor boundary (4 bases either side)
+    let (fetch_start, fetch_end) = (acceptor_pos.saturating_sub(4), acceptor_pos + 4);
+    let seq = sp
+        .fetch_sequence(&tr.chromosome, fetch_start, fetch_end)
+        .ok();
+
+    match seq {
+        Some(bytes) => {
+            let seq_str = if tr.strand == Strand::Reverse {
+                let rc: Vec<u8> = bytes.iter().rev().map(|&b| complement(b)).collect();
+                String::from_utf8_lossy(&rc).to_uppercase()
+            } else {
+                String::from_utf8_lossy(&bytes).to_uppercase()
+            };
+            // Look for AG.AG pattern (. is any single nucleotide)
+            if seq_str.len() >= 5 {
+                for i in 0..seq_str.len().saturating_sub(4) {
+                    let window = &seq_str[i..i + 5];
+                    if window.starts_with("AG") && window.ends_with("AG") {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        None => false,
+    }
+}
+
+/// Check if the variant is in the 5' UTR region (before coding start).
+pub fn check_5utr_splice(tr: &Transcript, variant_start: u64, variant_end: u64) -> bool {
+    match tr.strand {
+        Strand::Forward => {
+            if let Some(crs) = tr.coding_region_start {
+                variant_end < crs
+            } else {
+                false
+            }
+        }
+        Strand::Reverse => {
+            if let Some(cre) = tr.coding_region_end {
+                variant_start > cre
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Check if the variant is in the 3' UTR region (after coding end).
+pub fn check_3utr_splice(tr: &Transcript, variant_start: u64, variant_end: u64) -> bool {
+    match tr.strand {
+        Strand::Forward => {
+            if let Some(cre) = tr.coding_region_end {
+                variant_start > cre
+            } else {
+                false
+            }
+        }
+        Strand::Reverse => {
+            if let Some(crs) = tr.coding_region_start {
+                variant_end < crs
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Check if the ALT allele matches the ancestral allele (ANC_ALLELE filter).
+pub fn check_ancestral_allele(
+    chrom: &str,
+    variant_start: u64,
+    variant_end: u64,
+    alt_allele: &str,
+    ref_allele: &str,
+    ancestral_provider: &(dyn SequenceProvider + Send + Sync),
+) -> bool {
+    // Only apply to SNPs for now (matching Perl: ignoring indels)
+    if ref_allele.contains('-') || alt_allele.contains('-') || ref_allele.len() != 1 || alt_allele.len() != 1 {
+        return false;
+    }
+
+    match ancestral_provider.fetch_sequence(chrom, variant_start, variant_end) {
+        Ok(seq) => {
+            let ancestral = String::from_utf8_lossy(&seq).to_uppercase();
+            ancestral == alt_allele.to_uppercase()
+        }
+        Err(_) => false,
+    }
+}
+
+// --- Helper functions ---
+
+fn sorted_exons(tr: &Transcript) -> Vec<&fastvep_genome::Exon> {
+    let mut exons: Vec<&fastvep_genome::Exon> = tr.exons.iter().collect();
+    match tr.strand {
+        Strand::Forward => exons.sort_by_key(|e| e.start),
+        Strand::Reverse => exons.sort_by(|a, b| b.start.cmp(&a.start)),
+    }
+    exons
+}
+
+/// Get the first 2 bases of an intron (donor site dinucleotide).
+fn get_intron_start_dinuc(
+    tr: &Transcript,
+    intron_idx: usize,
+    sp: &(dyn SequenceProvider + Send + Sync),
+) -> Option<String> {
+    let sorted = sorted_exons(tr);
+    if intron_idx >= sorted.len().saturating_sub(1) {
+        return None;
+    }
+    let (start, end) = match tr.strand {
+        Strand::Forward => (sorted[intron_idx].end + 1, sorted[intron_idx].end + 2),
+        Strand::Reverse => (sorted[intron_idx].start - 2, sorted[intron_idx].start - 1),
+    };
+    let seq = sp.fetch_sequence(&tr.chromosome, start, end).ok()?;
+    let s = if tr.strand == Strand::Reverse {
+        let rc: Vec<u8> = seq.iter().rev().map(|&b| complement(b)).collect();
+        String::from_utf8_lossy(&rc).to_uppercase()
+    } else {
+        String::from_utf8_lossy(&seq).to_uppercase()
+    };
+    Some(s)
+}
+
+/// Get the last 2 bases of an intron (acceptor site dinucleotide).
+fn get_intron_end_dinuc(
+    tr: &Transcript,
+    intron_idx: usize,
+    sp: &(dyn SequenceProvider + Send + Sync),
+) -> Option<String> {
+    let sorted = sorted_exons(tr);
+    if intron_idx >= sorted.len().saturating_sub(1) {
+        return None;
+    }
+    let (start, end) = match tr.strand {
+        Strand::Forward => (sorted[intron_idx + 1].start - 2, sorted[intron_idx + 1].start - 1),
+        Strand::Reverse => (sorted[intron_idx + 1].end + 1, sorted[intron_idx + 1].end + 2),
+    };
+    let seq = sp.fetch_sequence(&tr.chromosome, start, end).ok()?;
+    let s = if tr.strand == Strand::Reverse {
+        let rc: Vec<u8> = seq.iter().rev().map(|&b| complement(b)).collect();
+        String::from_utf8_lossy(&rc).to_uppercase()
+    } else {
+        String::from_utf8_lossy(&seq).to_uppercase()
+    };
+    Some(s)
+}
+
+fn complement(b: u8) -> u8 {
+    match b {
+        b'A' | b'a' => b'T',
+        b'T' | b't' => b'A',
+        b'C' | b'c' => b'G',
+        b'G' | b'g' => b'C',
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fastvep_core::Strand;
+    use fastvep_genome::Exon;
+
+    fn make_transcript() -> Transcript {
+        crate::tests::make_multi_exon_transcript()
+    }
+
+    #[test]
+    fn test_check_single_exon() {
+        assert!(check_single_exon(1));
+        assert!(!check_single_exon(2));
+        assert!(!check_single_exon(3));
+    }
+
+    #[test]
+    fn test_check_incomplete_cds() {
+        assert!(!check_incomplete_cds(&[]));
+        assert!(check_incomplete_cds(&["cds_start_NF".to_string()]));
+        assert!(check_incomplete_cds(&["cds_end_NF".to_string()]));
+        assert!(check_incomplete_cds(&[
+            "cds_start_NF".to_string(),
+            "cds_end_NF".to_string(),
+        ]));
+        assert!(!check_incomplete_cds(&["some_other_flag".to_string()]));
+    }
+
+    #[test]
+    fn test_check_exon_intron_undef() {
+        assert!(check_exon_intron_undef(None));
+        assert!(!check_exon_intron_undef(Some((1, 3))));
+    }
+
+    #[test]
+    fn test_get_cds_length_fast() {
+        let tr = make_transcript();
+        // cdna_coding_end(952) - cdna_coding_start(51) + 1 = 902
+        assert_eq!(get_cds_length_fast(&tr), 902);
+    }
+
+    #[test]
+    fn test_get_intron_size() {
+        let tr = make_transcript();
+        // Intron 0: between exon1 (end=1200) and exon2 (start=2000)
+        // Size = 2000 - 1200 - 1 = 799
+        assert_eq!(get_intron_size(&tr, 0), 799);
+        // Intron 1: between exon2 (end=2300) and exon3 (start=4000)
+        // Size = 4000 - 2300 - 1 = 1699
+        assert_eq!(get_intron_size(&tr, 1), 1699);
+    }
+
+    #[test]
+    fn test_get_intron_size_small() {
+        let mut tr = make_transcript();
+        tr.exons = vec![
+            Exon {
+                stable_id: "E1".into(),
+                start: 1000,
+                end: 1200,
+                strand: Strand::Forward,
+                phase: 0,
+                end_phase: 0,
+                rank: 1,
+            },
+            Exon {
+                stable_id: "E2".into(),
+                start: 1211, // intron is 10bp: 1201-1210
+                end: 1400,
+                strand: Strand::Forward,
+                phase: 0,
+                end_phase: 0,
+                rank: 2,
+            },
+        ];
+        assert_eq!(get_intron_size(&tr, 0), 10);
+    }
+
+    #[test]
+    fn test_get_last_exon_coding_length() {
+        let tr = make_transcript();
+        // coding_region_end = 4500, last exon (E3) starts at 4000
+        // last_exon_coding_length = 4500 - 4000 = 500
+        assert_eq!(get_last_exon_coding_length(&tr), 500);
+    }
+
+    #[test]
+    fn test_get_bp_dist_to_stop() {
+        let tr = make_transcript();
+        // Variant at genomic 2100 in exon 2
+        // cdna pos of 2100 = 201 (exon1 len) + (2100 - 2000) + 1 = 302
+        // cdna_coding_end = 952
+        // dist = 952 - 302 = 650
+        let dist = get_bp_dist_to_stop(&tr, 2100);
+        assert_eq!(dist, 650);
+    }
+
+    #[test]
+    fn test_5utr_splice_forward() {
+        let tr = make_transcript();
+        // coding_region_start = 1050
+        // Variant at 1020-1020 is before CDS start → 5'UTR
+        assert!(check_5utr_splice(&tr, 1020, 1020));
+        // Variant at 1100-1100 is after CDS start → not 5'UTR
+        assert!(!check_5utr_splice(&tr, 1100, 1100));
+    }
+
+    #[test]
+    fn test_3utr_splice_forward() {
+        let tr = make_transcript();
+        // coding_region_end = 4500
+        // Variant at 4600-4600 is after CDS end → 3'UTR
+        assert!(check_3utr_splice(&tr, 4600, 4600));
+        // Variant at 4400-4400 is before CDS end → not 3'UTR
+        assert!(!check_3utr_splice(&tr, 4400, 4400));
+    }
+
+    #[test]
+    fn test_5utr_3utr_reverse_strand() {
+        let mut tr = make_transcript();
+        tr.strand = Strand::Reverse;
+        // For reverse strand:
+        // 5'UTR is genomically AFTER coding_region_end
+        // 3'UTR is genomically BEFORE coding_region_start
+        assert!(check_5utr_splice(&tr, 4600, 4600)); // after CRE (4500)
+        assert!(!check_5utr_splice(&tr, 1020, 1020));
+        assert!(check_3utr_splice(&tr, 1020, 1020)); // before CRS (1050)
+        assert!(!check_3utr_splice(&tr, 4600, 4600));
+    }
+
+    #[test]
+    fn test_ancestral_allele_snp() {
+        // Mock ancestral sequence provider
+        struct MockAncProvider;
+        impl SequenceProvider for MockAncProvider {
+            fn fetch_sequence(
+                &self,
+                _chrom: &str,
+                _start: u64,
+                _end: u64,
+            ) -> anyhow::Result<Vec<u8>> {
+                Ok(b"T".to_vec())
+            }
+        }
+        let provider = MockAncProvider;
+
+        // ALT matches ancestral → ANC_ALLELE should trigger
+        assert!(check_ancestral_allele("chr1", 100, 100, "T", "C", &provider));
+        // ALT does not match ancestral
+        assert!(!check_ancestral_allele("chr1", 100, 100, "A", "C", &provider));
+        // Indel → skip
+        assert!(!check_ancestral_allele("chr1", 100, 100, "-", "C", &provider));
+    }
+}

--- a/crates/fastvep-loftee/src/lib.rs
+++ b/crates/fastvep-loftee/src/lib.rs
@@ -1,0 +1,654 @@
+//! LOFTEE (Loss-Of-Function Transcript Effect Estimator) for fastVEP.
+//!
+//! Classifies putative loss-of-function variants (stop-gained, frameshift,
+//! splice-site disrupting) as High-Confidence (HC), Low-Confidence (LC),
+//! or Other-Splice (OS) based on LOFTEE filtering criteria.
+
+mod filters;
+pub mod conservation;
+pub mod maxentscan;
+pub mod motifs;
+pub mod splice;
+pub mod svm;
+
+pub use filters::*;
+
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_core::Consequence;
+use fastvep_genome::Transcript;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// LOFTEE confidence levels.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Confidence {
+    /// High Confidence: canonical LoF with no failing filters.
+    HC,
+    /// Low Confidence: canonical LoF that failed one or more filters.
+    LC,
+    /// Other Splice: LOFTEE-predicted splice disruption not called by VEP.
+    OS,
+}
+
+impl std::fmt::Display for Confidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Confidence::HC => write!(f, "HC"),
+            Confidence::LC => write!(f, "LC"),
+            Confidence::OS => write!(f, "OS"),
+        }
+    }
+}
+
+/// Result of LOFTEE evaluation for a single allele annotation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LofteeResult {
+    pub confidence: String,
+    pub filters: Vec<String>,
+    pub flags: Vec<String>,
+    pub info: HashMap<String, String>,
+}
+
+/// Configuration for LOFTEE evaluation.
+pub struct LofteeConfig {
+    pub min_intron_size: u64,
+    pub ancestral_seq_provider: Option<Box<dyn SequenceProvider + Send + Sync>>,
+    /// Splice prediction data (Phase 3). None = splice predictions disabled.
+    pub splice_data: Option<splice::SpliceData>,
+    /// GERP conservation provider (Phase 4). None = use 50bp fallback for END_TRUNC.
+    pub gerp_provider: Option<Box<dyn conservation::ConservationProvider>>,
+    /// PhyloCSF provider (Phase 4). None = skip PhyloCSF flags.
+    pub phylocsf_provider: Option<Box<dyn conservation::PhyloCsfProvider>>,
+}
+
+impl Default for LofteeConfig {
+    fn default() -> Self {
+        Self {
+            min_intron_size: 15,
+            ancestral_seq_provider: None,
+            splice_data: None,
+            gerp_provider: None,
+            phylocsf_provider: None,
+        }
+    }
+}
+
+/// Input data for LOFTEE evaluation.
+pub struct LofteeInput<'a> {
+    pub transcript: &'a Transcript,
+    pub consequences: &'a [Consequence],
+    pub exon: Option<(u32, u32)>,
+    pub intron: Option<(u32, u32)>,
+    pub cds_end: Option<u64>,
+    pub variant_start: u64,
+    pub variant_end: u64,
+    pub allele: &'a str,
+    pub ref_allele: &'a str,
+    pub flags: &'a [String],
+}
+
+/// Check if the consequence set contains a putative LoF consequence.
+pub fn has_lof_consequence(consequences: &[Consequence]) -> bool {
+    consequences.iter().any(|c| matches!(c,
+        Consequence::StopGained
+        | Consequence::FrameshiftVariant
+        | Consequence::SpliceAcceptorVariant
+        | Consequence::SpliceDonorVariant
+    ))
+}
+
+/// Evaluate LOFTEE filters for a single allele annotation.
+pub fn evaluate(
+    input: &LofteeInput,
+    config: &LofteeConfig,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> LofteeResult {
+    let mut filters: Vec<String> = Vec::new();
+    let mut flags: Vec<String> = Vec::new();
+    let mut info: HashMap<String, String> = HashMap::new();
+
+    let consequences = input.consequences;
+    let tr = input.transcript;
+
+    let is_stop_gained = consequences.contains(&Consequence::StopGained);
+    let is_frameshift = consequences.contains(&Consequence::FrameshiftVariant);
+    let is_splice_donor = consequences.contains(&Consequence::SpliceDonorVariant);
+    let is_splice_acceptor = consequences.contains(&Consequence::SpliceAcceptorVariant);
+    let is_vep_splice_lof = is_splice_donor || is_splice_acceptor;
+    let is_other_lof = is_stop_gained || is_frameshift;
+
+    let is_upstream = consequences.contains(&Consequence::UpstreamGeneVariant);
+    let is_downstream = consequences.contains(&Consequence::DownstreamGeneVariant);
+    let is_genic = !is_upstream && !is_downstream;
+    let is_utr = filters::check_5utr_splice(tr, input.variant_start, input.variant_end)
+        || filters::check_3utr_splice(tr, input.variant_start, input.variant_end);
+
+    // Splice predictions (Phase 3): run on genic, non-UTR, non-stop/frameshift variants
+    let mut loftee_splice_lof = false;
+    let mut _lof_position: Option<u64> = None;
+
+    if let Some(ref splice_data) = config.splice_data {
+        if is_genic && !is_utr && !is_other_lof {
+            // Extended splice: check if variant disrupts an annotated splice site
+            if let Some(intron) = input.intron {
+                let splice_result = splice::get_effect_on_splice(
+                    tr,
+                    intron.0 as usize,
+                    input.variant_start,
+                    input.variant_end,
+                    input.ref_allele,
+                    input.allele,
+                    is_vep_splice_lof,
+                    splice_data,
+                    seq_provider,
+                );
+
+                if let Some(result) = splice_result {
+                    for (k, v) in &result.features {
+                        info.insert(k.clone(), v.clone());
+                    }
+
+                    if result.disrupting {
+                        loftee_splice_lof = true;
+                        info.insert(
+                            format!("{}_DISRUPTING", result.splice_type),
+                            "true".into(),
+                        );
+                    } else if is_vep_splice_lof {
+                        filters.push(format!("NON_{}_DISRUPTING", result.splice_type));
+                    }
+                }
+            }
+
+            // De novo donor: check if variant creates a new strong donor
+            if !loftee_splice_lof {
+                if let Some(exon) = input.exon {
+                    let denovo = splice::check_for_denovo_donor(
+                        tr,
+                        exon.0 as usize,
+                        input.variant_start,
+                        input.variant_end,
+                        input.ref_allele,
+                        input.allele,
+                        splice_data,
+                        seq_provider,
+                    );
+
+                    if let Some(result) = denovo {
+                        if result.probability > splice_data.denovo_donor_cutoff {
+                            info.insert("DE_NOVO_DONOR".into(), "true".into());
+                            _lof_position = Some(result.lof_pos);
+                            loftee_splice_lof = result.lof;
+                        }
+                        for (k, v) in &result.features {
+                            info.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Determine initial confidence
+    let mut confidence = if is_vep_splice_lof || is_other_lof {
+        Confidence::HC
+    } else if loftee_splice_lof {
+        Confidence::OS
+    } else {
+        return LofteeResult {
+            confidence: String::new(),
+            filters: vec![],
+            flags: vec![],
+            info,
+        };
+    };
+
+    // === END_TRUNC filter (stop-gained / frameshift in exonic context) ===
+    if is_other_lof {
+        if let Some(cds_end) = input.cds_end {
+            let cds_length = filters::get_cds_length_fast(tr);
+            if cds_length > 0 {
+                let percentile = cds_end as f64 / cds_length as f64;
+                info.insert("PERCENTILE".into(), format!("{:.4}", percentile));
+            }
+
+            if let Some((_, _total_exons)) = input.exon {
+                let last_exon_coding_len =
+                    filters::get_last_exon_coding_length(tr);
+                let bp_dist = filters::get_bp_dist_to_stop(tr, input.variant_start);
+                let d = bp_dist as i64 - last_exon_coding_len as i64;
+                info.insert("BP_DIST".into(), bp_dist.to_string());
+                info.insert("DIST_FROM_LAST_EXON".into(), d.to_string());
+                info.insert(
+                    "50_BP_RULE".into(),
+                    if d <= 50 { "FAIL" } else { "PASS" }.into(),
+                );
+
+                // END_TRUNC: if GERP available, require d <= 50 AND gerp_dist <= 180
+                // Otherwise fall back to just d <= 50 (conservative over-filtering)
+                if d <= 50 {
+                    if let Some(ref gerp) = config.gerp_provider {
+                        let (gerp_dist, _) = conservation::get_gerp_weighted_dist(
+                            tr,
+                            input.variant_start,
+                            gerp.as_ref(),
+                        );
+                        info.insert("GERP_DIST".into(), format!("{:.2}", gerp_dist));
+                        if gerp_dist <= 180.0 {
+                            filters.push("END_TRUNC".into());
+                        }
+                    } else {
+                        // No GERP data: conservative fallback
+                        filters.push("END_TRUNC".into());
+                    }
+                }
+            } else {
+                flags.push("NO_EXON_NUMBER".into());
+            }
+        }
+    }
+
+    // === Exonic filters (stop-gained / frameshift) ===
+    if is_other_lof && input.exon.is_some() {
+        let (exon_num, total_exons) = input.exon.unwrap();
+
+        if filters::check_exon_intron_undef(input.exon) {
+            filters.push("EXON_INTRON_UNDEF".into());
+        } else if filters::check_single_exon(total_exons) {
+            flags.push("SINGLE_EXON".into());
+        } else {
+            if filters::check_incomplete_cds(&input.flags) {
+                filters.push("INCOMPLETE_CDS".into());
+            }
+        }
+
+        // PhyloCSF conservation check (Phase 4)
+        if let Some(ref phylocsf) = config.phylocsf_provider {
+            if let Some((flag, phylo_info)) =
+                conservation::check_phylocsf(tr, exon_num, phylocsf.as_ref())
+            {
+                flags.push(flag);
+                for (k, v) in phylo_info {
+                    info.insert(k, v);
+                }
+            } else {
+                info.insert("PHYLOCSF_TOO_SHORT".into(), "true".into());
+            }
+        }
+    }
+
+    // === Intronic filters (splice variants) ===
+    if input.intron.is_some() {
+        let (intron_idx, _total_introns) = input.intron.unwrap();
+
+        if filters::check_intron_annotation_errors(input.intron) {
+            filters.push("EXON_INTRON_UNDEF".into());
+        } else {
+            // Intron size filter
+            let intron_size = filters::get_intron_size(tr, intron_idx as usize);
+            info.insert("INTRON_SIZE".into(), intron_size.to_string());
+            if intron_size < config.min_intron_size {
+                filters.push("SMALL_INTRON".into());
+            }
+
+            if is_vep_splice_lof {
+                // GC_TO_GT_DONOR: splice donor GC→GT mutation
+                if is_splice_donor {
+                    if filters::check_gc_to_gt_donor(
+                        tr,
+                        intron_idx as usize,
+                        input.ref_allele,
+                        input.allele,
+                        seq_provider,
+                    ) {
+                        filters.push("GC_TO_GT_DONOR".into());
+                    }
+                }
+
+                // NON_CAN_SPLICE: non-canonical splice site motif
+                if filters::check_non_canonical_splice(
+                    tr,
+                    intron_idx as usize,
+                    seq_provider,
+                ) {
+                    flags.push("NON_CAN_SPLICE".into());
+                }
+
+                // UTR splice filters
+                if filters::check_5utr_splice(
+                    tr,
+                    input.variant_start,
+                    input.variant_end,
+                ) {
+                    filters.push("5UTR_SPLICE".into());
+                }
+                if filters::check_3utr_splice(
+                    tr,
+                    input.variant_start,
+                    input.variant_end,
+                ) {
+                    filters.push("3UTR_SPLICE".into());
+                }
+            }
+
+            // NAGNAG_SITE: splice acceptor AG.AG motif
+            if is_splice_acceptor {
+                if filters::check_nagnag(tr, intron_idx as usize, seq_provider) {
+                    flags.push("NAGNAG_SITE".into());
+                }
+            }
+        }
+    }
+
+    // === ANC_ALLELE filter (Phase 2) ===
+    if let Some(ref anc_provider) = config.ancestral_seq_provider {
+        if filters::check_ancestral_allele(
+            &tr.chromosome,
+            input.variant_start,
+            input.variant_end,
+            input.allele,
+            input.ref_allele,
+            anc_provider.as_ref(),
+        ) {
+            filters.push("ANC_ALLELE".into());
+        }
+    }
+
+    // === Confidence downgrade ===
+    // If there are any filters, downgrade from HC → LC (or OS → LC)
+    if !filters.is_empty() {
+        confidence = Confidence::LC;
+    }
+
+    LofteeResult {
+        confidence: confidence.to_string(),
+        filters,
+        flags,
+        info,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fastvep_core::Strand;
+    use fastvep_genome::{Exon, Gene, Transcript, Translation};
+
+    pub(crate) fn make_multi_exon_transcript() -> Transcript {
+        Transcript {
+            stable_id: "ENST00000001".into(),
+            version: None,
+            gene: Gene {
+                stable_id: "ENSG00000001".into(),
+                symbol: Some("TEST".into()),
+                symbol_source: None,
+                hgnc_id: None,
+                biotype: "protein_coding".into(),
+                chromosome: "chr1".into(),
+                start: 1000,
+                end: 5000,
+                strand: Strand::Forward,
+            },
+            biotype: "protein_coding".into(),
+            chromosome: "chr1".into(),
+            start: 1000,
+            end: 5000,
+            strand: Strand::Forward,
+            exons: vec![
+                Exon {
+                    stable_id: "E1".into(),
+                    start: 1000,
+                    end: 1200,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "E2".into(),
+                    start: 2000,
+                    end: 2300,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 2,
+                },
+                Exon {
+                    stable_id: "E3".into(),
+                    start: 4000,
+                    end: 5000,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 3,
+                },
+            ],
+            translation: Some(Translation {
+                stable_id: "ENSP1".into(),
+                genomic_start: 1050,
+                genomic_end: 4500,
+                start_exon_rank: 1,
+                start_exon_offset: 50,
+                end_exon_rank: 3,
+                end_exon_offset: 500,
+            }),
+            cdna_coding_start: Some(51),
+            cdna_coding_end: Some(952),
+            coding_region_start: Some(1050),
+            coding_region_end: Some(4500),
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: true,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: None,
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
+        }
+    }
+
+    fn make_single_exon_transcript() -> Transcript {
+        let mut tr = make_multi_exon_transcript();
+        tr.exons = vec![Exon {
+            stable_id: "E1".into(),
+            start: 1000,
+            end: 2000,
+            strand: Strand::Forward,
+            phase: 0,
+            end_phase: 0,
+            rank: 1,
+        }];
+        tr
+    }
+
+    #[test]
+    fn test_has_lof_consequence() {
+        assert!(has_lof_consequence(&[Consequence::StopGained]));
+        assert!(has_lof_consequence(&[Consequence::FrameshiftVariant]));
+        assert!(has_lof_consequence(&[Consequence::SpliceAcceptorVariant]));
+        assert!(has_lof_consequence(&[Consequence::SpliceDonorVariant]));
+        assert!(!has_lof_consequence(&[Consequence::MissenseVariant]));
+        assert!(!has_lof_consequence(&[Consequence::SynonymousVariant]));
+        assert!(!has_lof_consequence(&[]));
+    }
+
+    #[test]
+    fn test_evaluate_stop_gained_hc() {
+        let tr = make_multi_exon_transcript();
+        let config = LofteeConfig::default();
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::StopGained],
+            exon: Some((1, 3)),
+            intron: None,
+            cds_end: Some(300), // early in CDS, should pass END_TRUNC
+            variant_start: 2100,
+            variant_end: 2100,
+            allele: "T",
+            ref_allele: "C",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        assert_eq!(result.confidence, "HC");
+        assert!(result.filters.is_empty());
+    }
+
+    #[test]
+    fn test_evaluate_stop_gained_end_trunc() {
+        let tr = make_multi_exon_transcript();
+        let config = LofteeConfig::default();
+        // Variant near the end of CDS in the last exon
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::StopGained],
+            exon: Some((2, 3)),
+            intron: None,
+            cds_end: Some(890), // near end of CDS
+            variant_start: 4480, // close to coding_region_end (4500)
+            variant_end: 4480,
+            allele: "T",
+            ref_allele: "C",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        assert_eq!(result.confidence, "LC");
+        assert!(result.filters.contains(&"END_TRUNC".into()));
+    }
+
+    #[test]
+    fn test_evaluate_single_exon_flag() {
+        let tr = make_single_exon_transcript();
+        let config = LofteeConfig::default();
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::StopGained],
+            exon: Some((0, 1)),
+            intron: None,
+            cds_end: Some(300),
+            variant_start: 1300,
+            variant_end: 1300,
+            allele: "T",
+            ref_allele: "C",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        // SINGLE_EXON is a flag, not a filter, so confidence stays HC
+        assert_eq!(result.confidence, "HC");
+        assert!(result.flags.contains(&"SINGLE_EXON".into()));
+    }
+
+    #[test]
+    fn test_evaluate_incomplete_cds() {
+        let tr = make_multi_exon_transcript();
+        let config = LofteeConfig::default();
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::StopGained],
+            exon: Some((1, 3)),
+            intron: None,
+            cds_end: Some(300),
+            variant_start: 2100,
+            variant_end: 2100,
+            allele: "T",
+            ref_allele: "C",
+            flags: &["cds_start_NF".to_string()],
+        };
+        let result = evaluate(&input, &config, None);
+        assert_eq!(result.confidence, "LC");
+        assert!(result.filters.contains(&"INCOMPLETE_CDS".into()));
+    }
+
+    #[test]
+    fn test_evaluate_small_intron() {
+        // Build a transcript with a very small intron (10bp)
+        let mut tr = make_multi_exon_transcript();
+        tr.exons = vec![
+            Exon {
+                stable_id: "E1".into(),
+                start: 1000,
+                end: 1200,
+                strand: Strand::Forward,
+                phase: 0,
+                end_phase: 0,
+                rank: 1,
+            },
+            Exon {
+                stable_id: "E2".into(),
+                start: 1211, // intron is only 10bp (1201-1210)
+                end: 1400,
+                strand: Strand::Forward,
+                phase: 0,
+                end_phase: 0,
+                rank: 2,
+            },
+        ];
+        let config = LofteeConfig::default(); // min_intron_size = 15
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::SpliceDonorVariant],
+            exon: None,
+            intron: Some((0, 1)),
+            cds_end: None,
+            variant_start: 1201,
+            variant_end: 1202,
+            allele: "T",
+            ref_allele: "G",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        assert_eq!(result.confidence, "LC");
+        assert!(result.filters.contains(&"SMALL_INTRON".into()));
+    }
+
+    #[test]
+    fn test_evaluate_splice_donor_hc() {
+        let tr = make_multi_exon_transcript();
+        let config = LofteeConfig::default();
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::SpliceDonorVariant],
+            exon: None,
+            intron: Some((0, 2)),
+            cds_end: None,
+            variant_start: 1201,
+            variant_end: 1202,
+            allele: "T",
+            ref_allele: "G",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        assert_eq!(result.confidence, "HC");
+        assert!(result.filters.is_empty());
+    }
+
+    #[test]
+    fn test_evaluate_non_lof_returns_empty() {
+        let tr = make_multi_exon_transcript();
+        let config = LofteeConfig::default();
+        let input = LofteeInput {
+            transcript: &tr,
+            consequences: &[Consequence::MissenseVariant],
+            exon: Some((1, 3)),
+            intron: None,
+            cds_end: Some(300),
+            variant_start: 2100,
+            variant_end: 2100,
+            allele: "T",
+            ref_allele: "C",
+            flags: &[],
+        };
+        let result = evaluate(&input, &config, None);
+        assert!(result.confidence.is_empty());
+    }
+}

--- a/crates/fastvep-loftee/src/maxentscan.rs
+++ b/crates/fastvep-loftee/src/maxentscan.rs
@@ -1,0 +1,299 @@
+//! MaxEntScan splice site scoring.
+//!
+//! Ports the MaxEntScan algorithm (Yeo & Burge 2004) used by LOFTEE
+//! for donor (5' splice site, 9bp) and acceptor (3' splice site, 23bp) scoring.
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Pre-loaded MaxEntScan scoring tables.
+pub struct MaxEntScanData {
+    /// Donor context scores: 16384 entries indexed by hashseq of 7-mer (positions [0,1,2,5,6,7,8]).
+    pub me2x5: Vec<f64>,
+    /// Acceptor MaxEnt lookup tables (9 tables).
+    pub metables: Vec<Vec<f64>>,
+}
+
+// Background nucleotide frequencies
+const BGD_A: f64 = 0.27;
+const BGD_C: f64 = 0.23;
+const BGD_G: f64 = 0.23;
+const BGD_T: f64 = 0.27;
+
+// Donor consensus position 3 (first base of GT)
+const CONS1_A: f64 = 0.004;
+const CONS1_C: f64 = 0.0032;
+const CONS1_G: f64 = 0.9896;
+const CONS1_T: f64 = 0.0032;
+
+// Donor consensus position 4 (second base of GT)
+const CONS2_A: f64 = 0.0034;
+const CONS2_C: f64 = 0.0039;
+const CONS2_G: f64 = 0.0042;
+const CONS2_T: f64 = 0.9884;
+
+// Acceptor consensus position 18 (first base of AG)
+const ACONS1_A: f64 = 0.9903;
+const ACONS1_C: f64 = 0.0032;
+const ACONS1_G: f64 = 0.0034;
+const ACONS1_T: f64 = 0.0030;
+
+// Acceptor consensus position 19 (second base of AG)
+const ACONS2_A: f64 = 0.0027;
+const ACONS2_C: f64 = 0.0037;
+const ACONS2_G: f64 = 0.9905;
+const ACONS2_T: f64 = 0.0030;
+
+impl MaxEntScanData {
+    /// Load MaxEntScan data from a LOFTEE data directory.
+    /// Expects: <dir>/maxEntScan/me2x5 and <dir>/maxEntScan/splicemodels/me2x3acc{1-9}
+    pub fn load(loftee_dir: &Path) -> Result<Self, String> {
+        let mes_dir = loftee_dir.join("maxEntScan");
+
+        // Load me2x5 (donor context scores)
+        let me2x5_path = mes_dir.join("me2x5");
+        let me2x5 = load_score_table(&me2x5_path)?;
+        if me2x5.len() != 16384 {
+            return Err(format!(
+                "me2x5 should have 16384 entries, got {}",
+                me2x5.len()
+            ));
+        }
+
+        // Load 9 acceptor tables
+        let models_dir = mes_dir.join("splicemodels");
+        let mut metables = Vec::with_capacity(9);
+        for i in 1..=9 {
+            let path = models_dir.join(format!("me2x3acc{}", i));
+            let table = load_score_table(&path)?;
+            metables.push(table);
+        }
+
+        Ok(Self { me2x5, metables })
+    }
+
+    /// Score a 9-base donor splice site sequence.
+    /// Returns the MaxEntScan donor score (log2 scale).
+    pub fn score_donor(&self, seq: &[u8]) -> Option<f64> {
+        if seq.len() != 9 {
+            return None;
+        }
+        self.score_donor_impl(seq)
+    }
+
+    fn score_donor_impl(&self, seq: &[u8]) -> Option<f64> {
+        let cons_score = score_consensus_donor(seq)?;
+        // Get context bases [0,1,2,5,6,7,8] (skip positions 3,4)
+        let rest: Vec<u8> = [seq[0], seq[1], seq[2], seq[5], seq[6], seq[7], seq[8]].to_vec();
+        let idx = hashseq(&rest)?;
+        if idx >= self.me2x5.len() {
+            return None;
+        }
+        let context_score = self.me2x5[idx];
+        let raw = cons_score * context_score;
+        if raw <= 0.0 {
+            return None;
+        }
+        Some(raw.log2())
+    }
+
+    /// Score a 23-base acceptor splice site sequence.
+    /// Returns the MaxEntScan acceptor score (log2 scale).
+    pub fn score_acceptor(&self, seq: &[u8]) -> Option<f64> {
+        if seq.len() != 23 {
+            return None;
+        }
+        self.score_acceptor_impl(seq)
+    }
+
+    fn score_acceptor_impl(&self, seq: &[u8]) -> Option<f64> {
+        let cons_score = score_consensus_acceptor(seq)?;
+        // Get rest: positions [0..18] + [20..23] (skip positions 18,19 = AG consensus)
+        let mut rest = Vec::with_capacity(21);
+        rest.extend_from_slice(&seq[0..18]);
+        rest.extend_from_slice(&seq[20..23]);
+
+        let me_score = max_ent_score(&rest, &self.metables)?;
+        let raw = cons_score * me_score;
+        if raw <= 0.0 {
+            return None;
+        }
+        Some(raw.log2())
+    }
+}
+
+/// Donor consensus scoring (positions 3 and 4 of the 9-base sequence).
+fn score_consensus_donor(seq: &[u8]) -> Option<f64> {
+    let c1 = match seq[3] {
+        b'A' | b'a' => CONS1_A,
+        b'C' | b'c' => CONS1_C,
+        b'G' | b'g' => CONS1_G,
+        b'T' | b't' => CONS1_T,
+        _ => return None,
+    };
+    let c2 = match seq[4] {
+        b'A' | b'a' => CONS2_A,
+        b'C' | b'c' => CONS2_C,
+        b'G' | b'g' => CONS2_G,
+        b'T' | b't' => CONS2_T,
+        _ => return None,
+    };
+    let b1 = bgd(seq[3])?;
+    let b2 = bgd(seq[4])?;
+    Some((c1 * c2) / (b1 * b2))
+}
+
+/// Acceptor consensus scoring (positions 18 and 19 of the 23-base sequence).
+fn score_consensus_acceptor(seq: &[u8]) -> Option<f64> {
+    let c1 = match seq[18] {
+        b'A' | b'a' => ACONS1_A,
+        b'C' | b'c' => ACONS1_C,
+        b'G' | b'g' => ACONS1_G,
+        b'T' | b't' => ACONS1_T,
+        _ => return None,
+    };
+    let c2 = match seq[19] {
+        b'A' | b'a' => ACONS2_A,
+        b'C' | b'c' => ACONS2_C,
+        b'G' | b'g' => ACONS2_G,
+        b'T' | b't' => ACONS2_T,
+        _ => return None,
+    };
+    let b1 = bgd(seq[18])?;
+    let b2 = bgd(seq[19])?;
+    Some((c1 * c2) / (b1 * b2))
+}
+
+/// MaxEnt score for the 21-base acceptor context (after removing AG consensus).
+fn max_ent_score(seq: &[u8], metables: &[Vec<f64>]) -> Option<f64> {
+    if seq.len() != 21 || metables.len() != 9 {
+        return None;
+    }
+
+    // 9 overlapping windows into the 21-base sequence
+    let indices = [
+        (0, 7),   // table 0: positions 0-6
+        (7, 14),  // table 1: positions 7-13
+        (14, 21), // table 2: positions 14-20
+        (4, 11),  // table 3: positions 4-10
+        (11, 18), // table 4: positions 11-17
+        (4, 7),   // table 5: positions 4-6 (3-mer)
+        (7, 11),  // table 6: positions 7-10 (4-mer)
+        (11, 14), // table 7: positions 11-13 (3-mer)
+        (14, 18), // table 8: positions 14-17 (4-mer)
+    ];
+
+    let mut scores = [0.0f64; 9];
+    for (i, &(start, end)) in indices.iter().enumerate() {
+        let subseq = &seq[start..end];
+        let idx = hashseq(subseq)?;
+        if idx >= metables[i].len() {
+            return None;
+        }
+        scores[i] = metables[i][idx];
+    }
+
+    // Final score: (sc0 * sc1 * sc2 * sc3 * sc4) / (sc5 * sc6 * sc7 * sc8)
+    let numerator = scores[0] * scores[1] * scores[2] * scores[3] * scores[4];
+    let denominator = scores[5] * scores[6] * scores[7] * scores[8];
+    if denominator == 0.0 {
+        return None;
+    }
+    Some(numerator / denominator)
+}
+
+/// Convert a DNA sequence to a base-4 index.
+fn hashseq(seq: &[u8]) -> Option<usize> {
+    let mut result = 0usize;
+    for (i, &base) in seq.iter().enumerate() {
+        let val = match base {
+            b'A' | b'a' => 0,
+            b'C' | b'c' => 1,
+            b'G' | b'g' => 2,
+            b'T' | b't' => 3,
+            _ => return None,
+        };
+        result += val * 4usize.pow((seq.len() - i - 1) as u32);
+    }
+    Some(result)
+}
+
+fn bgd(base: u8) -> Option<f64> {
+    match base {
+        b'A' | b'a' => Some(BGD_A),
+        b'C' | b'c' => Some(BGD_C),
+        b'G' | b'g' => Some(BGD_G),
+        b'T' | b't' => Some(BGD_T),
+        _ => None,
+    }
+}
+
+/// Load a score table from a file (one float per line).
+fn load_score_table(path: &Path) -> Result<Vec<f64>, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("Cannot open {}: {}", path.display(), e))?;
+    let reader = BufReader::new(file);
+    let mut scores = Vec::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("Read error in {}: {}", path.display(), e))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let score: f64 = trimmed
+            .parse()
+            .map_err(|e| format!("Parse error in {}: {} (line: '{}')", path.display(), e, trimmed))?;
+        scores.push(score);
+    }
+    Ok(scores)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hashseq() {
+        assert_eq!(hashseq(b"A"), Some(0));
+        assert_eq!(hashseq(b"C"), Some(1));
+        assert_eq!(hashseq(b"G"), Some(2));
+        assert_eq!(hashseq(b"T"), Some(3));
+        assert_eq!(hashseq(b"AA"), Some(0));
+        assert_eq!(hashseq(b"AC"), Some(1));
+        assert_eq!(hashseq(b"CA"), Some(4));
+        assert_eq!(hashseq(b"TT"), Some(15));
+        // 7-mer AAAAAAA = 0
+        assert_eq!(hashseq(b"AAAAAAA"), Some(0));
+        // 7-mer TTTTTTT = 4^7 - 1 = 16383
+        assert_eq!(hashseq(b"TTTTTTT"), Some(16383));
+        // Invalid base
+        assert_eq!(hashseq(b"N"), None);
+    }
+
+    #[test]
+    fn test_score_consensus_donor() {
+        // GT at positions 3-4 should give high score
+        let gt_seq = b"AAAGTAAAA";
+        let score = score_consensus_donor(gt_seq).unwrap();
+        // Expected: (0.9896 * 0.9884) / (0.23 * 0.27) ≈ 15.74
+        assert!(score > 10.0);
+
+        // Non-GT should give low score
+        let aa_seq = b"AAAAAAAA\x00"; // 9 bytes
+        // Use proper 9-byte slice
+        let low_seq = b"AAAAAAAAA";
+        let low_score = score_consensus_donor(low_seq).unwrap();
+        assert!(low_score < 1.0);
+    }
+
+    #[test]
+    fn test_score_consensus_acceptor() {
+        // AG at positions 18-19 should give high score
+        let mut seq = [b'A'; 23];
+        seq[18] = b'A';
+        seq[19] = b'G';
+        let score = score_consensus_acceptor(&seq).unwrap();
+        // Expected: (0.9903 * 0.9905) / (0.27 * 0.23) ≈ 15.79
+        assert!(score > 10.0);
+    }
+}

--- a/crates/fastvep-loftee/src/motifs.rs
+++ b/crates/fastvep-loftee/src/motifs.rs
@@ -1,0 +1,109 @@
+//! Splice regulatory element (SRE) motif scanning.
+//!
+//! Scans sequences for exonic/intronic splice enhancers and silencers (ESE, ESS, ISE, ISS).
+
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Pre-loaded motif sets for donor or acceptor splice contexts.
+#[derive(Debug, Clone)]
+pub struct MotifSet {
+    pub ese: HashSet<String>,
+    pub ess: HashSet<String>,
+    pub ise: HashSet<String>,
+    pub iss: HashSet<String>,
+}
+
+impl MotifSet {
+    /// Load motif files from a directory (expects ese.txt, ess.txt, ise.txt, iss.txt).
+    pub fn load(dir: &Path) -> Result<Self, String> {
+        Ok(Self {
+            ese: load_motif_file(&dir.join("ese.txt"))?,
+            ess: load_motif_file(&dir.join("ess.txt"))?,
+            ise: load_motif_file(&dir.join("ise.txt"))?,
+            iss: load_motif_file(&dir.join("iss.txt"))?,
+        })
+    }
+
+    /// Scan a sequence for motif hits of the given type.
+    pub fn scan(&self, seq: &[u8], motif_type: MotifType) -> usize {
+        let motifs = match motif_type {
+            MotifType::Ese => &self.ese,
+            MotifType::Ess => &self.ess,
+            MotifType::Ise => &self.ise,
+            MotifType::Iss => &self.iss,
+        };
+        scan_seq(seq, motifs)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MotifType {
+    Ese,
+    Ess,
+    Ise,
+    Iss,
+}
+
+/// Scan a sequence for k-mer hits in a motif set (k = 6, 7, 8).
+fn scan_seq(seq: &[u8], motifs: &HashSet<String>) -> usize {
+    let seq_upper: Vec<u8> = seq.iter().map(|&b| b.to_ascii_uppercase()).collect();
+    let seq_str = String::from_utf8_lossy(&seq_upper);
+    let len = seq_str.len();
+    let mut hits = 0;
+
+    for i in 0..len {
+        for k in [6, 7, 8] {
+            if i + k <= len {
+                let kmer = &seq_str[i..i + k];
+                if motifs.contains(kmer) {
+                    hits += 1;
+                }
+            }
+        }
+    }
+    hits
+}
+
+fn load_motif_file(path: &Path) -> Result<HashSet<String>, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("Cannot open {}: {}", path.display(), e))?;
+    let reader = BufReader::new(file);
+    let mut motifs = HashSet::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("Read error in {}: {}", path.display(), e))?;
+        let trimmed = line.trim().to_uppercase();
+        if !trimmed.is_empty() {
+            motifs.insert(trimmed);
+        }
+    }
+    Ok(motifs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scan_seq_basic() {
+        let mut motifs = HashSet::new();
+        motifs.insert("AAAAAA".to_string()); // 6-mer
+        // Sequence with two overlapping hits
+        assert_eq!(scan_seq(b"AAAAAAA", &motifs), 2); // positions 0-5 and 1-6
+    }
+
+    #[test]
+    fn test_scan_seq_no_hits() {
+        let mut motifs = HashSet::new();
+        motifs.insert("GGGGGG".to_string());
+        assert_eq!(scan_seq(b"AAAAAA", &motifs), 0);
+    }
+
+    #[test]
+    fn test_scan_seq_case_insensitive() {
+        let mut motifs = HashSet::new();
+        motifs.insert("AAAAAA".to_string());
+        assert_eq!(scan_seq(b"aaaaaa", &motifs), 1);
+    }
+}

--- a/crates/fastvep-loftee/src/splice.rs
+++ b/crates/fastvep-loftee/src/splice.rs
@@ -1,0 +1,701 @@
+//! Extended splice site prediction and de novo donor detection.
+//!
+//! Ports the `extended_splice.pl` and `de_novo_donor.pl` LOFTEE algorithms.
+
+use crate::maxentscan::MaxEntScanData;
+use crate::motifs::{MotifSet, MotifType};
+use crate::svm::{self, SvmModel};
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_core::Strand;
+use fastvep_genome::Transcript;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Pre-loaded splice prediction data.
+pub struct SpliceData {
+    pub mes: MaxEntScanData,
+    pub donor_motifs: MotifSet,
+    pub acceptor_motifs: MotifSet,
+    pub donor_model: HashMap<String, f64>,
+    pub acceptor_model: HashMap<String, f64>,
+    pub donor_svm: SvmModel,
+    // Thresholds
+    pub donor_disruption_cutoff: f64,
+    pub acceptor_disruption_cutoff: f64,
+    pub donor_disruption_mes_cutoff: f64,
+    pub acceptor_disruption_mes_cutoff: f64,
+    pub donor_rescue_cutoff: f64,
+    pub acceptor_rescue_cutoff: f64,
+    pub weak_donor_cutoff: f64,
+    pub max_scan_distance: usize,
+    pub max_denovo_donor_distance: usize,
+    pub denovo_donor_cutoff: f64,
+    pub sre_flanksize: usize,
+    pub exonic_denovo_only: bool,
+}
+
+impl SpliceData {
+    /// Load all splice prediction data from a LOFTEE data directory.
+    pub fn load(loftee_dir: &Path) -> Result<Self, String> {
+        let mes = MaxEntScanData::load(loftee_dir)?;
+        let splice_data_dir = loftee_dir.join("splice_data");
+        let donor_motifs = MotifSet::load(&splice_data_dir.join("donor_motifs"))?;
+        let acceptor_motifs = MotifSet::load(&splice_data_dir.join("acceptor_motifs"))?;
+        let donor_model = svm::load_logreg_model(&splice_data_dir.join("donor_model.txt"))?;
+        let acceptor_model = svm::load_logreg_model(&splice_data_dir.join("acceptor_model.txt"))?;
+        let donor_svm = SvmModel::load(&splice_data_dir.join("de_novo_donor_SVM"))?;
+
+        Ok(Self {
+            mes,
+            donor_motifs,
+            acceptor_motifs,
+            donor_model,
+            acceptor_model,
+            donor_svm,
+            donor_disruption_cutoff: 0.98,
+            acceptor_disruption_cutoff: 0.99,
+            donor_disruption_mes_cutoff: 6.0,
+            acceptor_disruption_mes_cutoff: 7.0,
+            donor_rescue_cutoff: 8.5,
+            acceptor_rescue_cutoff: 8.5,
+            weak_donor_cutoff: -4.0,
+            max_scan_distance: 15,
+            max_denovo_donor_distance: 200,
+            denovo_donor_cutoff: 0.995,
+            sre_flanksize: 100,
+            exonic_denovo_only: true,
+        })
+    }
+}
+
+/// Result of extended splice analysis.
+#[derive(Debug, Clone)]
+pub struct SpliceResult {
+    /// Whether the variant disrupts the splice site.
+    pub disrupting: bool,
+    /// Type of splice site affected ("DONOR" or "ACCEPTOR").
+    pub splice_type: String,
+    /// Features computed during analysis.
+    pub features: HashMap<String, String>,
+    /// Info strings for LoF_info field.
+    pub info: Vec<String>,
+}
+
+/// Result of de novo donor analysis.
+#[derive(Debug, Clone)]
+pub struct DeNovoDonorResult {
+    /// SVM probability that a de novo donor is created.
+    pub probability: f64,
+    /// Features computed during analysis.
+    pub features: HashMap<String, String>,
+    /// Whether this is a loss of function (frameshift or stop introduced).
+    pub lof: bool,
+    /// Position of the de novo junction relative to the original.
+    pub lof_pos: u64,
+}
+
+/// Check whether a variant disrupts an existing splice site.
+/// Returns None if the variant doesn't overlap the extended splice region.
+pub fn get_effect_on_splice(
+    tr: &Transcript,
+    intron_idx: usize,
+    variant_start: u64,
+    variant_end: u64,
+    ref_allele: &str,
+    alt_allele: &str,
+    is_vep_splice_lof: bool,
+    splice_data: &SpliceData,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> Option<SpliceResult> {
+    let sp = seq_provider?;
+    let sorted = sorted_exons(tr);
+    if intron_idx >= sorted.len().saturating_sub(1) {
+        return None;
+    }
+
+    // Determine intron boundaries
+    let (intron_start, intron_end) = match tr.strand {
+        Strand::Forward => (
+            sorted[intron_idx].end + 1,
+            sorted[intron_idx + 1].start - 1,
+        ),
+        Strand::Reverse => (
+            sorted[intron_idx + 1].end + 1,
+            sorted[intron_idx].start - 1,
+        ),
+    };
+
+    // Check overlap with donor region (9bp around intron start: -3 to +5)
+    let donor_start = intron_start.saturating_sub(3);
+    let donor_end = intron_start + 5;
+    let overlaps_donor = variant_start <= donor_end && variant_end >= donor_start;
+
+    // Check overlap with acceptor region (23bp around intron end: -19 to +3)
+    let acceptor_start = intron_end.saturating_sub(19);
+    let acceptor_end = intron_end + 3;
+    let overlaps_acceptor = variant_start <= acceptor_end && variant_end >= acceptor_start;
+
+    if !overlaps_donor && !overlaps_acceptor {
+        return None;
+    }
+
+    let mut features = HashMap::new();
+    let mut info = Vec::new();
+
+    let splice_type = if overlaps_donor { "DONOR" } else { "ACCEPTOR" };
+
+    // Get reference and variant splice site sequences
+    let (ref_seq_start, ref_seq_end, _seq_len) = if overlaps_donor {
+        (intron_start.saturating_sub(3), intron_start + 5, 9usize)
+    } else {
+        (intron_end.saturating_sub(19), intron_end + 3, 23usize)
+    };
+
+    let ref_bytes = sp
+        .fetch_sequence(&tr.chromosome, ref_seq_start, ref_seq_end)
+        .ok()?;
+
+    // Handle strand
+    let ref_seq = if tr.strand == Strand::Reverse {
+        reverse_complement(&ref_bytes)
+    } else {
+        ref_bytes.iter().map(|b| b.to_ascii_uppercase()).collect()
+    };
+
+    // Score reference
+    let ref_mes = if overlaps_donor {
+        splice_data.mes.score_donor(&ref_seq)?
+    } else {
+        splice_data.mes.score_acceptor(&ref_seq)?
+    };
+
+    // Create variant sequence by mutating the reference
+    let var_seq = mutate_splice_seq(
+        &ref_seq,
+        variant_start,
+        variant_end,
+        ref_allele,
+        alt_allele,
+        ref_seq_start,
+        tr.strand,
+    );
+
+    let var_mes = if overlaps_donor {
+        splice_data.mes.score_donor(&var_seq).unwrap_or(f64::NEG_INFINITY)
+    } else {
+        splice_data.mes.score_acceptor(&var_seq).unwrap_or(f64::NEG_INFINITY)
+    };
+
+    let mes_diff = ref_mes - var_mes;
+
+    features.insert(
+        format!("{}_MES_DIFF", splice_type),
+        format!("{:.4}", mes_diff),
+    );
+    features.insert(
+        format!("MUTANT_{}_MES", splice_type),
+        format!("{:.4}", var_mes),
+    );
+
+    // Compute SRE features
+    let motifs = if overlaps_donor {
+        &splice_data.donor_motifs
+    } else {
+        &splice_data.acceptor_motifs
+    };
+
+    let flank_start = ref_seq_start.saturating_sub(splice_data.sre_flanksize as u64);
+    let flank_end = ref_seq_end + splice_data.sre_flanksize as u64;
+    if let Ok(flank_bytes) = sp.fetch_sequence(&tr.chromosome, flank_start, flank_end) {
+        let flank = if tr.strand == Strand::Reverse {
+            reverse_complement(&flank_bytes)
+        } else {
+            flank_bytes.iter().map(|b| b.to_ascii_uppercase()).collect()
+        };
+
+        let ese_count = motifs.scan(&flank, MotifType::Ese);
+        let ess_count = motifs.scan(&flank, MotifType::Ess);
+        let ise_count = motifs.scan(&flank, MotifType::Ise);
+        let iss_count = motifs.scan(&flank, MotifType::Iss);
+
+        features.insert(format!("{}_ESE", splice_type), ese_count.to_string());
+        features.insert(format!("{}_ESS", splice_type), ess_count.to_string());
+        features.insert(format!("{}_ISE", splice_type), ise_count.to_string());
+        features.insert(format!("{}_ISS", splice_type), iss_count.to_string());
+    }
+
+    // Determine disruption using MES-only mode (no GERP in Phase 3)
+    let cutoff = if overlaps_donor {
+        splice_data.donor_disruption_mes_cutoff
+    } else {
+        splice_data.acceptor_disruption_mes_cutoff
+    };
+    let disrupting = mes_diff > cutoff;
+
+    features.insert(
+        format!("{}_DISRUPTION_PROB", splice_type),
+        format!("{:.4}", mes_diff),
+    );
+
+    if disrupting {
+        info.push(format!("{}_DISRUPTING", splice_type));
+    } else if is_vep_splice_lof {
+        // VEP called it splice_donor/acceptor_variant but MES says not disrupted
+        info.push(format!("NON_{}_DISRUPTING", splice_type));
+    }
+
+    Some(SpliceResult {
+        disrupting,
+        splice_type: splice_type.to_string(),
+        features,
+        info,
+    })
+}
+
+/// Check for de novo donor splice site creation.
+pub fn check_for_denovo_donor(
+    tr: &Transcript,
+    exon_idx: usize,
+    variant_start: u64,
+    variant_end: u64,
+    ref_allele: &str,
+    alt_allele: &str,
+    splice_data: &SpliceData,
+    seq_provider: Option<&(dyn SequenceProvider + Send + Sync)>,
+) -> Option<DeNovoDonorResult> {
+    let sp = seq_provider?;
+    let sorted = sorted_exons(tr);
+    let n_exons = sorted.len();
+
+    // Skip if in last exon (no downstream intron)
+    if exon_idx >= n_exons.saturating_sub(1) {
+        return None;
+    }
+
+    let exon = sorted[exon_idx];
+    let exon_length = (exon.end - exon.start + 1) as usize;
+
+    // Check distance from exon boundary
+    let dist_from_boundary = match tr.strand {
+        Strand::Forward => {
+            if variant_start > exon.end {
+                (variant_start - exon.end) as usize
+            } else {
+                0
+            }
+        }
+        Strand::Reverse => {
+            if variant_end < exon.start {
+                (exon.start - variant_end) as usize
+            } else {
+                0
+            }
+        }
+    };
+
+    if splice_data.exonic_denovo_only && dist_from_boundary > 6 {
+        return None;
+    }
+    if dist_from_boundary > splice_data.max_denovo_donor_distance {
+        return None;
+    }
+
+    // Get sequence context: 200bp flanking
+    let flank = 200u64;
+    let (intron_start, intron_end) = match tr.strand {
+        Strand::Forward => (exon.end + 1, sorted[exon_idx + 1].start - 1),
+        Strand::Reverse => (sorted[exon_idx + 1].end + 1, exon.start - 1),
+    };
+
+    let seq_start = match tr.strand {
+        Strand::Forward => exon.start.saturating_sub(flank),
+        Strand::Reverse => intron_start.saturating_sub(flank),
+    };
+    let seq_end = match tr.strand {
+        Strand::Forward => intron_end + flank,
+        Strand::Reverse => exon.end + flank,
+    };
+
+    let raw_seq = sp.fetch_sequence(&tr.chromosome, seq_start, seq_end).ok()?;
+    let full_seq = if tr.strand == Strand::Reverse {
+        reverse_complement(&raw_seq)
+    } else {
+        raw_seq.iter().map(|b| b.to_ascii_uppercase()).collect()
+    };
+
+    // Reference donor position
+    let ref_junc = flank as usize + exon_length;
+    if ref_junc + 6 > full_seq.len() || ref_junc < 3 {
+        return None;
+    }
+
+    let ref_donor = &full_seq[ref_junc - 3..ref_junc + 6];
+    let ref_mes = splice_data.mes.score_donor(ref_donor)?;
+
+    if ref_mes < splice_data.weak_donor_cutoff {
+        return None;
+    }
+    // Validate GT consensus
+    if ref_donor[3] != b'G' || ref_donor[4] != b'T' {
+        return None;
+    }
+
+    // Compute variant position relative to sequence start
+    let var_pos_in_seq = match tr.strand {
+        Strand::Forward => (variant_start - seq_start) as usize,
+        Strand::Reverse => (seq_end - variant_end) as usize,
+    };
+
+    // Mutate sequence
+    let (var_seq, nt_delta) = mutate_full_seq(
+        &full_seq,
+        var_pos_in_seq,
+        ref_allele,
+        alt_allele,
+        tr.strand,
+    );
+
+    let effective_exon_length = (exon_length as i64 + nt_delta) as usize;
+    let new_ref_junc = flank as usize + effective_exon_length;
+
+    // Scan for de novo donor sites
+    let adj = if nt_delta > 0 { nt_delta as usize } else { 0 };
+    let scan_start = var_pos_in_seq.saturating_sub(8);
+    let scan_end = (var_pos_in_seq + adj + 1).min(var_seq.len().saturating_sub(9));
+
+    let mut best_prob = 0.0;
+    let mut best_features = HashMap::new();
+    let mut best_lof = false;
+    let mut best_lof_pos = 0u64;
+
+    for pos in scan_start..=scan_end {
+        if pos + 9 > var_seq.len() {
+            continue;
+        }
+        let new_junc = pos + 3;
+        if new_junc == new_ref_junc {
+            continue;
+        }
+
+        let current_exon_len = new_junc.saturating_sub(flank as usize);
+        if current_exon_len == 0 {
+            continue;
+        }
+
+        // Check minimum intron length
+        let intron_len = var_seq.len().saturating_sub(flank as usize + new_junc);
+        if intron_len < 70 {
+            continue;
+        }
+
+        let candidate = &var_seq[pos..pos + 9];
+        let alt_mes = match splice_data.mes.score_donor(candidate) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Filter: must not be dramatically worse than reference
+        if alt_mes - ref_mes < -15.0 {
+            continue;
+        }
+
+        // Compute SRE features
+        let flanksize = splice_data.sre_flanksize;
+        let ese_delta = compute_sre_delta(
+            &var_seq,
+            new_junc,
+            new_ref_junc,
+            flanksize,
+            &splice_data.donor_motifs,
+            MotifType::Ese,
+            true,
+        );
+        let ess_delta = compute_sre_delta(
+            &var_seq,
+            new_junc,
+            new_ref_junc,
+            flanksize,
+            &splice_data.donor_motifs,
+            MotifType::Ess,
+            true,
+        );
+        let ise_delta = compute_sre_delta(
+            &var_seq,
+            new_junc,
+            new_ref_junc,
+            flanksize,
+            &splice_data.donor_motifs,
+            MotifType::Ise,
+            false,
+        );
+        let iss_delta = compute_sre_delta(
+            &var_seq,
+            new_junc,
+            new_ref_junc,
+            flanksize,
+            &splice_data.donor_motifs,
+            MotifType::Iss,
+            false,
+        );
+
+        let mes_diff = if new_junc > new_ref_junc {
+            alt_mes - ref_mes
+        } else {
+            ref_mes - alt_mes
+        };
+
+        let mut svm_features = HashMap::new();
+        svm_features.insert("ese".to_string(), ese_delta);
+        svm_features.insert("ess".to_string(), ess_delta);
+        svm_features.insert("ise".to_string(), ise_delta);
+        svm_features.insert("iss".to_string(), iss_delta);
+        svm_features.insert("MESdiff".to_string(), mes_diff);
+
+        let mut pr = splice_data.donor_svm.predict(&svm_features);
+        // Flip probability for exon truncation
+        if new_junc < new_ref_junc {
+            pr = 1.0 - pr;
+        }
+
+        if pr > best_prob {
+            best_prob = pr;
+            let delta = new_junc as i64 - new_ref_junc as i64;
+            let lof = if delta.unsigned_abs() as usize % 3 != 0 {
+                true // frameshift
+            } else {
+                check_stop_introduced(&var_seq, new_junc, new_ref_junc)
+            };
+            best_lof = lof;
+            best_lof_pos = match tr.strand {
+                Strand::Forward => exon.start + new_junc as u64 - flank,
+                Strand::Reverse => exon.end - new_junc as u64 + flank,
+            };
+            best_features.clear();
+            best_features.insert("ese".to_string(), format!("{:.4}", ese_delta));
+            best_features.insert("ess".to_string(), format!("{:.4}", ess_delta));
+            best_features.insert("ise".to_string(), format!("{:.4}", ise_delta));
+            best_features.insert("iss".to_string(), format!("{:.4}", iss_delta));
+            best_features.insert("MESdiff".to_string(), format!("{:.4}", mes_diff));
+            best_features.insert("de_novo_donor_prob".to_string(), format!("{:.6}", pr));
+        }
+    }
+
+    if best_prob > 0.0 {
+        Some(DeNovoDonorResult {
+            probability: best_prob,
+            features: best_features,
+            lof: best_lof,
+            lof_pos: best_lof_pos,
+        })
+    } else {
+        None
+    }
+}
+
+// --- Helper functions ---
+
+fn sorted_exons(tr: &Transcript) -> Vec<&fastvep_genome::Exon> {
+    let mut exons: Vec<&fastvep_genome::Exon> = tr.exons.iter().collect();
+    match tr.strand {
+        Strand::Forward => exons.sort_by_key(|e| e.start),
+        Strand::Reverse => exons.sort_by(|a, b| b.start.cmp(&a.start)),
+    }
+    exons
+}
+
+fn reverse_complement(seq: &[u8]) -> Vec<u8> {
+    seq.iter()
+        .rev()
+        .map(|&b| match b {
+            b'A' | b'a' => b'T',
+            b'T' | b't' => b'A',
+            b'C' | b'c' => b'G',
+            b'G' | b'g' => b'C',
+            other => other,
+        })
+        .collect()
+}
+
+/// Mutate a splice site sequence (9bp or 23bp) at the variant position.
+fn mutate_splice_seq(
+    ref_seq: &[u8],
+    variant_start: u64,
+    _variant_end: u64,
+    _ref_allele: &str,
+    alt_allele: &str,
+    seq_genomic_start: u64,
+    strand: Strand,
+) -> Vec<u8> {
+    let mut result = ref_seq.to_vec();
+    let offset = match strand {
+        Strand::Forward => (variant_start - seq_genomic_start) as usize,
+        Strand::Reverse => (ref_seq.len() - 1) - (variant_start - seq_genomic_start) as usize,
+    };
+    if offset < result.len() && alt_allele.len() == 1 {
+        let alt_byte = if strand == Strand::Reverse {
+            complement(alt_allele.as_bytes()[0])
+        } else {
+            alt_allele.as_bytes()[0].to_ascii_uppercase()
+        };
+        result[offset] = alt_byte;
+    }
+    result
+}
+
+/// Mutate a full-length sequence for de novo donor analysis.
+fn mutate_full_seq(
+    seq: &[u8],
+    var_pos: usize,
+    ref_allele: &str,
+    alt_allele: &str,
+    strand: Strand,
+) -> (Vec<u8>, i64) {
+    let mut result = seq.to_vec();
+    let alt_bases: Vec<u8> = if strand == Strand::Reverse {
+        alt_allele
+            .as_bytes()
+            .iter()
+            .rev()
+            .map(|&b| complement(b))
+            .collect()
+    } else {
+        alt_allele.as_bytes().iter().map(|b| b.to_ascii_uppercase()).collect()
+    };
+
+    if ref_allele == "-" {
+        // Insertion
+        for (j, &b) in alt_bases.iter().enumerate() {
+            result.insert(var_pos + j, b);
+        }
+        (result, alt_bases.len() as i64)
+    } else if alt_allele == "-" {
+        // Deletion
+        let del_len = ref_allele.len().min(result.len() - var_pos);
+        result.drain(var_pos..var_pos + del_len);
+        (result, -(del_len as i64))
+    } else {
+        // SNP or MNP
+        for (j, &b) in alt_bases.iter().enumerate() {
+            if var_pos + j < result.len() {
+                result[var_pos + j] = b;
+            }
+        }
+        (result, alt_bases.len() as i64 - ref_allele.len() as i64)
+    }
+}
+
+fn complement(b: u8) -> u8 {
+    match b {
+        b'A' | b'a' => b'T',
+        b'T' | b't' => b'A',
+        b'C' | b'c' => b'G',
+        b'G' | b'g' => b'C',
+        other => other,
+    }
+}
+
+/// Compute SRE motif count delta between new and reference junctions.
+fn compute_sre_delta(
+    seq: &[u8],
+    new_junc: usize,
+    ref_junc: usize,
+    flanksize: usize,
+    motifs: &MotifSet,
+    motif_type: MotifType,
+    upstream: bool,
+) -> f64 {
+    let len = seq.len();
+    let (new_start, new_end) = if upstream {
+        (new_junc.saturating_sub(flanksize), new_junc.min(len))
+    } else {
+        (new_junc.min(len), (new_junc + flanksize).min(len))
+    };
+    let (ref_start, ref_end) = if upstream {
+        (ref_junc.saturating_sub(flanksize), ref_junc.min(len))
+    } else {
+        (ref_junc.min(len), (ref_junc + flanksize).min(len))
+    };
+
+    let new_count = if new_start < new_end {
+        motifs.scan(&seq[new_start..new_end], motif_type)
+    } else {
+        0
+    };
+    let ref_count = if ref_start < ref_end {
+        motifs.scan(&seq[ref_start..ref_end], motif_type)
+    } else {
+        0
+    };
+
+    new_count as f64 - ref_count as f64
+}
+
+/// Check if exon extension/truncation introduces a stop codon.
+fn check_stop_introduced(seq: &[u8], new_junc: usize, ref_junc: usize) -> bool {
+    let (start, end) = if new_junc > ref_junc {
+        (ref_junc, new_junc)
+    } else {
+        (new_junc, ref_junc)
+    };
+
+    // Check codons in the extended/truncated region
+    let region = &seq[start..end.min(seq.len())];
+    for i in (0..region.len()).step_by(3) {
+        if i + 3 <= region.len() {
+            let codon = &region[i..i + 3];
+            let codon_upper: Vec<u8> = codon.iter().map(|b| b.to_ascii_uppercase()).collect();
+            if codon_upper == b"TAG" || codon_upper == b"TAA" || codon_upper == b"TGA" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reverse_complement() {
+        assert_eq!(reverse_complement(b"ACGT"), b"ACGT");
+        assert_eq!(reverse_complement(b"AAAA"), b"TTTT");
+        assert_eq!(reverse_complement(b"GCAT"), b"ATGC");
+    }
+
+    #[test]
+    fn test_mutate_full_seq_snp() {
+        let seq = b"ACGTACGT";
+        let (result, delta) = mutate_full_seq(seq, 2, "G", "A", Strand::Forward);
+        assert_eq!(result, b"ACATACGT");
+        assert_eq!(delta, 0);
+    }
+
+    #[test]
+    fn test_mutate_full_seq_insertion() {
+        let seq = b"ACGTACGT";
+        let (result, delta) = mutate_full_seq(seq, 2, "-", "AA", Strand::Forward);
+        assert_eq!(result, b"ACAAGTACGT");
+        assert_eq!(delta, 2);
+    }
+
+    #[test]
+    fn test_mutate_full_seq_deletion() {
+        let seq = b"ACGTACGT";
+        let (result, delta) = mutate_full_seq(seq, 2, "GT", "-", Strand::Forward);
+        assert_eq!(result, b"ACACGT");
+        assert_eq!(delta, -2);
+    }
+
+    #[test]
+    fn test_check_stop_introduced() {
+        // Region contains TAG
+        assert!(check_stop_introduced(b"AAATAGGGG", 0, 6));
+        // No stop codon
+        assert!(!check_stop_introduced(b"AAAGCTGGG", 0, 6));
+        // TAA
+        assert!(check_stop_introduced(b"TAAGGGGGG", 0, 3));
+        // TGA
+        assert!(check_stop_introduced(b"TGAGGGGGG", 0, 3));
+    }
+}

--- a/crates/fastvep-loftee/src/svm.rs
+++ b/crates/fastvep-loftee/src/svm.rs
@@ -1,0 +1,221 @@
+//! SVM evaluation for de novo donor splice site prediction.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Pre-loaded SVM model for de novo donor prediction.
+pub struct SvmModel {
+    /// Feature names in order.
+    pub feature_names: Vec<String>,
+    /// Support vectors: each row is [feature_values..., alpha].
+    pub support_vectors: Vec<Vec<f64>>,
+    /// Feature centering values.
+    pub center: HashMap<String, f64>,
+    /// Feature scaling values.
+    pub scale: HashMap<String, f64>,
+    /// SVM parameter: decision boundary offset.
+    pub rho: f64,
+    /// Platt scaling parameter A.
+    pub prob_a: f64,
+    /// Platt scaling parameter B.
+    pub prob_b: f64,
+    /// RBF kernel gamma parameter.
+    pub gamma: f64,
+}
+
+impl SvmModel {
+    /// Load SVM model from a directory containing sv.txt, center.txt, scale.txt, misc.txt.
+    pub fn load(dir: &Path) -> Result<Self, String> {
+        // Load support vectors
+        let sv_path = dir.join("sv.txt");
+        let file = std::fs::File::open(&sv_path)
+            .map_err(|e| format!("Cannot open {}: {}", sv_path.display(), e))?;
+        let reader = BufReader::new(file);
+        let mut lines = reader.lines();
+
+        // First line is header with feature names
+        let header_line = lines
+            .next()
+            .ok_or("Empty sv.txt")?
+            .map_err(|e| format!("Read error: {}", e))?;
+        let feature_names: Vec<String> = header_line
+            .split('\t')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim().to_string())
+            .collect();
+        // Last column is "alpha", feature names are all but last
+        let n_features = feature_names.len() - 1; // exclude alpha
+
+        let mut support_vectors = Vec::new();
+        for line in lines {
+            let line = line.map_err(|e| format!("Read error: {}", e))?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let values: Vec<f64> = trimmed
+                .split('\t')
+                .filter_map(|s| s.trim().parse().ok())
+                .collect();
+            if values.len() == n_features + 1 {
+                support_vectors.push(values);
+            }
+        }
+
+        // Load center, scale, misc
+        let center = load_kv_file(&dir.join("center.txt"))?;
+        let scale = load_kv_file(&dir.join("scale.txt"))?;
+        let misc = load_kv_file(&dir.join("misc.txt"))?;
+
+        let rho = *misc.get("rho").ok_or("Missing rho in misc.txt")?;
+        let prob_a = *misc.get("probA").ok_or("Missing probA in misc.txt")?;
+        let prob_b = *misc.get("probB").ok_or("Missing probB in misc.txt")?;
+        let gamma = *misc.get("gamma").ok_or("Missing gamma in misc.txt")?;
+
+        Ok(Self {
+            feature_names: feature_names[..n_features].to_vec(),
+            support_vectors,
+            center,
+            scale,
+            rho,
+            prob_a,
+            prob_b,
+            gamma,
+        })
+    }
+
+    /// Evaluate the SVM decision function for the given features.
+    /// Returns the raw margin value.
+    pub fn decision_function(&self, features: &HashMap<String, f64>) -> f64 {
+        // Scale features
+        let scaled: Vec<f64> = self
+            .feature_names
+            .iter()
+            .map(|name| {
+                let val = features.get(name).copied().unwrap_or(0.0);
+                let center = self.center.get(name).copied().unwrap_or(0.0);
+                let scale = self.scale.get(name).copied().unwrap_or(1.0);
+                (val - center) / scale
+            })
+            .collect();
+
+        let n_features = self.feature_names.len();
+        let mut margin = 0.0;
+
+        for sv in &self.support_vectors {
+            let sv_features = &sv[..n_features];
+            let alpha = sv[n_features];
+
+            // RBF kernel
+            let k = rbf_kernel(&scaled, sv_features, self.gamma);
+            margin += alpha * k;
+        }
+
+        margin - self.rho
+    }
+
+    /// Convert SVM margin to probability using Platt scaling.
+    pub fn predict_probability(&self, margin: f64) -> f64 {
+        let logit = self.prob_a * margin + self.prob_b;
+        1.0 / (1.0 + (-logit).exp())
+    }
+
+    /// Evaluate SVM and return probability.
+    pub fn predict(&self, features: &HashMap<String, f64>) -> f64 {
+        let margin = self.decision_function(features);
+        self.predict_probability(margin)
+    }
+}
+
+/// RBF (Radial Basis Function) kernel.
+fn rbf_kernel(v1: &[f64], v2: &[f64], gamma: f64) -> f64 {
+    let sq_dist: f64 = v1
+        .iter()
+        .zip(v2.iter())
+        .map(|(a, b)| (a - b).powi(2))
+        .sum();
+    (-gamma * sq_dist).exp()
+}
+
+fn load_kv_file(path: &Path) -> Result<HashMap<String, f64>, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("Cannot open {}: {}", path.display(), e))?;
+    let reader = BufReader::new(file);
+    let mut map = HashMap::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("Read error: {}", e))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split('\t').collect();
+        if parts.len() == 2 {
+            if let Ok(val) = parts[1].parse() {
+                map.insert(parts[0].to_string(), val);
+            }
+        }
+    }
+    Ok(map)
+}
+
+/// Logistic regression scoring (used for disruption probability).
+pub fn logreg(features: &HashMap<String, f64>, coefficients: &HashMap<String, f64>) -> f64 {
+    let mut logit = coefficients.get("(Intercept)").copied().unwrap_or(0.0);
+    for (name, &coef) in coefficients {
+        if name == "(Intercept)" {
+            continue;
+        }
+        let val = features.get(name).copied().unwrap_or(0.0);
+        logit += coef * val;
+    }
+    1.0 / (1.0 + (-logit).exp())
+}
+
+/// Load logistic regression coefficients from a file (name\tvalue per line).
+pub fn load_logreg_model(path: &Path) -> Result<HashMap<String, f64>, String> {
+    load_kv_file(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rbf_kernel_same() {
+        let v = vec![1.0, 2.0, 3.0];
+        let k = rbf_kernel(&v, &v, 0.25);
+        assert!((k - 1.0).abs() < 1e-10); // same vector → distance=0, exp(0)=1
+    }
+
+    #[test]
+    fn test_rbf_kernel_different() {
+        let v1 = vec![0.0, 0.0];
+        let v2 = vec![1.0, 1.0];
+        let k = rbf_kernel(&v1, &v2, 0.25);
+        // sq_dist = 2.0, exp(-0.25*2.0) = exp(-0.5) ≈ 0.6065
+        assert!((k - 0.6065).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_logreg() {
+        let mut features = HashMap::new();
+        features.insert("x".to_string(), 1.0);
+        let mut coefficients = HashMap::new();
+        coefficients.insert("(Intercept)".to_string(), 0.0);
+        coefficients.insert("x".to_string(), 0.0);
+        let prob = logreg(&features, &coefficients);
+        assert!((prob - 0.5).abs() < 1e-10); // logit=0 → prob=0.5
+    }
+
+    #[test]
+    fn test_logreg_strong_positive() {
+        let mut features = HashMap::new();
+        features.insert("x".to_string(), 10.0);
+        let mut coefficients = HashMap::new();
+        coefficients.insert("(Intercept)".to_string(), 0.0);
+        coefficients.insert("x".to_string(), 1.0);
+        let prob = logreg(&features, &coefficients);
+        assert!(prob > 0.999); // logit=10 → very high probability
+    }
+}


### PR DESCRIPTION
Port the LOFTEE VEP plugin (Karczewski et al.) to native Rust as a new fastvep-loftee crate. Classifies putative LoF variants (stop-gained, frameshift, splice-site) as HC/LC/OS with filter and flag annotations.

Implements all four phases:
- Phase 1: Structural filters (END_TRUNC, SMALL_INTRON, INCOMPLETE_CDS, EXON_INTRON_UNDEF, SINGLE_EXON), sequence context filters (GC_TO_GT_DONOR, NON_CAN_SPLICE, NAGNAG_SITE, 5UTR_SPLICE, 3UTR_SPLICE), HC/LC confidence
- Phase 2: ANC_ALLELE via ancestral sequence provider
- Phase 3: MaxEntScan scoring, extended splice disruption prediction, de novo donor detection with SVM, OS confidence level
- Phase 4: GERP weighted distance, PhyloCSF conservation flags

Adds LofteeResult to AlleleAnnotation and LoF/LoF_filter/LoF_flags/LoF_info fields to JSON and CSQ output formats.