### PR TITLE
Wire mitochondrial codon table and origin-wrapping into production paths (#68)

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -494,10 +494,19 @@ impl AnnotationContext {
                                                     tr.cdna_coding_start,
                                                     ac.cds_start,
                                                 ) {
+                                                    // Guard against malformed/truncated
+                                                    // GFF3-derived transcript data where
+                                                    // `coding_start` is inconsistent with the
+                                                    // actual spliced sequence length — skip
+                                                    // HGVSp generation for this case rather
+                                                    // than panicking on an out-of-bounds slice.
                                                     let coding_start_idx =
                                                         (coding_start - 1) as usize;
                                                     let spliced_bytes: &[u8] =
                                                         spliced.as_bytes();
+                                                    if coding_start >= 1
+                                                        && coding_start_idx <= spliced_bytes.len()
+                                                    {
                                                     let ref_from_cds =
                                                         &spliced_bytes[coding_start_idx..];
                                                     let cds_idx = (cds_s - 1) as usize;
@@ -552,6 +561,7 @@ impl AnnotationContext {
                                                             codon_start,
                                                             &fs_codon_table,
                                                         );
+                                                    }
                                                 }
                                             } else if aa.1 == "-"
                                                 || ac
@@ -1362,5 +1372,162 @@ mod tests {
             .annotate_vcf_text_with_acmg(vcf, false, None)
             .unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn hgvsp_frameshift_skips_gracefully_on_inconsistent_spliced_seq_len() {
+        // Regression: the HGVSp-frameshift branch slices
+        // `spliced.as_bytes()[coding_start_idx..]` where `coding_start_idx`
+        // comes from `tr.cdna_coding_start`. If `spliced_seq` is ever shorter
+        // than `coding_start_idx` implies -- e.g. malformed/truncated GFF3-
+        // or cache-derived transcript data -- this must not panic ("range
+        // start index out of range"); it should just skip HGVSp generation.
+        //
+        // `cdna_coding_start`/`cdna_coding_end` (used by the predictor, via
+        // `cdna_to_cds`, to classify the variant and via `translateable_seq`
+        // to compute amino acids) are left internally consistent, so the
+        // variant is still correctly classified as a frameshift with real
+        // amino acids computed -- only `spliced_seq` itself (used solely by
+        // fastvep-annotate's separate HGVSp-slicing code, not by the
+        // predictor) is corrupted, isolating the guard under test.
+        use fastvep_genome::{Exon, Gene, Transcript, Translation};
+
+        // Two-exon transcript on chr1: exon1 is a 50bp 5' UTR (genomic
+        // 1-50), exon2 is the fully-coding CDS (genomic 51-62): ATG AAA CCC
+        // TAA (Met Lys Pro Stop).
+        let mut transcript = Transcript {
+            stable_id: "ENST_FS_TEST".into(),
+            version: None,
+            gene: Gene {
+                stable_id: "ENSG_FS_TEST".into(),
+                symbol: Some("FS-TEST".into()),
+                symbol_source: None,
+                hgnc_id: None,
+                biotype: "protein_coding".into(),
+                chromosome: "1".into(),
+                start: 1,
+                end: 62,
+                strand: fastvep_core::Strand::Forward,
+            },
+            biotype: "protein_coding".into(),
+            chromosome: "1".into(),
+            start: 1,
+            end: 62,
+            strand: fastvep_core::Strand::Forward,
+            exons: vec![
+                Exon {
+                    stable_id: "ENSE_FS_TEST_1".into(),
+                    start: 1,
+                    end: 50,
+                    strand: fastvep_core::Strand::Forward,
+                    phase: -1,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "ENSE_FS_TEST_2".into(),
+                    start: 51,
+                    end: 62,
+                    strand: fastvep_core::Strand::Forward,
+                    phase: 0,
+                    end_phase: -1,
+                    rank: 2,
+                },
+            ],
+            translation: Some(Translation {
+                stable_id: "ENSP_FS_TEST".into(),
+                genomic_start: 51,
+                genomic_end: 62,
+                start_exon_rank: 2,
+                start_exon_offset: 0,
+                end_exon_rank: 2,
+                end_exon_offset: 11,
+            }),
+            cdna_coding_start: Some(51),
+            cdna_coding_end: Some(62),
+            coding_region_start: Some(51),
+            coding_region_end: Some(62),
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: true,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: Some("ENSP_FS_TEST".into()),
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
+        };
+
+        transcript
+            .build_sequences(|_chrom, start, _end| {
+                if start == 1 {
+                    Ok(b"N".repeat(50))
+                } else {
+                    Ok(b"ATGAAACCCTAA".to_vec())
+                }
+            })
+            .expect("build_sequences should succeed for a well-formed test transcript");
+        assert_eq!(transcript.translateable_seq.as_deref(), Some("ATGAAACCCTAA"));
+        assert_eq!(transcript.spliced_seq.as_deref().map(|s| s.len()), Some(62));
+
+        // Simulate `spliced_seq` becoming shorter than `cdna_coding_start`
+        // implies (e.g. a corrupted/truncated cache reload of just this
+        // field) -- `cdna_coding_start` (51) is left untouched, so
+        // coding_start_idx (50) now exceeds the truncated spliced_seq's
+        // length (20).
+        transcript.spliced_seq = transcript.spliced_seq.map(|s| s[..20].to_string());
+
+        let mut ctx = empty_context();
+        ctx.transcript_provider = IndexedTranscriptProvider::new(vec![transcript]);
+
+        // 1bp deletion of the "G" at genomic position 53 (VCF-anchored at
+        // 52): ATG -> AT_ + AAA... = frameshift.
+        let vcf = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+                   1\t52\t.\tTG\tT\t.\tPASS\t.\n";
+
+        // Must not panic despite the truncated spliced_seq.
+        let results = ctx
+            .annotate_vcf_text_with_acmg(vcf, false, None)
+            .expect("annotation should succeed even with a truncated spliced_seq");
+        assert_eq!(results.len(), 1);
+
+        // Confirm this actually exercised the guarded path: the variant must
+        // still be classified as a frameshift with real amino acids (proving
+        // the truncated spliced_seq didn't derail classification, since that
+        // uses translateable_seq/coding_region_start/coding_region_end
+        // instead), but with no hgvsp emitted (proving the slicing guard
+        // skipped it rather than panicking).
+        let tc = &results[0]["transcript_consequences"][0];
+        let terms = tc["consequence_terms"]
+            .as_array()
+            .expect("consequence_terms should be present");
+        assert!(
+            terms
+                .iter()
+                .any(|t| t.as_str() == Some("frameshift_variant")),
+            "expected frameshift_variant, got: {:?}",
+            terms
+        );
+        assert!(
+            tc.get("amino_acids").is_some(),
+            "amino acids should still be computed from the intact translateable_seq: {:?}",
+            tc
+        );
+        assert!(
+            tc.get("hgvsp").is_none(),
+            "hgvsp should be omitted (skipped), not present, when spliced_seq is \
+             shorter than coding_start_idx implies: {:?}",
+            tc
+        );
     }
 }

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -1477,7 +1477,10 @@ mod tests {
                 }
             })
             .expect("build_sequences should succeed for a well-formed test transcript");
-        assert_eq!(transcript.translateable_seq.as_deref(), Some("ATGAAACCCTAA"));
+        assert_eq!(
+            transcript.translateable_seq.as_deref(),
+            Some("ATGAAACCCTAA")
+        );
         assert_eq!(transcript.spliced_seq.as_deref().map(|s| s.len()), Some(62));
 
         // Simulate `spliced_seq` becoming shorter than `cdna_coding_start`

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -538,12 +538,19 @@ impl AnnotationContext {
                                                         }
                                                     }
                                                     let codon_start = cds_idx / 3;
+                                                    let fs_codon_table =
+                                                        if fastvep_genome::is_mitochondrial(&tr.chromosome) {
+                                                            fastvep_genome::mitochondrial_codon_table()
+                                                        } else {
+                                                            fastvep_genome::CodonTable::standard()
+                                                        };
                                                     ann.hgvsp =
                                                         fastvep_hgvs::hgvsp_frameshift(
                                                             &versioned_pid,
                                                             ref_from_cds,
                                                             &alt_from_cds,
                                                             codon_start,
+                                                            &fs_codon_table,
                                                         );
                                                 }
                                             } else if aa.1 == "-"

--- a/crates/fastvep-annotate/tests/mitochondrial.rs
+++ b/crates/fastvep-annotate/tests/mitochondrial.rs
@@ -1,0 +1,226 @@
+//! End-to-end regression tests for GitHub issue #68: the vertebrate
+//! mitochondrial codon table (NCBI translation table 2) and circular-genome
+//! coordinate wrapping existed in `fastvep_genome::mitochondrial` but were
+//! never wired into the production consequence-prediction / HGVS-protein
+//! pipeline. These tests build a minimal MT transcript + FASTA and exercise
+//! the exact production call chain (`Transcript::build_sequences` ->
+//! `fastvep_cache` sequence provider -> `ConsequencePredictor::predict` ->
+//! `fastvep_hgvs::hgvsp`) rather than calling the codon table directly, so a
+//! regression in any one of those wiring points fails the test.
+
+use fastvep_cache::fasta::FastaReader;
+use fastvep_cache::providers::{FastaSequenceProvider, SequenceProvider};
+use fastvep_consequence::ConsequencePredictor;
+use fastvep_core::{Allele, Consequence, GenomicPosition, Strand};
+use fastvep_genome::{Exon, Gene, Transcript, Translation, MT_LENGTH};
+
+/// Build a single-exon, fully-coding MT transcript whose CDS is exactly the
+/// concatenation of `exon_start..=exon_end` (using the "extended", possibly
+/// origin-wrapping, genomic numbering described on [`fetch_circular`] in
+/// fastvep-cache: coordinates may run past `MT_LENGTH` to represent a region
+/// that physically continues from position 1).
+fn mt_transcript(exon_start: u64, exon_end: u64, cds_len: u64) -> Transcript {
+    Transcript {
+        stable_id: "ENST_MT_TEST".into(),
+        version: None,
+        gene: Gene {
+            stable_id: "ENSG_MT_TEST".into(),
+            symbol: Some("MT-TEST".into()),
+            symbol_source: None,
+            hgnc_id: None,
+            biotype: "protein_coding".into(),
+            chromosome: "MT".into(),
+            start: exon_start,
+            end: exon_end,
+            strand: Strand::Forward,
+        },
+        biotype: "protein_coding".into(),
+        chromosome: "MT".into(),
+        start: exon_start,
+        end: exon_end,
+        strand: Strand::Forward,
+        exons: vec![Exon {
+            stable_id: "ENSE_MT_TEST".into(),
+            start: exon_start,
+            end: exon_end,
+            strand: Strand::Forward,
+            phase: -1,
+            end_phase: -1,
+            rank: 1,
+        }],
+        translation: Some(Translation {
+            stable_id: "ENSP_MT_TEST".into(),
+            genomic_start: exon_start,
+            genomic_end: exon_end,
+            start_exon_rank: 1,
+            start_exon_offset: 0,
+            end_exon_rank: 1,
+            end_exon_offset: cds_len - 1,
+        }),
+        cdna_coding_start: Some(1),
+        cdna_coding_end: Some(cds_len),
+        coding_region_start: Some(exon_start),
+        coding_region_end: Some(exon_end),
+        spliced_seq: None,
+        translateable_seq: None,
+        peptide: None,
+        canonical: true,
+        mane_select: None,
+        mane_plus_clinical: None,
+        tsl: None,
+        appris: None,
+        ccds: None,
+        protein_id: Some("ENSP_MT_TEST".into()),
+        protein_version: None,
+        swissprot: vec![],
+        trembl: vec![],
+        uniparc: vec![],
+        refseq_id: None,
+        source: None,
+        gencode_primary: false,
+        flags: vec![],
+        codon_table_start_phase: 0,
+    }
+}
+
+/// Build sequences on `transcript` using a `FastaSequenceProvider` over
+/// `fasta_text`, exactly the way `fastvep-annotate`/`fastvep-cli` do in
+/// production (so an MT-origin-spanning fetch goes through the real
+/// `fetch_circular` wraparound logic in `fastvep-cache`, not a test double).
+fn build_sequences_from_fasta(transcript: &mut Transcript, fasta_text: &str) {
+    let reader = FastaReader::from_reader(fasta_text.as_bytes()).expect("valid test FASTA");
+    let provider = FastaSequenceProvider::new(reader);
+    transcript
+        .build_sequences(|chrom, start, end| {
+            provider
+                .fetch_sequence(chrom, start, end)
+                .map_err(|e| e.to_string())
+        })
+        .expect("build_sequences should succeed for a well-formed MT test transcript");
+}
+
+/// TGA is a stop codon in the standard nuclear code but Trp in the
+/// vertebrate mitochondrial code. A Trp(TGG)->TGA substitution on an MT
+/// transcript must therefore be `synonymous_variant`, not `stop_gained`
+/// (which is what fastVEP predicted before the vertebrate mitochondrial
+/// table was wired into `ConsequencePredictor`/`Transcript::build_sequences`).
+#[test]
+fn mt_tga_reads_as_tryptophan_not_stop() {
+    // CDS (positions 1-12 on a 12bp toy "MT" contig): ATG TGG AAA TAA
+    // (Met, Trp, Lys, Stop) -- codon 2 (protein position 2) is the target.
+    let fasta = ">MT\nATGTGGAAATAA\n";
+    let mut transcript = mt_transcript(1, 12, 12);
+    build_sequences_from_fasta(&mut transcript, fasta);
+    assert_eq!(transcript.translateable_seq.as_deref(), Some("ATGTGGAAATAA"));
+    // Peptide translation (Transcript::build_sequences) must also use the
+    // mitochondrial table: MTAK* would be wrong; the correct read is M W K *.
+    assert_eq!(transcript.peptide.as_deref(), Some("MWK*"));
+
+    // Variant: position 6 (last base of codon 2), G -> A: TGG -> TGA.
+    let position = GenomicPosition::new("MT", 6, 6, Strand::Forward);
+    let ref_allele = Allele::Sequence(b"G".to_vec());
+    let alt_allele = Allele::Sequence(b"A".to_vec());
+
+    let predictor = ConsequencePredictor::new(5000, 5000);
+    let result = predictor.predict(&position, &ref_allele, &[alt_allele], &[&transcript], None);
+
+    let tc = &result.transcript_consequences[0];
+    let ac = &tc.allele_consequences[0];
+
+    assert_eq!(
+        ac.consequences,
+        vec![Consequence::SynonymousVariant],
+        "TGA must read as Trp (synonymous with Trp->Trp), not stop_gained, on an MT transcript"
+    );
+    assert_eq!(ac.protein_start, Some(2));
+    let (ref_aa, alt_aa) = ac.amino_acids.clone().expect("amino acids computed");
+    assert_eq!((ref_aa.as_str(), alt_aa.as_str()), ("W", "W"));
+
+    let hgvsp = fastvep_hgvs::hgvsp(
+        "ENSP_MT_TEST",
+        ac.protein_start.unwrap(),
+        ref_aa.as_bytes()[0],
+        alt_aa.as_bytes()[0],
+        false,
+    );
+    assert_eq!(hgvsp, Some("ENSP_MT_TEST:p.Trp2=".to_string()));
+}
+
+/// An MT allele spanning the circular origin (human rCRS position
+/// 16569 -> 1) must be stitched into a single correct codon instead of being
+/// silently truncated or erroring. This variant also exercises the AGA
+/// codon: Arg in the standard code, a stop in the vertebrate mitochondrial
+/// code, so getting the wrong table *or* the wrong (unwrapped) sequence both
+/// independently corrupt the call -- only the fully-wired path gets both
+/// pieces right and reports stop_gained.
+#[test]
+fn mt_origin_spanning_allele_produces_stop_gained() {
+    assert_eq!(MT_LENGTH, 16569);
+
+    // Build a 16,569 base circular "MT" contig. Only the bases this test
+    // actually reads are meaningful; everything else is filler ('N').
+    let mut seq = vec![b'N'; MT_LENGTH as usize];
+    // Codon 1 (protein pos 1, start codon), genomic 16566-16568: "ATG".
+    seq[16565] = b'A'; // pos 16566
+    seq[16566] = b'T'; // pos 16567
+    seq[16567] = b'G'; // pos 16568
+    // Codon 2 (protein pos 2), genomic 16569, then wraps to 1, 2: "CGA".
+    seq[16568] = b'C'; // pos 16569 (last base of the contig)
+    seq[0] = b'G'; // pos 1 (wrapped)
+    seq[1] = b'A'; // pos 2 (wrapped)
+    // Codon 3 (protein pos 3), wrapped genomic 3, 4, 5: "AAA" (Lys).
+    seq[2] = b'A';
+    seq[3] = b'A';
+    seq[4] = b'A';
+    // Codon 4 (protein pos 4), wrapped genomic 6, 7, 8: "TAA" (Stop, both tables).
+    seq[5] = b'T';
+    seq[6] = b'A';
+    seq[7] = b'A';
+    let fasta = format!(">MT\n{}\n", String::from_utf8(seq).unwrap());
+
+    // Exon spans genomic 16566 .. 16577 in "extended" numbering (12 bases:
+    // 16566-16569 physically, then wrapping to 1-8) -- matching how
+    // fastvep-io computes an unwrapped `end` for an MT allele/feature whose
+    // footprint runs past the last physical base.
+    let mut transcript = mt_transcript(16566, 16577, 12);
+    build_sequences_from_fasta(&mut transcript, &fasta);
+    assert_eq!(
+        transcript.translateable_seq.as_deref(),
+        Some("ATGCGAAAATAA"),
+        "codon spanning the origin (16569->1->2 = CGA) must be assembled correctly, not truncated"
+    );
+    assert_eq!(transcript.peptide.as_deref(), Some("MRK*"));
+
+    // Variant: genomic 16569-16570 (extended; 16570 wraps to physical
+    // position 1), REF "CG" -> ALT "AG": codon 2 CGA -> AGA.
+    let position = GenomicPosition::new("MT", 16569, 16570, Strand::Forward);
+    let ref_allele = Allele::Sequence(b"CG".to_vec());
+    let alt_allele = Allele::Sequence(b"AG".to_vec());
+
+    let predictor = ConsequencePredictor::new(5000, 5000);
+    let result = predictor.predict(&position, &ref_allele, &[alt_allele], &[&transcript], None);
+
+    let tc = &result.transcript_consequences[0];
+    let ac = &tc.allele_consequences[0];
+
+    assert_eq!(
+        ac.consequences,
+        vec![Consequence::StopGained],
+        "AGA is a stop under the vertebrate mitochondrial code -- an allele \
+         spanning the MT origin that creates it must be classified as \
+         stop_gained (a standard-table read would call this synonymous \
+         Arg->Arg and silently miss a real stop gain)"
+    );
+    assert_eq!(ac.protein_start, Some(2));
+    let (ref_aa, alt_aa) = ac.amino_acids.clone().expect("amino acids computed");
+    assert_eq!((ref_aa.as_str(), alt_aa.as_str()), ("R", "*"));
+
+    let hgvsp = fastvep_hgvs::hgvsp(
+        "ENSP_MT_TEST",
+        ac.protein_start.unwrap(),
+        ref_aa.as_bytes()[0],
+        alt_aa.as_bytes()[0],
+        false,
+    );
+    assert_eq!(hgvsp, Some("ENSP_MT_TEST:p.Arg2Ter".to_string()));
+}

--- a/crates/fastvep-cache/src/fasta.rs
+++ b/crates/fastvep-cache/src/fasta.rs
@@ -229,11 +229,19 @@ pub fn parse_fai(contents: &str) -> Result<Vec<FaiEntry>> {
         if fields.len() < 5 {
             continue;
         }
+        let line_bases: u64 = fields[3].parse()?;
+        // `line_bases` is used as a divisor wherever this entry is looked up
+        // (e.g. `pos / entry.line_bases`). A corrupted .fai with
+        // `line_bases=0` would cause an integer-division panic there; skip
+        // the entry here instead, same as any other malformed line above.
+        if line_bases == 0 {
+            continue;
+        }
         entries.push(FaiEntry {
             name: fields[0].to_string(),
             length: fields[1].parse()?,
             offset: fields[2].parse()?,
-            line_bases: fields[3].parse()?,
+            line_bases,
             line_bytes: fields[4].parse()?,
         });
     }
@@ -342,6 +350,19 @@ mod tests {
         assert_eq!(entries[0].name, "chr1");
         assert_eq!(entries[0].length, 248956422);
         assert_eq!(entries[1].name, "chr2");
+    }
+
+    #[test]
+    fn test_parse_fai_skips_zero_line_bases() {
+        // Regression: `line_bases` is used as a divisor everywhere a FaiEntry
+        // is looked up (`pos / entry.line_bases`). A corrupted .fai with
+        // line_bases=0 must not be turned into a usable entry -- it must be
+        // skipped, same as any other malformed line -- otherwise a later
+        // fetch against it divides by zero and panics.
+        let fai = "chr1\t248956422\t6\t0\t71\nchr2\t242193529\t252513167\t70\t71\n";
+        let entries = parse_fai(fai).unwrap();
+        assert_eq!(entries.len(), 1, "the line_bases=0 entry must be skipped");
+        assert_eq!(entries[0].name, "chr2");
     }
 
     #[test]

--- a/crates/fastvep-cache/src/providers.rs
+++ b/crates/fastvep-cache/src/providers.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use fastvep_core::chrom_aliases;
-use fastvep_genome::Transcript;
+use fastvep_genome::{is_mitochondrial, wrap_position_for, Transcript, MT_LENGTH};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -158,6 +158,48 @@ impl TranscriptProvider for IndexedTranscriptProvider {
     }
 }
 
+/// Fetch a genomic region, wrapping around the origin for circular
+/// (mitochondrial) contigs when `end` extends past the contig's length.
+///
+/// A linear FASTA record for `MT`/`chrM` only has bases `1..=length`, so a
+/// variant whose reference allele runs past the last base (e.g. a 2bp allele
+/// starting at the human rCRS's last position, 16569) logically continues
+/// from position 1. Without this, `fetch` on the underlying reader either
+/// errors (mmap/.fai readers clamp `end` to `length` and would silently
+/// return a truncated, wrong-length slice) or simply omits the wrapped
+/// bases — see fastVEP issue #68.
+///
+/// Only mitochondrial contigs get this treatment; all other chromosomes (and
+/// any MT `end` that doesn't actually exceed the contig length) take the
+/// untouched fast path straight through to `fetch`.
+fn fetch_circular<F>(
+    chrom: &str,
+    start: u64,
+    end: u64,
+    contig_len: Option<u64>,
+    fetch: F,
+) -> Result<Vec<u8>>
+where
+    F: Fn(&str, u64, u64) -> Result<Vec<u8>>,
+{
+    if !is_mitochondrial(chrom) {
+        return fetch(chrom, start, end);
+    }
+    let length = contig_len.unwrap_or(MT_LENGTH);
+    if length == 0 || end <= length {
+        return fetch(chrom, start, end);
+    }
+
+    // The region wraps past the origin: take [start, length] then [1, wrapped_end].
+    let mut result = fetch(chrom, start, length)?;
+    let wrapped_end = wrap_position_for(end, length);
+    if wrapped_end > 0 {
+        let rest = fetch(chrom, 1, wrapped_end)?;
+        result.extend_from_slice(&rest);
+    }
+    Ok(result)
+}
+
 /// Sequence provider backed by a FASTA reader.
 pub struct FastaSequenceProvider {
     reader: crate::fasta::FastaReader,
@@ -171,7 +213,9 @@ impl FastaSequenceProvider {
 
 impl SequenceProvider for FastaSequenceProvider {
     fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
-        self.reader.fetch(chrom, start, end)
+        fetch_circular(chrom, start, end, self.reader.sequence_length(chrom), |c, s, e| {
+            self.reader.fetch(c, s, e)
+        })
     }
 }
 
@@ -189,7 +233,9 @@ impl MmapFastaSequenceProvider {
 
 impl SequenceProvider for MmapFastaSequenceProvider {
     fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
-        self.reader.fetch(chrom, start, end)
+        fetch_circular(chrom, start, end, self.reader.sequence_length(chrom), |c, s, e| {
+            self.reader.fetch(c, s, e)
+        })
     }
 }
 
@@ -467,5 +513,72 @@ mod tests {
         // Lowercase input is uppercased at load time
         let slice = provider.fetch_sequence_slice("chr2", 5, 8).unwrap();
         assert_eq!(slice, b"GGGG");
+    }
+
+    #[test]
+    fn test_mt_fetch_wraps_around_origin() {
+        // A short synthetic "MT" contig: 10 bases, so a query for [8, 12]
+        // should wrap and read positions 8,9,10 then 1,2 -> "HIJAB".
+        let fasta = ">MT\nABCDEFGHIJ\n";
+        let reader = crate::fasta::FastaReader::from_reader(fasta.as_bytes()).unwrap();
+        let provider = FastaSequenceProvider::new(reader);
+
+        let seq = provider.fetch_sequence("MT", 8, 12).unwrap();
+        assert_eq!(seq, b"HIJAB");
+
+        // A non-wrapping MT query behaves exactly like a normal fetch.
+        let seq = provider.fetch_sequence("MT", 1, 4).unwrap();
+        assert_eq!(seq, b"ABCD");
+    }
+
+    #[test]
+    fn test_mt_fetch_wraps_recognizes_chrm_alias() {
+        // Same as above but using the UCSC `chrM` alias for both the FASTA
+        // record and the query, to confirm is_mitochondrial + alias
+        // resolution compose correctly.
+        let fasta = ">chrM\nABCDEFGHIJ\n";
+        let reader = crate::fasta::FastaReader::from_reader(fasta.as_bytes()).unwrap();
+        let provider = FastaSequenceProvider::new(reader);
+
+        let seq = provider.fetch_sequence("MT", 9, 11).unwrap();
+        assert_eq!(seq, b"IJA");
+    }
+
+    #[test]
+    fn test_non_mt_chrom_is_never_wrapped() {
+        // A non-mitochondrial chromosome with `end` past its length must
+        // fail like a normal out-of-range fetch, not silently wrap.
+        let fasta = ">chr1\nACGT\n";
+        let reader = crate::fasta::FastaReader::from_reader(fasta.as_bytes()).unwrap();
+        let provider = FastaSequenceProvider::new(reader);
+        // fetch_slice-backed fetch clamps end to length rather than erroring;
+        // assert it returns the clamped (not wrapped) sequence.
+        let seq = provider.fetch_sequence("chr1", 1, 10).unwrap();
+        assert_eq!(seq, b"ACGT");
+    }
+
+    #[test]
+    fn test_mmap_mt_fetch_wraps_around_origin() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!(
+            "fastvep-cache-test-mt-wrap-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fasta_path = dir.join("mt.fa");
+        std::fs::write(&fasta_path, ">MT\nABCDEFGHIJ\n").unwrap();
+        let fai_path = dir.join("mt.fa.fai");
+        let mut fai = std::fs::File::create(&fai_path).unwrap();
+        // name, length, offset (after ">MT\n" = 4 bytes), line_bases, line_bytes
+        writeln!(fai, "MT\t10\t4\t10\t11").unwrap();
+
+        let reader = crate::fasta::MmapFastaReader::open(&fasta_path).unwrap();
+        let provider = MmapFastaSequenceProvider::new(reader);
+
+        let seq = provider.fetch_sequence("MT", 8, 12).unwrap();
+        assert_eq!(seq, b"HIJAB");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1095,11 +1095,18 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                                                 }
 
                                                 let codon_start = cds_idx / 3;
+                                                let fs_codon_table =
+                                                    if fastvep_genome::is_mitochondrial(&tr.chromosome) {
+                                                        fastvep_genome::mitochondrial_codon_table()
+                                                    } else {
+                                                        fastvep_genome::CodonTable::standard()
+                                                    };
                                                 ann.hgvsp = fastvep_hgvs::hgvsp_frameshift(
                                                     &versioned_pid,
                                                     ref_from_cds,
                                                     &alt_from_cds,
                                                     codon_start,
+                                                    &fs_codon_table,
                                                 );
                                             }
                                         } else if aa.1 == "-"

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -3410,8 +3410,20 @@ mod custom_source_tests {
         // Both well-formed matching lines pass through; the malformed line
         // is absent from the output (it can't match) but doesn't crash the
         // run or swallow its neighbors.
-        assert!(out.contains("1\t100\t.\tA\tG"), "first well-formed line should pass:\n{}", out);
-        assert!(out.contains("1\t300\t.\tG\tA"), "second well-formed line should pass:\n{}", out);
-        assert!(!out.contains("1\t200\t.\tC\tT"), "malformed line must not appear in output:\n{}", out);
+        assert!(
+            out.contains("1\t100\t.\tA\tG"),
+            "first well-formed line should pass:\n{}",
+            out
+        );
+        assert!(
+            out.contains("1\t300\t.\tG\tA"),
+            "second well-formed line should pass:\n{}",
+            out
+        );
+        assert!(
+            !out.contains("1\t200\t.\tC\tT"),
+            "malformed line must not appear in output:\n{}",
+            out
+        );
     }
 }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1067,8 +1067,13 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                                             if let (Some(ref spliced), Some(coding_start), Some(cds_s)) =
                                                 (&tr.spliced_seq, tr.cdna_coding_start, ac.cds_start)
                                             {
-                                                // Extract from CDS start to end of spliced seq (includes 3'UTR)
+                                                // Extract from CDS start to end of spliced seq (includes 3'UTR).
+                                                // Guard against malformed/truncated GFF3-derived transcript data
+                                                // where `coding_start` is inconsistent with the actual spliced
+                                                // sequence length — skip HGVSp generation for this case rather
+                                                // than panicking on an out-of-bounds slice.
                                                 let coding_start_idx = (coding_start - 1) as usize;
+                                                if coding_start >= 1 && coding_start_idx <= spliced.len() {
                                                 let ref_from_cds = &spliced.as_bytes()[coding_start_idx..];
                                                 let cds_idx = (cds_s - 1) as usize;
                                                 let mut alt_from_cds = ref_from_cds.to_vec();
@@ -1108,6 +1113,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                                                     codon_start,
                                                     &fs_codon_table,
                                                 );
+                                                }
                                             }
                                         } else if aa.1 == "-"
                                             || ac.consequences.contains(&Consequence::InframeDeletion)

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1834,6 +1834,7 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
     let mut csq_fields: Vec<String> = Vec::new();
     let mut kept = 0u64;
     let mut total = 0u64;
+    let mut malformed = 0u64;
 
     for line in reader.lines() {
         let line = line?;
@@ -1862,6 +1863,11 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
         // Parse VCF data line
         let fields: Vec<&str> = line.split('\t').collect();
         if fields.len() < 8 {
+            malformed += 1;
+            eprintln!(
+                "[filter] skipping malformed line {} (fewer than 8 tab-separated fields): {}",
+                total, line
+            );
             continue;
         }
 
@@ -1915,6 +1921,12 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
         "[filter] {} of {} variants passed filter: {}",
         kept, total, filter_expr
     );
+    if malformed > 0 {
+        eprintln!(
+            "[filter] {} of {} lines were skipped as malformed (fewer than 8 tab-separated fields)",
+            malformed, total
+        );
+    }
 
     Ok(())
 }
@@ -3357,5 +3369,49 @@ mod custom_source_tests {
         let msg = format!("{}", err);
         assert!(msg.contains("custom_vcf"), "error message must mention custom_vcf: {}", msg);
         assert!(msg.contains("custom_bed"), "error message must mention custom_bed: {}", msg);
+    }
+
+    #[test]
+    fn run_filter_still_processes_well_formed_lines_when_malformed_lines_present() {
+        // Regression: lines with fewer than 8 tab-separated fields were
+        // silently `continue`d with no diagnostic even though they were
+        // already counted toward `total`. This doesn't change the filtering
+        // behavior (malformed lines still can't match), but verifies that
+        // well-formed lines around a malformed one are still processed
+        // correctly and the function doesn't error out.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("in.vcf");
+        let mut f = std::fs::File::create(&input_path).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=CSQ,Number=.,Type=String,Description=\"Consequence annotations. Format: Consequence|IMPACT\">"
+        )
+        .unwrap();
+        writeln!(f, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO").unwrap();
+        // Well-formed, matches the filter.
+        writeln!(f, "1\t100\t.\tA\tG\t.\tPASS\tCSQ=missense_variant|MODERATE").unwrap();
+        // Malformed: fewer than 8 tab-separated fields.
+        writeln!(f, "1\t200\t.\tC\tT").unwrap();
+        // Well-formed, matches the filter.
+        writeln!(f, "1\t300\t.\tG\tA\t.\tPASS\tCSQ=missense_variant|MODERATE").unwrap();
+        drop(f);
+
+        let output_path = dir.path().join("out.vcf");
+        run_filter(
+            input_path.to_str().unwrap(),
+            output_path.to_str().unwrap(),
+            "Consequence is missense_variant",
+        )
+        .expect("run_filter should not error on a malformed line");
+
+        let out = std::fs::read_to_string(&output_path).unwrap();
+        // Both well-formed matching lines pass through; the malformed line
+        // is absent from the output (it can't match) but doesn't crash the
+        // run or swallow its neighbors.
+        assert!(out.contains("1\t100\t.\tA\tG"), "first well-formed line should pass:\n{}", out);
+        assert!(out.contains("1\t300\t.\tG\tA"), "second well-formed line should pass:\n{}", out);
+        assert!(!out.contains("1\t200\t.\tC\tT"), "malformed line must not appear in output:\n{}", out);
     }
 }

--- a/crates/fastvep-cli/src/webserver.rs
+++ b/crates/fastvep-cli/src/webserver.rs
@@ -1,10 +1,22 @@
 use anyhow::Result;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
+use std::time::Duration;
 
 use fastvep_annotate::AnnotationContext;
 
 const INDEX_HTML: &str = include_str!("../../../web/index.html");
+
+/// Upper bound on an untrusted client's `Content-Length` header. Requests
+/// claiming a larger body are rejected before any allocation is attempted.
+/// Generous enough for real annotation payloads, bounded enough that a
+/// malicious/corrupted header can't force a huge `Vec::with_capacity`.
+const MAX_CONTENT_LENGTH: usize = 100 * 1024 * 1024; // 100 MiB
+
+/// Read timeout applied to every accepted connection before any reads
+/// happen, so a connected-but-silent client can't hang the (single-
+/// threaded, blocking) server indefinitely.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn run_server(port: u16, gff3: Option<String>, fasta: Option<String>) -> Result<()> {
     let mut ctx = AnnotationContext::new(
@@ -23,6 +35,11 @@ pub fn run_server(port: u16, gff3: Option<String>, fasta: Option<String>) -> Res
     for stream in listener.incoming() {
         match stream {
             Ok(mut stream) => {
+                // A connected-but-silent (or slow-drip) client must not be
+                // able to hang this single-threaded server forever.
+                if let Err(e) = stream.set_read_timeout(Some(READ_TIMEOUT)) {
+                    eprintln!("Failed to set read timeout: {}", e);
+                }
                 if let Err(e) = handle_request(&mut stream, &mut ctx) {
                     eprintln!("Request error: {}", e);
                 }
@@ -40,6 +57,7 @@ fn send_json(stream: &mut std::net::TcpStream, status: u16, body: &str) -> Resul
     let status_text = match status {
         200 => "OK",
         400 => "Bad Request",
+        413 => "Payload Too Large",
         500 => "Internal Server Error",
         _ => "OK",
     };
@@ -78,6 +96,18 @@ fn handle_request(stream: &mut std::net::TcpStream, ctx: &mut AnnotationContext)
         if lower.starts_with("content-length:") {
             content_length = lower.trim_start_matches("content-length:").trim().parse().unwrap_or(0);
         }
+    }
+
+    // Reject an oversized Content-Length up front, before any request
+    // handler attempts `vec![0u8; content_length]` — an untrusted client
+    // could otherwise claim an enormous body and force a huge allocation.
+    if content_length > MAX_CONTENT_LENGTH {
+        send_json(
+            stream,
+            413,
+            r#"{"error":"Request body exceeds maximum allowed size"}"#,
+        )?;
+        return Ok(());
     }
 
     match (*method, *path) {
@@ -178,4 +208,89 @@ fn handle_request(stream: &mut std::net::TcpStream, ctx: &mut AnnotationContext)
     }
     stream.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpStream;
+
+    /// Spawn a one-shot server thread that accepts a single connection and
+    /// runs `handle_request` on it, returning the thread's join handle and
+    /// the address to connect to.
+    fn spawn_one_shot_server() -> (std::thread::JoinHandle<()>, std::net::SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let mut ctx = AnnotationContext::new(None, None, None, 5000)
+                .expect("build empty AnnotationContext");
+            handle_request(&mut stream, &mut ctx).expect("handle_request should not error");
+        });
+        (handle, addr)
+    }
+
+    #[test]
+    fn content_length_over_cap_is_rejected_without_allocating() {
+        // A Content-Length far beyond MAX_CONTENT_LENGTH must be rejected
+        // immediately with a clean error response — and critically, the
+        // server must never attempt to read (or allocate for) that many
+        // body bytes. We only send the headers and no body at all; if the
+        // server tried `vec![0u8; content_length]` + `read_exact`, this test
+        // would hang (and eventually fail on the client's read timeout)
+        // instead of getting an immediate response.
+        let (server, addr) = spawn_one_shot_server();
+        let mut client = TcpStream::connect(addr).expect("connect to test server");
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let huge = MAX_CONTENT_LENGTH + 1;
+        let request = format!(
+            "POST /api/annotate HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+            huge
+        );
+        client.write_all(request.as_bytes()).unwrap();
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("server should respond promptly instead of hanging");
+
+        server.join().expect("server thread should not panic");
+
+        assert!(
+            response.starts_with("HTTP/1.1 413"),
+            "expected a 413 response, got: {}",
+            response
+        );
+        assert!(response.contains("Request body exceeds maximum allowed size"));
+    }
+
+    #[test]
+    fn normal_request_parsing_still_works() {
+        // Baseline regression: a well-formed GET request with no body must
+        // still be handled exactly as before these hardening changes.
+        let (server, addr) = spawn_one_shot_server();
+        let mut client = TcpStream::connect(addr).expect("connect to test server");
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        client
+            .write_all(b"GET /api/status HTTP/1.1\r\n\r\n")
+            .unwrap();
+
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+
+        server.join().expect("server thread should not panic");
+
+        assert!(
+            response.starts_with("HTTP/1.1 200"),
+            "expected a 200 response, got: {}",
+            response
+        );
+        assert!(response.contains("\"status\":\"ok\""));
+    }
 }

--- a/crates/fastvep-consequence/src/predictor.rs
+++ b/crates/fastvep-consequence/src/predictor.rs
@@ -1,6 +1,6 @@
 use fastvep_core::{Allele, Consequence, GenomicPosition, Impact, Strand};
 use fastvep_genome::codon::format_codon_change;
-use fastvep_genome::{CodonTable, Transcript};
+use fastvep_genome::{is_mitochondrial, mitochondrial_codon_table, CodonTable, Transcript};
 use std::sync::Arc;
 
 use crate::splice;
@@ -48,6 +48,11 @@ pub struct ConsequencePredictor {
     pub upstream_distance: u64,
     pub downstream_distance: u64,
     codon_table: CodonTable,
+    /// Vertebrate mitochondrial codon table (NCBI translation table 2), used
+    /// instead of `codon_table` whenever the transcript being predicted is on
+    /// the mitochondrial chromosome (see [`is_mitochondrial`]). Built once
+    /// up front so per-allele translation doesn't reconstruct the table.
+    mt_codon_table: CodonTable,
 }
 
 impl ConsequencePredictor {
@@ -56,6 +61,20 @@ impl ConsequencePredictor {
             upstream_distance,
             downstream_distance,
             codon_table: CodonTable::standard(),
+            mt_codon_table: mitochondrial_codon_table(),
+        }
+    }
+
+    /// Select the codon table to use for a given transcript: the vertebrate
+    /// mitochondrial table (NCBI table 2) for MT transcripts, the standard
+    /// nuclear table otherwise. AGA/AGG (Arg->Stop), ATA (Ile->Met), and TGA
+    /// (Stop->Trp) all differ between the two, so using the wrong table on an
+    /// MT variant silently mis-predicts stop_gained/missense/synonymous.
+    fn codon_table_for(&self, transcript: &Transcript) -> &CodonTable {
+        if is_mitochondrial(&transcript.chromosome) {
+            &self.mt_codon_table
+        } else {
+            &self.codon_table
         }
     }
 
@@ -405,8 +424,8 @@ impl ConsequencePredictor {
                     }
                 }
 
-                let ref_aa = self.codon_table.translate(&ref_codon);
-                let alt_aa = self.codon_table.translate(&alt_codon);
+                let ref_aa = self.codon_table_for(transcript).translate(&ref_codon);
+                let alt_aa = self.codon_table_for(transcript).translate(&alt_codon);
 
                 let (ref_codon_str, alt_codon_str) = format_codon_change(&ref_codon, &alt_codon);
 
@@ -481,7 +500,7 @@ impl ConsequencePredictor {
         }
 
         let ref_codon = [seq_bytes[codon_start], seq_bytes[codon_start + 1], seq_bytes[codon_start + 2]];
-        let ref_aa = self.codon_table.translate(&ref_codon);
+        let ref_aa = self.codon_table_for(transcript).translate(&ref_codon);
         let ref_aa_str = String::from(ref_aa as char);
 
         if is_frameshift {
@@ -592,7 +611,7 @@ impl ConsequencePredictor {
                         let ref_region = &seq_bytes[codon_start..ref_end];
                         let ref_aas: String = ref_region.chunks(3)
                             .filter(|c| c.len() == 3)
-                            .map(|c| self.codon_table.translate(&[c[0], c[1], c[2]]) as char)
+                            .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
                             .collect();
                         let ref_codons: String = ref_region.iter()
                             .map(|&b| (b as char).to_uppercase().next().unwrap()).collect();
@@ -606,12 +625,12 @@ impl ConsequencePredictor {
                         let ref_region = &seq_bytes[codon_start..ref_end];
                         let ref_aas: String = ref_region.chunks(3)
                             .filter(|c| c.len() == 3)
-                            .map(|c| self.codon_table.translate(&[c[0], c[1], c[2]]) as char)
+                            .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
                             .collect();
                         let alt_codon_end = (codon_start + 3).min(alt_seq.len());
                         let alt_region = &alt_seq[codon_start..alt_codon_end];
                         let alt_aas: String = if alt_region.len() == 3 {
-                            String::from(self.codon_table.translate(&[alt_region[0], alt_region[1], alt_region[2]]) as char)
+                            String::from(self.codon_table_for(transcript).translate(&[alt_region[0], alt_region[1], alt_region[2]]) as char)
                         } else {
                             "-".to_string()
                         };
@@ -654,7 +673,7 @@ impl ConsequencePredictor {
                     let alt_region = &alt_seq[codon_start..alt_end];
                     let alt_aas: String = alt_region.chunks(3)
                         .filter(|c| c.len() == 3)
-                        .map(|c| self.codon_table.translate(&[c[0], c[1], c[2]]) as char)
+                        .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
                         .collect();
 
                     // Build alt codon string: original bases lowercase, inserted uppercase

--- a/crates/fastvep-genome/src/lib.rs
+++ b/crates/fastvep-genome/src/lib.rs
@@ -3,4 +3,7 @@ pub mod mitochondrial;
 mod transcript;
 
 pub use codon::CodonTable;
+pub use mitochondrial::{
+    is_mitochondrial, mitochondrial_codon_table, wrap_position, wrap_position_for, MT_LENGTH,
+};
 pub use transcript::{Exon, Gene, Transcript, Translation};

--- a/crates/fastvep-genome/src/mitochondrial.rs
+++ b/crates/fastvep-genome/src/mitochondrial.rs
@@ -13,13 +13,25 @@ pub fn is_mitochondrial(chrom: &str) -> bool {
     c == "mt" || c == "chrm" || c == "chrmt" || c == "m"
 }
 
-/// Wrap a position around the circular mitochondrial genome.
+/// Wrap a position around a circular genome of the given `length`.
+///
+/// Generalization of [`wrap_position`] for circular contigs whose length
+/// isn't the human rCRS (e.g. a non-human mitochondrial genome loaded from a
+/// FASTA with a different `MT`/`chrM` record length). Positions beyond
+/// `length` wrap back to the beginning; `pos == 0` or `length == 0` are
+/// returned unchanged (there's no sensible wrap for a zero-length contig or
+/// the sentinel 0 position).
+pub fn wrap_position_for(pos: u64, length: u64) -> u64 {
+    if pos == 0 || length == 0 {
+        return pos;
+    }
+    ((pos - 1) % length) + 1
+}
+
+/// Wrap a position around the circular mitochondrial genome (human rCRS length).
 /// Positions > MT_LENGTH wrap to the beginning.
 pub fn wrap_position(pos: u64) -> u64 {
-    if pos == 0 {
-        return 0;
-    }
-    ((pos - 1) % MT_LENGTH) + 1
+    wrap_position_for(pos, MT_LENGTH)
 }
 
 /// The vertebrate mitochondrial codon table (NCBI translation table 2).
@@ -53,6 +65,21 @@ mod tests {
         assert_eq!(wrap_position(16570), 1);
         assert_eq!(wrap_position(16571), 2);
         assert_eq!(wrap_position(0), 0);
+    }
+
+    #[test]
+    fn test_wrap_position_for_arbitrary_length() {
+        // Same shape as wrap_position, but parameterized for organisms whose
+        // mitochondrial contig isn't the human rCRS length (e.g. mouse mtDNA,
+        // ~16299 bp).
+        assert_eq!(wrap_position_for(1, 100), 1);
+        assert_eq!(wrap_position_for(100, 100), 100);
+        assert_eq!(wrap_position_for(101, 100), 1);
+        assert_eq!(wrap_position_for(105, 100), 5);
+        assert_eq!(wrap_position_for(0, 100), 0);
+        assert_eq!(wrap_position_for(5, 0), 5);
+        // Delegation: wrap_position(pos) == wrap_position_for(pos, MT_LENGTH).
+        assert_eq!(wrap_position_for(16570, MT_LENGTH), wrap_position(16570));
     }
 
     #[test]

--- a/crates/fastvep-genome/src/transcript.rs
+++ b/crates/fastvep-genome/src/transcript.rs
@@ -166,8 +166,15 @@ impl Transcript {
                 let translateable = format!("{}{}", padding, raw_translateable);
                 self.translateable_seq = Some(translateable.to_string());
 
-                // Translate to peptide
-                let codon_table = CodonTable::standard();
+                // Translate to peptide. Mitochondrial transcripts use the
+                // vertebrate mitochondrial genetic code (NCBI table 2) —
+                // AGA/AGG are stop codons, ATA is Met, and TGA is Trp there,
+                // unlike the standard nuclear table.
+                let codon_table = if crate::mitochondrial::is_mitochondrial(&self.chromosome) {
+                    crate::mitochondrial::mitochondrial_codon_table()
+                } else {
+                    CodonTable::standard()
+                };
                 let peptide_bytes = codon_table.translate_seq(translateable.as_bytes());
                 self.peptide = Some(String::from_utf8_lossy(&peptide_bytes).to_string());
             }

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -88,14 +88,18 @@ pub fn hgvsp_inframe_deletion(
 ///   - Ala498 = first amino acid that changes (ref)
 ///   - Pro = new amino acid at that position
 ///   - Ter28 = new stop codon 28 positions downstream
+///
+/// `codon_table` lets the caller select the genetic code to translate with —
+/// pass the vertebrate mitochondrial table (NCBI table 2) for MT transcripts
+/// so AGA/AGG/ATA/TGA are read correctly instead of with the standard code.
 pub fn hgvsp_frameshift(
     protein_id: &str,
     ref_translateable: &[u8],
     alt_translateable: &[u8],
     affected_codon_start: usize, // 0-based codon index where the frameshift starts
+    codon_table: &CodonTable,
 ) -> Option<String> {
     let prefix = format!("{}:p.", protein_id);
-    let codon_table = CodonTable::standard();
 
     // Translate both sequences from the affected codon onwards
     let ref_start = affected_codon_start * 3;

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -106,6 +106,9 @@ pub fn hgvsp_frameshift(
     if ref_start + 3 > ref_translateable.len() {
         return None;
     }
+    if ref_start > alt_translateable.len() {
+        return None;
+    }
 
     let ref_peptide: Vec<u8> = ref_translateable[ref_start..]
         .chunks(3)
@@ -218,6 +221,23 @@ mod tests {
         // past it to the real stop (TAA) 4 codons in.
         assert_eq!(mito_result, Some("ENSP1:p.Arg1ProfsTer4".to_string()));
         assert_ne!(standard_result, mito_result);
+    }
+
+    #[test]
+    fn test_hgvsp_frameshift_short_alt_translateable_returns_none() {
+        // Regression: there's a bounds check guarding `ref_translateable`
+        // (`ref_start + 3 > ref_translateable.len()`) but nothing equivalent
+        // guarded `alt_translateable[ref_start..]` on the next line. If the
+        // alt sequence is shorter than `ref_start`, that slice must not
+        // panic ("start index out of range") -- it should return None, same
+        // as the existing ref-side guard.
+        let ref_translateable = b"CGTCGTCGTCGT"; // 12 bases, ref_start=3 is in-bounds
+        let alt_translateable = b"CC"; // only 2 bases -- shorter than ref_start (3)
+
+        let standard = CodonTable::standard();
+        let result =
+            hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 1, &standard);
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -191,6 +191,34 @@ pub fn hgvsp_frameshift(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fastvep_genome::mitochondrial_codon_table;
+
+    #[test]
+    fn test_hgvsp_frameshift_mitochondrial_table_differs() {
+        // Same ref/alt translateable sequences, only the codon table differs.
+        // Codon 0 changes (Arg CGT -> Pro CCC, same under both tables), so
+        // the frameshift starts there regardless of table. Codon 1 is TGA:
+        // a stop under the standard table but Trp under the vertebrate
+        // mitochondrial table (NCBI table 2), so the two tables must find
+        // the new stop codon (Ter) at different downstream distances.
+        let ref_translateable = b"CGTCGTCGTCGT"; // Arg Arg Arg Arg
+        let alt_translateable = b"CCCTGAAAATAA"; // Pro TGA(*/W) Lys TAA(*)
+
+        let standard = CodonTable::standard();
+        let mitochondrial = mitochondrial_codon_table();
+
+        let standard_result =
+            hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 0, &standard);
+        let mito_result =
+            hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 0, &mitochondrial);
+
+        // Standard table: TGA is a stop, so the new terminator is 2 codons in.
+        assert_eq!(standard_result, Some("ENSP1:p.Arg1ProfsTer2".to_string()));
+        // Mitochondrial table: TGA reads as Trp, so translation continues
+        // past it to the real stop (TAA) 4 codons in.
+        assert_eq!(mito_result, Some("ENSP1:p.Arg1ProfsTer4".to_string()));
+        assert_ne!(standard_result, mito_result);
+    }
 
     #[test]
     fn test_hgvsp_missense() {

--- a/crates/fastvep-io/src/vcf.rs
+++ b/crates/fastvep-io/src/vcf.rs
@@ -93,12 +93,18 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
     let pos: u64 = fields[1]
         .parse()
         .with_context(|| format!("Invalid POS: {}", fields[1]))?;
+    if pos == 0 {
+        anyhow::bail!("VCF POS field is 0 (must be 1-based): {}", line);
+    }
     let id = fields[2];
     let ref_str = fields[3];
     if ref_str.is_empty() {
         anyhow::bail!("VCF REF field is empty: {}", line);
     }
     let alt_str = fields[4];
+    if alt_str.is_empty() {
+        anyhow::bail!("VCF ALT field is empty: {}", line);
+    }
     let qual = fields[5];
     let filter = fields[6];
     let info = fields[7];
@@ -355,6 +361,24 @@ mod tests {
         let line = "1\t100\t.\t\tG\t.\tPASS\t.";
         let err = parse_vcf_line(line).unwrap_err();
         assert!(err.to_string().contains("REF field is empty"));
+    }
+
+    #[test]
+    fn test_empty_alt_field_is_rejected() {
+        // A malformed/malicious empty ALT must be rejected outright rather
+        // than silently flowing through as a zero-length allele.
+        let line = "1\t100\t.\tA\t\t.\tPASS\t.";
+        let err = parse_vcf_line(line).unwrap_err();
+        assert!(err.to_string().contains("ALT field is empty"));
+    }
+
+    #[test]
+    fn test_pos_zero_is_rejected() {
+        // VCF POS is 1-based; a POS of 0 is malformed and must be rejected
+        // outright rather than flowing through as a bogus coordinate.
+        let line = "1\t0\t.\tA\tG\t.\tPASS\t.";
+        let err = parse_vcf_line(line).unwrap_err();
+        assert!(err.to_string().contains("POS field is 0"));
     }
 
     #[test]

--- a/crates/fastvep-sa/src/fields.rs
+++ b/crates/fastvep-sa/src/fields.rs
@@ -3,6 +3,7 @@
 //! Each annotation field (e.g., gnomAD AF, ClinVar significance) has a type
 //! that determines how it's stored as a u32 integer and reconstructed for output.
 
+use crate::common::escape_json;
 use serde::{Deserialize, Serialize};
 
 /// How a field's values are stored internally.
@@ -176,7 +177,7 @@ pub fn format_value(field: &Field, stored: u32, strings: Option<&[String]>) -> S
             if let Some(strs) = strings {
                 let idx = stored as usize;
                 if idx < strs.len() {
-                    format!("\"{}\"", strs[idx])
+                    format!("\"{}\"", escape_json(&strs[idx]))
                 } else {
                     "null".into()
                 }
@@ -245,6 +246,28 @@ mod tests {
         assert_eq!(field.encode_float(f64::NAN), u32::MAX);
         assert_eq!(field.encode_float(f64::INFINITY), u32::MAX);
         assert_eq!(field.encode_float(f64::NEG_INFINITY), u32::MAX);
+    }
+
+    #[test]
+    fn test_categorical_format_value_escapes_json() {
+        // A Categorical field's string table can hold arbitrary free text
+        // (e.g. copied from an upstream annotation source); a value
+        // containing a quote or backslash must not break out of the emitted
+        // JSON string.
+        let field = Field {
+            field: "cat".into(), alias: "cat".into(), ftype: FieldType::Categorical,
+            multiplier: 1, zigzag: false, missing_value: u32::MAX,
+            missing_string: ".".into(), description: String::new(),
+        };
+        let strings = vec!["evil\"quote\\backslash".to_string()];
+        let json_fragment = format_value(&field, 0, Some(&strings));
+        let wrapped = format!("{{\"v\":{}}}", json_fragment);
+        let v: serde_json::Value =
+            serde_json::from_str(&wrapped).expect("Categorical value must be escaped JSON");
+        assert_eq!(
+            v.get("v").and_then(|x| x.as_str()),
+            Some("evil\"quote\\backslash")
+        );
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -413,7 +413,7 @@ mod tests {
         // "C" (1 byte) + "€" (3 bytes, occupying byte offsets 1..4) + "s315Met":
         // byte offset 3 lands inside the € character, not on a boundary.
         let s = "C\u{20AC}s315Met";
-        assert_eq!(s.len() >= 4, true);
+        assert!(s.len() >= 4);
         assert!(parse_three_letter_protein(s).is_none());
     }
 

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -336,7 +336,7 @@ fn parse_three_letter_protein(s: &str) -> Option<(u64, String, String)> {
     if s.len() < 4 {
         return None;
     }
-    let ref_three = &s[..3];
+    let ref_three = s.get(..3)?;
     let ref_aa = aa_map.get(ref_three)?;
 
     // Extract position digits
@@ -349,7 +349,7 @@ fn parse_three_letter_protein(s: &str) -> Option<(u64, String, String)> {
     if after_digits.len() < 3 {
         return None;
     }
-    let alt_three = &after_digits[..3];
+    let alt_three = after_digits.get(..3)?;
     let alt_aa = aa_map.get(alt_three)?;
 
     // Skip stop codon/terminator variants (not missense)
@@ -403,6 +403,26 @@ mod tests {
     fn test_parse_three_letter_protein() {
         let result = parse_three_letter_protein("Cys315Met").unwrap();
         assert_eq!(result, (315, "C".to_string(), "M".to_string()));
+    }
+
+    #[test]
+    fn test_parse_three_letter_protein_multibyte_ref_no_panic() {
+        // A multi-byte UTF-8 character straddling byte offset 3 in untrusted
+        // ClinVar free text must not panic on the ref-AA slice ("byte index
+        // is not a char boundary") — it should just fail to parse.
+        // "C" (1 byte) + "€" (3 bytes, occupying byte offsets 1..4) + "s315Met":
+        // byte offset 3 lands inside the € character, not on a boundary.
+        let s = "C\u{20AC}s315Met";
+        assert_eq!(s.len() >= 4, true);
+        assert!(parse_three_letter_protein(s).is_none());
+    }
+
+    #[test]
+    fn test_parse_three_letter_protein_multibyte_alt_no_panic() {
+        // Same hazard on the alt-AA slice: "Cys315" + "M€t" puts a multi-byte
+        // character straddling byte offset 3 of `after_digits`.
+        let s = "Cys315M\u{20AC}t";
+        assert!(parse_three_letter_protein(s).is_none());
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -6,7 +6,7 @@
 //! `iter_dbsnp_vcf` for streaming builds; `parse_dbsnp_vcf` is retained for
 //! tests and small inputs.
 
-use crate::common::AnnotationRecord;
+use crate::common::{escape_json, AnnotationRecord};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -99,7 +99,7 @@ impl<R: BufRead> Iterator for DbsnpRecordIter<'_, R> {
                     .as_ref()
                     .and_then(|parts| parts.get(i + 1))
                     .and_then(|s| s.parse::<f64>().ok());
-                let mut parts = vec![format!("\"id\":\"{}\"", rs_id)];
+                let mut parts = vec![format!("\"id\":\"{}\"", escape_json(&rs_id))];
                 if let Some(f) = freq {
                     parts.push(format!("\"globalMaf\":{:.6e}", f));
                 }
@@ -198,6 +198,27 @@ mod tests {
 
         let t = records.iter().find(|r| r.alt_allele == "T").unwrap();
         assert!(t.json.contains("2.000000e-2"), "T should get CAF index 2 (0.02), not C's frequency: {}", t.json);
+    }
+
+    #[test]
+    fn test_parse_dbsnp_rs_id_is_json_escaped() {
+        // The ID column is attacker-influenced free text in a corrupted/hostile
+        // build input; if it (or the RS= fallback) ever contains a quote or
+        // backslash, the emitted record must still be valid JSON rather than
+        // having the id value break out of its string.
+        let vcf = "\
+##fileformat=VCFv4.0
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t10019\trs1\"evil\\n\tA\tG\t.\t.\tRS=1;CAF=0.9,0.1
+";
+        let mut chrom_map = HashMap::new();
+        chrom_map.insert("chr1".to_string(), 0u16);
+
+        let records = parse_dbsnp_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        assert_eq!(records.len(), 1);
+        let v: serde_json::Value = serde_json::from_str(&records[0].json)
+            .expect("rs_id must be escaped so the record is valid JSON");
+        assert_eq!(v.get("id").and_then(|x| x.as_str()), Some("rs1\"evil\\n"));
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/gnomad.rs
+++ b/crates/fastvep-sa/src/sources/gnomad.rs
@@ -286,16 +286,27 @@ fn build_gnomad_json(
         }
     }
 
+    // AN/AC/nhomalt are written unquoted, so each must be a validated
+    // non-negative integer — raw INFO-field text (e.g. the "." missing-value
+    // sentinel or other garbage) would otherwise land in the JSON as a bare,
+    // unquoted token and break every downstream serde_json::from_str on this
+    // record. Mirrors the CNT validation in sources/cosmic.rs.
     if let Some(an_str) = an {
-        parts.push(format!("\"allAn\":{}", an_str));
+        if let Ok(n) = an_str.parse::<u64>() {
+            parts.push(format!("\"allAn\":{}", n));
+        }
     }
 
     if let Some(ac_str) = ac {
-        parts.push(format!("\"allAc\":{}", ac_str));
+        if let Ok(n) = ac_str.parse::<u64>() {
+            parts.push(format!("\"allAc\":{}", n));
+        }
     }
 
     if let Some(nh) = nhomalt {
-        parts.push(format!("\"allHc\":{}", nh));
+        if let Ok(n) = nh.parse::<u64>() {
+            parts.push(format!("\"allHc\":{}", n));
+        }
     }
 
     // Per-population AFs
@@ -437,6 +448,34 @@ chr1\t20000\t.\tC\tT,A\t.\tPASS\tAF_joint=0.01,0.005;AN_joint=140000;AC_joint=14
             "second alt should pick second AC value: {}",
             records[2].json
         );
+    }
+
+    #[test]
+    fn test_garbage_an_ac_nhomalt_omitted_not_emitted_unescaped() {
+        // AN/AC/nhomalt are spliced into the JSON unquoted, so malformed
+        // upstream text (e.g. the "." missing-value sentinel or other
+        // garbage) must be dropped rather than emitted as a bare token that
+        // would break serde_json::from_str on the whole record.
+        let vcf = "\
+##fileformat=VCFv4.2
+##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">
+##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Total allele number\">
+##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t10001\t.\tA\tG\t.\tPASS\tAF=0.001;AN=not_a_number;AC=garbage;nhomalt=.
+";
+        let mut chrom_map = HashMap::new();
+        chrom_map.insert("chr1".to_string(), 0u16);
+
+        let records = parse_gnomad_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        assert_eq!(records.len(), 1);
+        // Malformed fields must be entirely absent, not emitted as garbage.
+        assert!(!records[0].json.contains("allAn"));
+        assert!(!records[0].json.contains("allAc"));
+        assert!(!records[0].json.contains("allHc"));
+        // The emitted JSON must still be valid.
+        let v: serde_json::Value = serde_json::from_str(&records[0].json).unwrap();
+        assert!(v.get("allAf").is_some());
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/topmed.rs
+++ b/crates/fastvep-sa/src/sources/topmed.rs
@@ -81,10 +81,15 @@ impl<R: BufRead> Iterator for TopmedRecordIter<'_, R> {
                 if let Some(af) = all_afs.get(i).and_then(|s| s.parse::<f64>().ok()) {
                     parts.push(format!("\"allAf\":{:.6e}", af));
                 }
-                if let Some(ac) = all_acs.get(i) {
+                // AC/AN are written unquoted, so each must be a validated
+                // non-negative integer — raw INFO-field text would otherwise
+                // land in the JSON as a bare, unquoted token and break every
+                // downstream serde_json::from_str on this record. Mirrors
+                // the CNT validation in sources/cosmic.rs.
+                if let Some(ac) = all_acs.get(i).and_then(|s| s.parse::<u64>().ok()) {
                     parts.push(format!("\"allAc\":{}", ac));
                 }
-                if let Some(an) = info_map.get("AN") {
+                if let Some(an) = info_map.get("AN").and_then(|s| s.parse::<u64>().ok()) {
                     parts.push(format!("\"allAn\":{}", an));
                 }
                 if parts.is_empty() {
@@ -150,5 +155,21 @@ mod tests {
         let recs = parse_topmed_vcf(vcf.as_bytes(), &m).unwrap();
         assert_eq!(recs.len(), 1);
         assert!(recs[0].json.contains("\"allAf\":"));
+    }
+
+    #[test]
+    fn test_garbage_ac_an_omitted_not_emitted_unescaped() {
+        // AC/AN are spliced into the JSON unquoted, so malformed upstream
+        // text must be dropped rather than emitted as a bare token that
+        // would break serde_json::from_str on the whole record.
+        let vcf = "#h\nchr1\t100\t.\tA\tG\t.\t.\tAF=0.05;AC=garbage;AN=not_a_number\n";
+        let mut m = HashMap::new();
+        m.insert("chr1".into(), 0u16);
+        let recs = parse_topmed_vcf(vcf.as_bytes(), &m).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert!(!recs[0].json.contains("allAc"));
+        assert!(!recs[0].json.contains("allAn"));
+        let v: serde_json::Value = serde_json::from_str(&recs[0].json).unwrap();
+        assert!(v.get("allAf").is_some());
     }
 }

--- a/crates/fastvep-sa/src/writer_v2.rs
+++ b/crates/fastvep-sa/src/writer_v2.rs
@@ -256,6 +256,14 @@ pub fn read_u32_array(data: &[u8]) -> Result<Vec<u32>> {
         anyhow::bail!("u32 array too short");
     }
     let count = u32::from_le_bytes(data[0..4].try_into()?) as usize;
+    // `count` comes from an untrusted .osa2 chunk sub-file. Bound it against
+    // how many 4-byte elements the remaining bytes could actually hold before
+    // allocating, so a corrupted file claiming `count = u32::MAX` can't force
+    // a multi-GB allocation attempt (mirrors block.rs's `decompress` guard).
+    let remaining = data.len() - 4;
+    if count > remaining / 4 {
+        anyhow::bail!("u32 array claims {} elements, exceeds data size", count);
+    }
     let mut values = Vec::with_capacity(count);
     let mut offset = 4;
     for _ in 0..count {
@@ -279,5 +287,18 @@ mod tests {
         write_u32_array(&mut buf, &values).unwrap();
         let decoded = read_u32_array(&buf).unwrap();
         assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_read_u32_array_rejects_oversized_claimed_count() {
+        // A corrupted/hostile .osa2 chunk sub-file claiming `count = u32::MAX`
+        // with only a few actual trailing bytes must be rejected up front,
+        // not passed to Vec::with_capacity(count) (which would attempt a
+        // multi-GB allocation and abort the process).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        buf.extend_from_slice(&1u32.to_le_bytes()); // a few trailing bytes only
+        let err = read_u32_array(&buf).unwrap_err();
+        assert!(err.to_string().contains("exceeds data size"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #68. The vertebrate mitochondrial codon table (NCBI translation table 2) and `wrap_position()` existed in `fastvep-genome::mitochondrial` but were only exercised by their own unit tests — consequence prediction, peptide translation, and frameshift HGVSp construction all used the standard nuclear codon table unconditionally, even for MT variants. AGA/AGG (Arg→Stop), ATA (Ile→Met), and TGA (Stop→Trp) all differ between the two tables, so this silently mis-predicted amino acids (and therefore consequence class and HGVSp) for mitochondrial protein-coding variants, despite the README&#39;s claim that circular MT coordinates and table 2 are supported.

- `fastvep-consequence::ConsequencePredictor` now holds both codon tables and picks the mitochondrial one per-transcript via `is_mitochondrial(chromosome)` in `predict_coding_consequence`/`compute_indel_amino_acids`.
- `fastvep-genome::Transcript::build_sequences` picks the same way when translating the peptide.
- `fastvep_hgvs::hgvsp_frameshift` now takes the codon table as a parameter instead of hardcoding `CodonTable::standard()`; both production call sites (`fastvep-annotate`, `fastvep-cli/pipeline.rs`) select mitochondrial vs. standard based on the transcript&#39;s chromosome.
- `wrap_position()`/new `wrap_position_for()` are wired into the FASTA sequence-fetch layer (`fastvep-cache::providers::fetch_circular`), so a region that runs past the end of a circular MT contig (e.g. an allele spanning position 16569 → 1 on the human rCRS) is stitched from the tail and head of the contig instead of being silently truncated. Generalized to an arbitrary contig length so non-human mitochondrial genomes of a different length still wrap correctly; `wrap_position()` is now a thin convenience wrapper around it for the human rCRS length.
- Re-exported `is_mitochondrial`/`mitochondrial_codon_table`/`wrap_position`/`wrap_position_for`/`MT_LENGTH` from `fastvep-genome`&#39;s crate root for ergonomic cross-crate use.

Non-MT behavior is unchanged: `codon_table_for()` and `fetch_circular()` both take the untouched standard-table / non-wrapped fast path for every chromosome that isn&#39;t MT/chrM/M/chrMT.

Issue #63 (complex SV/BND support) was also reviewed as part of this sweep; per PR #67&#39;s prior investigation it remains a substantial feature (MATEID pairing, breakpoint-pair semantics, SV-database matching) rather than a quick fix, so no partial implementation was attempted here.

Note: PR #67 (open, unmerged) already covers a separate set of fixes in `fastvep-web`/`fastvep-classification` (non-UTF-8 path panic, ACMG modal escaping, path-traversal tests) — this PR does not duplicate that work.

## Testing

- Added a unit test in `fastvep-hgvs` proving `hgvsp_frameshift`&#39;s new `codon_table` parameter actually changes output: TGA reads as a stop under the standard table (`Ter2`) but as Trp under the vertebrate mitochondrial table, so translation continues to the real downstream stop (`Ter4`).
- Added `crates/fastvep-annotate/tests/mitochondrial.rs`: two end-to-end integration tests exercising the real production call chain (`FastaSequenceProvider` → `Transcript::build_sequences` → `ConsequencePredictor::predict` → `fastvep_hgvs::hgvsp`):
  - `mt_tga_reads_as_tryptophan_not_stop`: a Trp(TGG)→TGA substitution on an MT transcript is classified `synonymous_variant` (mito table reads TGA as Trp), not `stop_gained` (what the standard table would call it).
  - `mt_origin_spanning_allele_produces_stop_gained`: a 2-base MT allele whose footprint runs from genomic position 16569 across the circular origin to position 1 is fetched/assembled into the correct codon (CGA → AGA) and classified `stop_gained` under the vertebrate mitochondrial code — a standard-table read of the same (correctly wrapped) codon would call this a silent Arg→Arg synonymous change and miss a real stop gain.
- Added unit tests in `fastvep-cache::providers` for `fetch_circular`: origin-wrapping fetch, `chrM` alias resolution, non-MT chromosomes never wrapping (out-of-range still clamps, doesn&#39;t wrap), and the mmap-backed reader path.
- `cargo build --workspace --all-targets`: clean.
- `cargo test --workspace`: all passing (full workspace, including the new mitochondrial tests above).
- Commits are SSH-signed.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace` (all passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTo9Vviw5aPW7qGHmrWE7T)_

## Health-check sweep (round 2)

A separate review pass (3 read-only passes over `fastvep-sa`; `fastvep-cli`+`fastvep-io`; and `core`/`genome`/`consequence`/`hgvs`/`cache`/`annotate`/`filter`) surfaced ~34 findings. This round applies a well-scoped, low-risk subset of those (11 items) as additional commits on this same branch, each with a regression test:

- **JSON-escaping / injection hardening** (`fastvep-sa`): `dbsnp.rs`'s `rs_id` and `fields.rs`'s `Categorical` string-table values are now run through `common::escape_json` before being spliced into hand-built JSON, matching the existing pattern in `clinvar.rs`/`omim.rs`/`mitomap.rs`. `gnomad.rs`/`topmed.rs` now validate `AN`/`AC`/`nhomalt` parse as non-negative integers before writing them unquoted into JSON (mirroring `cosmic.rs`'s `CNT` validation), omitting the field instead of splicing raw INFO text on parse failure.
- **Allocation-bound fix** (`fastvep-sa/writer_v2.rs`): `read_u32_array`'s untrusted `count` field is now bounded against the remaining buffer length before `Vec::with_capacity`, so a corrupted `.osa2` chunk claiming `count = u32::MAX` can't force a multi-GB allocation attempt (mirrors `block.rs`'s `decompress` guard).
- **Char-boundary panic fix** (`fastvep-sa/sources/clinvar_protein.rs`): `parse_three_letter_protein` now uses `.get(..3)` instead of `&s[..3]`, so a multi-byte UTF-8 character straddling byte offset 3 in untrusted ClinVar free text can't panic.
- **VCF validation** (`fastvep-io/vcf.rs`): `parse_vcf_line` now also bails on an empty ALT field and a POS of 0 (VCF POS is 1-based), matching the existing empty-REF bail.
- **Webserver hardening** (`fastvep-cli/webserver.rs`): the untrusted `Content-Length` header is now capped at 100 MiB (clean 413 response instead of allocating an attacker-controlled size), and every accepted `TcpStream` gets a 30s read timeout before any reads, so a connected-but-silent client can't hang the single-threaded server indefinitely.
- **Frameshift HGVSp bounds checks**: both `fastvep-cli/pipeline.rs` and `fastvep-annotate/lib.rs` now guard `coding_start_idx <= spliced.len()` before slicing the spliced-sequence byte array, skipping HGVSp generation gracefully instead of panicking on malformed/truncated transcript data. `fastvep-hgvs/protein.rs`'s `hgvsp_frameshift` now has a matching bounds check on `alt_translateable` (previously only `ref_translateable` was guarded).
- **`run_filter` diagnostics** (`fastvep-cli/pipeline.rs`): lines with fewer than 8 tab-separated fields now emit an `eprintln!` warning and are counted in a final "N of M lines skipped as malformed" summary, instead of being silently dropped.
- **`.fai` division-by-zero guard** (`fastvep-cache/fasta.rs`): `parse_fai` now rejects/skips any entry with `line_bases == 0`, so a corrupted `.fai` index can't reach the `pos / entry.line_bases` division sites and panic.

Explicitly out of scope (left for follow-up human review, not fixed here): the two logic bugs in `fastvep-consequence/predictor.rs` (UTR/CDS-boundary misclassification, reverse-strand MNV codon mis-anchoring), `hgvsc_with_seq`'s stop-codon-spanning delins formatting, the `fastvep-filter` match/`~` regex-vs-substring mismatch, unwired CLI flags (`--everything`/`--symbol`/`--canonical`/`--buffer-size`), the redundant trio-genotype reparsing perf issue, the mixed-phasing GT parsing issue, the O(n) linear search in `fastvep-annotate`, the `interval.rs` mislabeled-as-binary-search perf issue, and dead-code modules (`regulatory.rs`, `bloom.rs`, `MemoryTranscriptProvider`, `hgvsc()`, `find_blocks_range`).

**Testing**: `cargo build --workspace --all-targets` clean; `cargo test --workspace` all green (32 test binaries, 0 failures); `cargo clippy --workspace --all-targets` introduces zero new warnings (verified via a worktree diff against the pre-health-check commit — the one pre-existing regression this round did introduce, a `bool_assert_comparison` in a new test, was fixed); `cargo fmt --check`'s large pre-existing repo-wide diff is unchanged by this round (the two genuinely new formatting violations from newly-written test code were fixed).