### PR TITLE
fix(sa): make .osa2 startup O(central directory), not O(entries) (#78)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "flate2",
  "rayon",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/fastvep-annotate/Cargo.toml
+++ b/crates/fastvep-annotate/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = { workspace = true }
 rayon = { workspace = true }
 tracing = "0.1"
 flate2.workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -1223,89 +1223,113 @@ fn enrich_compound_het(
     }
 }
 
-/// Load supplementary annotation providers (.osa, .osa2 files) from a directory.
+/// Load supplementary annotation providers (.osa, .osa2, .osi files) from a
+/// directory.
+///
+/// Opening is done in parallel and the results are ordered by path (issue
+/// #78). A per-chromosome deployment puts 200+ shards in one `--sa-dir`, and
+/// opening a shard is latency-bound rather than CPU-bound, so serial opens made
+/// startup scale linearly with shard count for no reason. Sorting by path also
+/// makes the provider order - and therefore the output column order - depend on
+/// the file names rather than on directory iteration order.
 pub fn load_sa_providers(
     sa_dir: &Path,
 ) -> Result<Vec<Mutex<Box<dyn AnnotationProvider>>>> {
     use fastvep_sa::interval::OsiReader;
     use fastvep_sa::reader::SaReader;
     use fastvep_sa::reader_v2::Osa2Reader;
-
-    let mut providers: Vec<Mutex<Box<dyn AnnotationProvider>>> = Vec::new();
+    use rayon::prelude::*;
 
     if !sa_dir.is_dir() {
         tracing::warn!(
             "SA directory does not exist: {} (skipping)",
             sa_dir.display()
         );
-        return Ok(providers);
+        return Ok(Vec::new());
     }
 
-    for entry in std::fs::read_dir(sa_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ext = path.extension().and_then(|e| e.to_str());
+    let paths = sorted_paths_with_extensions(sa_dir, &["osa2", "osa", "osi"])?;
 
-        match ext {
-            Some("osa2") => match Osa2Reader::open(&path) {
-                Ok(reader) => {
-                    tracing::info!("Loaded SA v2: {} ({})", reader.name(), path.display());
-                    providers.push(Mutex::new(Box::new(reader)));
+    // A source that fails to open is skipped with a warning, as before; only
+    // the directory walk itself is fatal.
+    let providers: Vec<Mutex<Box<dyn AnnotationProvider>>> = paths
+        .par_iter()
+        .filter_map(|path| {
+            let ext = path.extension().and_then(|e| e.to_str());
+            let opened: Result<(&str, Box<dyn AnnotationProvider>)> = match ext {
+                Some("osa2") => Osa2Reader::open(path).map(|r| ("SA v2", boxed(r))),
+                Some("osa") => SaReader::open(path).map(|r| ("SA", boxed(r))),
+                // Interval-level (.osi) - typically BED-derived custom sources.
+                // Wired up alongside .osa so a directory with mixed file types
+                // "just works" via --sa-dir; the OsiReader exposes the same
+                // AnnotationProvider trait, returning AnnotationValue::Interval.
+                Some("osi") => OsiReader::open(path).map(|r| ("SA interval", boxed(r))),
+                _ => return None,
+            };
+            match opened {
+                Ok((kind, provider)) => {
+                    tracing::info!("Loaded {}: {} ({})", kind, provider.name(), path.display());
+                    Some(Mutex::new(provider))
                 }
                 Err(e) => {
                     tracing::warn!("Could not load {}: {}", path.display(), e);
+                    None
                 }
-            },
-            Some("osa") => match SaReader::open(&path) {
-                Ok(reader) => {
-                    tracing::info!("Loaded SA: {} ({})", reader.name(), path.display());
-                    providers.push(Mutex::new(Box::new(reader)));
-                }
-                Err(e) => {
-                    tracing::warn!("Could not load {}: {}", path.display(), e);
-                }
-            },
-            // Interval-level (.osi) — typically BED-derived custom sources.
-            // Wired up alongside .osa so a directory with mixed file types
-            // "just works" via --sa-dir; the OsiReader exposes the same
-            // AnnotationProvider trait, returning AnnotationValue::Interval.
-            Some("osi") => match OsiReader::open(&path) {
-                Ok(reader) => {
-                    tracing::info!(
-                        "Loaded SA interval: {} ({})",
-                        reader.name(),
-                        path.display()
-                    );
-                    providers.push(Mutex::new(Box::new(reader)));
-                }
-                Err(e) => {
-                    tracing::warn!("Could not load {}: {}", path.display(), e);
-                }
-            },
-            _ => {}
-        }
-    }
+            }
+        })
+        .collect();
 
     Ok(providers)
 }
 
+fn boxed<P: AnnotationProvider + 'static>(provider: P) -> Box<dyn AnnotationProvider> {
+    Box::new(provider)
+}
+
+/// Every file in `dir` whose extension is one of `exts`, sorted by path so the
+/// caller's provider order is reproducible across machines and filesystems.
+///
+/// A failed directory entry is propagated rather than skipped: on a network
+/// `--sa-dir` a transient error would otherwise drop a shard, and the run would
+/// finish successfully with that source's annotations simply missing.
+fn sorted_paths_with_extensions(dir: &Path, exts: &[&str]) -> Result<Vec<std::path::PathBuf>> {
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(dir)
+        .with_context(|| format!("Listing annotation directory {}", dir.display()))?
+    {
+        let path = entry
+            .with_context(|| format!("Reading an entry of {}", dir.display()))?
+            .path();
+        if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| exts.contains(&e))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
 /// Load gene-level annotation providers (.oga files) from a directory.
+///
+/// Same ordering and parallelism contract as [`load_sa_providers`].
 pub fn load_gene_providers(
     sa_dir: &Path,
 ) -> Result<Vec<fastvep_sa::gene::GeneIndex>> {
-    let mut providers = Vec::new();
+    use rayon::prelude::*;
 
     if !sa_dir.is_dir() {
-        return Ok(providers);
+        return Ok(Vec::new());
     }
 
-    for entry in std::fs::read_dir(sa_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ext = path.extension().and_then(|e| e.to_str());
+    let paths = sorted_paths_with_extensions(sa_dir, &["oga"])?;
 
-        if ext == Some("oga") {
-            match std::fs::File::open(&path)
+    let providers: Vec<fastvep_sa::gene::GeneIndex> = paths
+        .par_iter()
+        .filter_map(|path| {
+            match std::fs::File::open(path)
                 .map_err(anyhow::Error::from)
                 .and_then(|mut f| fastvep_sa::gene::GeneIndex::read_from(&mut f))
             {
@@ -1316,14 +1340,15 @@ pub fn load_gene_providers(
                         path.display(),
                         index.gene_count()
                     );
-                    providers.push(index);
+                    Some(index)
                 }
                 Err(e) => {
                     tracing::warn!("Could not load {}: {}", path.display(), e);
+                    None
                 }
             }
-        }
-    }
+        })
+        .collect();
 
     Ok(providers)
 }

--- a/crates/fastvep-annotate/tests/sa_provider_loading.rs
+++ b/crates/fastvep-annotate/tests/sa_provider_loading.rs
@@ -1,0 +1,102 @@
+//! Issue #78: `--sa-dir` loading is parallel, so the contract that used to come
+//! for free from a sequential `read_dir` loop now has to be asserted.
+//!
+//! Provider order decides the order of the supplementary output columns, so it
+//! must be stable - and it must not depend on directory iteration order, which
+//! differs between filesystems. These tests pin both: the order is the sorted
+//! path order, and a source that fails to open is skipped rather than taking
+//! the whole run down.
+
+use fastvep_annotate::load_sa_providers;
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2Writer};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write_osa2(dir: &Path, file_stem: &str, json_key: &str) {
+    let fields = vec![Field {
+        field: "AF".into(),
+        alias: "af".into(),
+        ftype: FieldType::Float,
+        multiplier: 1_000_000,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: "allele frequency".into(),
+    }];
+    let metadata = Osa2Metadata {
+        format_version: 2,
+        name: json_key.into(),
+        version: "test".into(),
+        assembly: "GRCh38".into(),
+        json_key: json_key.into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: String::new(),
+    };
+    let records = vec![Osa2Record {
+        chrom: "chr1".into(),
+        position: 1000,
+        ref_allele: b"A".to_vec(),
+        alt_allele: b"G".to_vec(),
+        values: vec![fields[0].encode_float(0.25)],
+        json_blob: None,
+    }];
+    let path = dir.join(format!("{file_stem}.osa2"));
+    let file = std::fs::File::create(&path).unwrap();
+    Osa2Writer::new(metadata, fields)
+        .write_all(std::io::BufWriter::new(file), &records)
+        .unwrap();
+}
+
+/// Written in an order that does not match the sorted order, so a loader that
+/// simply preserved creation/iteration order would fail this.
+#[test]
+fn providers_are_ordered_by_path() {
+    let dir = TempDir::new().unwrap();
+    for (stem, key) in [
+        ("gnomad_chr9", "k9"),
+        ("gnomad_chr1", "k1"),
+        ("gnomad_chr21", "k21"),
+        ("gnomad_chr2", "k2"),
+    ] {
+        write_osa2(dir.path(), stem, key);
+    }
+
+    let providers = load_sa_providers(dir.path()).unwrap();
+    let keys: Vec<String> = providers
+        .iter()
+        .map(|p| p.lock().unwrap().json_key().to_string())
+        .collect();
+
+    // Sorted by file name, which is lexicographic - chr1 < chr2 < chr21 < chr9.
+    assert_eq!(keys, vec!["k1", "k2", "k21", "k9"]);
+}
+
+/// An unreadable source must be skipped with a warning, exactly as it was
+/// before loading became parallel, and must not disturb the others' order.
+#[test]
+fn an_unopenable_source_is_skipped_not_fatal() {
+    let dir = TempDir::new().unwrap();
+    write_osa2(dir.path(), "a_good", "good_a");
+    std::fs::write(dir.path().join("b_broken.osa2"), b"not a zip archive").unwrap();
+    write_osa2(dir.path(), "c_good", "good_c");
+    // Unrelated extensions in the same directory must be ignored.
+    std::fs::write(dir.path().join("notes.txt"), b"ignore me").unwrap();
+
+    let providers = load_sa_providers(dir.path()).unwrap();
+    let keys: Vec<String> = providers
+        .iter()
+        .map(|p| p.lock().unwrap().json_key().to_string())
+        .collect();
+    assert_eq!(keys, vec!["good_a", "good_c"]);
+}
+
+#[test]
+fn a_missing_directory_loads_nothing() {
+    let dir = TempDir::new().unwrap();
+    let providers = load_sa_providers(&dir.path().join("does_not_exist")).unwrap();
+    assert!(providers.is_empty());
+}

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -319,11 +319,23 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
     // Load supplementary annotation providers from --sa-dir
     // Shared load_sa_providers returns Mutex-wrapped providers; unwrap for batch pipeline
     // (batch pipeline processes variants sequentially per chunk, no concurrent access).
+    // Reported on stderr like the other startup steps: this is the one that
+    // scales with the number of files in --sa-dir, so a slow shared filesystem
+    // shows up here rather than as a silent stall before the progress meter
+    // (issue #78). `tracing` has no subscriber installed in the CLI.
     let sa_providers: Vec<Box<dyn AnnotationProvider>> = if let Some(ref dir) = config.sa_dir {
-        load_sa_providers(Path::new(dir))?
+        let t0 = std::time::Instant::now();
+        let loaded: Vec<Box<dyn AnnotationProvider>> = load_sa_providers(Path::new(dir))?
             .into_iter()
             .map(|m| m.into_inner().unwrap())
-            .collect()
+            .collect();
+        eprintln!(
+            "Loaded {} supplementary annotation source(s) from {} in {:.1}s",
+            loaded.len(),
+            dir,
+            t0.elapsed().as_secs_f64()
+        );
+        loaded
     } else {
         Vec::new()
     };
@@ -364,7 +376,11 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
         }
         Vec::new()
     } else if let Some(ref dir) = config.sa_dir {
-        load_gene_providers(Path::new(dir))?
+        let loaded = load_gene_providers(Path::new(dir))?;
+        if !loaded.is_empty() {
+            eprintln!("Loaded {} gene-level annotation source(s) from {}", loaded.len(), dir);
+        }
+        loaded
     } else {
         Vec::new()
     };

--- a/crates/fastvep-sa/examples/bench_osa2_open.rs
+++ b/crates/fastvep-sa/examples/bench_osa2_open.rs
@@ -1,0 +1,183 @@
+//! Reproduction/benchmark for issue #78: "after adding gnomad_chr*.osa2 to
+//! --sa-dir the pre-startup time increased by 20+ minutes".
+//!
+//! Builds a set of per-chromosome gnomAD-schema `.osa2` shards (the exact
+//! layout `fastvep sa-build --format osa2 --source gnomad` emits) into a
+//! temporary "sa-dir", then times `Osa2Reader::open` for every shard the way
+//! `load_sa_providers` does at annotate startup.
+//!
+//! The interesting number is not just wall time but `entries` and
+//! `header_reads`: the old open path resolved every ZIP entry's data offset up
+//! front, which is one random read per entry scattered across a multi-GB file.
+//!
+//! Usage:
+//!   cargo run --release --example bench_osa2_open -p fastvep-sa
+//!
+//! Env knobs:
+//!   OSA2_BENCH_CHROMS    number of chromosome shards to build (default 4)
+//!   OSA2_BENCH_PER_CHROM records per shard                    (default 2_000_000)
+//!   OSA2_BENCH_DIR       reuse/keep shards in this directory (default: temp dir)
+
+use anyhow::Result;
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::sources::gnomad::{gnomad_osa2_fields, gnomad_osa2_metadata};
+use fastvep_sa::writer_v2::{Osa2Record, Osa2StreamWriter};
+use std::env;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const HUMAN_CHROMS: &[(&str, u32)] = &[
+    ("chr1", 248_956_422),
+    ("chr2", 242_193_529),
+    ("chr3", 198_295_559),
+    ("chr4", 190_214_555),
+    ("chr5", 181_538_259),
+    ("chr6", 170_805_979),
+    ("chr7", 159_345_973),
+    ("chr8", 145_138_636),
+    ("chr9", 138_394_717),
+    ("chr10", 133_797_422),
+    ("chr11", 135_086_622),
+    ("chr12", 133_275_309),
+    ("chr13", 114_364_328),
+    ("chr14", 107_043_718),
+    ("chr15", 101_991_189),
+    ("chr16", 90_338_345),
+    ("chr17", 83_257_441),
+    ("chr18", 80_373_285),
+    ("chr19", 58_617_616),
+    ("chr20", 64_444_167),
+    ("chr21", 46_709_983),
+    ("chr22", 50_818_468),
+    ("chrX", 156_040_895),
+];
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Write one per-chromosome gnomAD `.osa2` shard with `n` evenly spread
+/// records, using the streaming writer (the path `sa-build` uses).
+fn build_shard(path: &Path, chrom: &str, length: u32, n: usize) -> Result<u64> {
+    let fields = gnomad_osa2_fields();
+    let metadata = gnomad_osa2_metadata("GRCh38");
+    let n_fields = fields.len();
+    let file = BufWriter::with_capacity(1 << 22, File::create(path)?);
+    let mut writer = Osa2StreamWriter::new(file, &metadata, fields.clone())?;
+
+    let step = (length as u64 / n.max(1) as u64).max(1);
+    let alts = [b'C', b'G', b'T', b'A'];
+    for j in 0..n {
+        let pos = (1 + j as u64 * step).min(length as u64) as u32;
+        let values: Vec<u32> = (0..n_fields)
+            .map(|f| ((pos as u64 + f as u64 * 7) % 1_000_000) as u32)
+            .collect();
+        writer.push(Osa2Record {
+            chrom: chrom.to_string(),
+            position: pos,
+            ref_allele: vec![b'A'],
+            alt_allele: vec![alts[j % alts.len()]],
+            values,
+            json_blob: None,
+        })?;
+    }
+    writer.finish()?;
+    Ok(std::fs::metadata(path)?.len())
+}
+
+fn main() -> Result<()> {
+    let n_chroms = env_usize("OSA2_BENCH_CHROMS", 4).min(HUMAN_CHROMS.len());
+    let per_chrom = env_usize("OSA2_BENCH_PER_CHROM", 2_000_000);
+
+    let (dir, _keep): (PathBuf, Option<tempfile::TempDir>) = match env::var("OSA2_BENCH_DIR") {
+        Ok(d) => {
+            std::fs::create_dir_all(&d)?;
+            (PathBuf::from(d), None)
+        }
+        Err(_) => {
+            let t = tempfile::TempDir::new()?;
+            (t.path().to_path_buf(), Some(t))
+        }
+    };
+
+    println!(
+        "sa-dir: {}  ({} shards x {} records)",
+        dir.display(),
+        n_chroms,
+        per_chrom
+    );
+
+    let mut paths = Vec::new();
+    let mut total_bytes = 0u64;
+    for (chrom, length) in HUMAN_CHROMS.iter().take(n_chroms) {
+        let path = dir.join(format!("gnomad_{}.osa2", chrom));
+        if path.exists() {
+            total_bytes += std::fs::metadata(&path)?.len();
+            paths.push(path);
+            continue;
+        }
+        let t = Instant::now();
+        let bytes = build_shard(&path, chrom, *length, per_chrom)?;
+        total_bytes += bytes;
+        println!(
+            "  built {:<22} {:>8.1} MB in {:>6.1}s",
+            path.file_name().unwrap().to_string_lossy(),
+            bytes as f64 / 1e6,
+            t.elapsed().as_secs_f64()
+        );
+        paths.push(path);
+    }
+    println!("total on-disk: {:.2} GB\n", total_bytes as f64 / 1e9);
+
+    // Startup path: open every shard, exactly as load_sa_providers does.
+    let t = Instant::now();
+    let mut readers = Vec::new();
+    for path in &paths {
+        let t1 = Instant::now();
+        let r = Osa2Reader::open(path)?;
+        println!(
+            "  open {:<22} entries={:>7}  header_reads={:>7}  {:>7.3}s",
+            path.file_name().unwrap().to_string_lossy(),
+            r.entry_count(),
+            r.header_read_count(),
+            t1.elapsed().as_secs_f64()
+        );
+        readers.push(r);
+    }
+    let open_secs = t.elapsed().as_secs_f64();
+    let entries: usize = readers.iter().map(|r| r.entry_count()).sum();
+    let header_reads: u64 = readers.iter().map(|r| r.header_read_count()).sum();
+    println!(
+        "\nOPEN TOTAL: {:.3}s  entries={}  header_reads={}",
+        open_secs, entries, header_reads
+    );
+
+    // Sanity: a lookup must still work after open (guards the lazy-offset path).
+    use fastvep_cache::annotation::AnnotationProvider;
+    let mut hits = 0;
+    for (i, r) in readers.iter().enumerate() {
+        let (chrom, length) = HUMAN_CHROMS[i];
+        let step = (length as u64 / per_chrom.max(1) as u64).max(1);
+        let alts = [b'C', b'G', b'T', b'A'];
+        for j in [0usize, per_chrom / 2, per_chrom.saturating_sub(1)] {
+            let pos = (1 + j as u64 * step).min(length as u64);
+            let alt = (alts[j % alts.len()] as char).to_string();
+            if r.annotate_position(chrom, pos, "A", &alt)?.is_some() {
+                hits += 1;
+            }
+        }
+    }
+    println!(
+        "post-open lookups: {}/{} hit  header_reads_after={}",
+        hits,
+        readers.len() * 3,
+        readers.iter().map(|r| r.header_read_count()).sum::<u64>()
+    );
+
+    Ok(())
+}

--- a/crates/fastvep-sa/src/lib.rs
+++ b/crates/fastvep-sa/src/lib.rs
@@ -26,3 +26,4 @@ pub mod var32;
 pub mod writer;
 pub mod writer_v2;
 pub mod zigzag;
+mod zipdir;

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -11,6 +11,14 @@
 //! readers (mirror of the `.osa` block cache), so a dense whole-genome source
 //! queried in parallel neither serializes on a lock nor thrashes a too-small
 //! per-reader cache. See [`crate::common::sa_cache_budget_bytes`].
+//!
+//! **Startup cost (issue #78):** `open` reads only the central directory (see
+//! [`crate::zipdir`]) - one contiguous region at the end of the file. Each
+//! entry's *data* offset lives in its local file header, next to the data
+//! itself, so resolving those eagerly meant one random read per entry across
+//! the whole file: a 24-shard gnomAD `--sa-dir` spent 25+ minutes on that
+//! before the first variant was annotated. They are now resolved lazily, on the
+//! first read of each entry, when the page is about to be touched anyway.
 
 use crate::chunk::{delta_decode, Chunk};
 use crate::common::chrom_aliases;
@@ -29,7 +37,7 @@ use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Hard cap on a per-chunk zstd-decompressed JSON blob (256 MiB). Defends
 /// against zstd bombs in maliciously crafted .osa2 files.
@@ -123,14 +131,33 @@ enum EntryMethod {
     Deflated,
 }
 
-/// Location of one ZIP entry's compressed data within the mmap, resolved once
-/// at `open` so query-time reads never touch the `ZipArchive` (and thus never
-/// take a shared lock).
-#[derive(Clone, Copy)]
+impl EntryMethod {
+    /// Map a raw ZIP method id. Anything else means the `.osa2` was not written
+    /// by this crate's writer and we would silently mis-read it.
+    fn from_id(id: u16, name: &str) -> Result<Self> {
+        match id {
+            0 => Ok(EntryMethod::Stored),
+            8 => Ok(EntryMethod::Deflated),
+            other => anyhow::bail!(
+                "Unsupported ZIP compression method {} for entry '{}' in .osa2",
+                other,
+                name
+            ),
+        }
+    }
+}
+
+/// Location of one ZIP entry's compressed data within the mmap.
+///
+/// `comp_size` and `header_start` come from the central directory at `open`.
+/// `data_start` needs the entry's *local* header, which sits next to the data
+/// and would be a random read per entry at startup (issue #78), so it is filled
+/// in on first read and memoized here.
 struct EntryLoc {
-    data_start: u64,
+    header_start: u64,
     comp_size: u64,
     method: EntryMethod,
+    data_start: OnceLock<u64>,
 }
 
 /// Reader for .osa2 annotation files.
@@ -148,6 +175,9 @@ pub struct Osa2Reader {
     /// Count of chunks built (cache misses) — a thrash diagnostic, exposed via
     /// `chunk_load_count()`.
     chunk_load_count: AtomicU64,
+    /// Count of ZIP local file headers parsed - each one is a random read into
+    /// a potentially multi-GB file. Startup diagnostic for issue #78.
+    header_read_count: AtomicU64,
     metadata: Osa2Metadata,
     sa_metadata: SaMetadata,
     fields: Vec<Field>,
@@ -178,38 +208,66 @@ impl Osa2Reader {
         let file = File::open(path).with_context(|| format!("Opening {}", path.display()))?;
         // SAFETY: the file is opened read-only and the mmap is only read from.
         let mmap = unsafe { Mmap::map(&file)? };
+        drop(file);
 
-        // Parse the central directory once to read the small metadata entries
-        // and to record every entry's compressed byte range for the lock-free
-        // read path. The archive is dropped at the end of this function.
-        let mut archive = zip::ZipArchive::new(file)?;
+        // One sequential pass over the central directory (issue #78): record
+        // each entry's compressed byte range for the lock-free read path and
+        // assign each chromosome directory a dense index. No entry's local
+        // header is touched here - see the module docs.
+        let central = crate::zipdir::parse_central_directory(&mmap)
+            .with_context(|| format!("Reading .osa2 archive index of {}", path.display()))?;
+
+        let mut entries: HashMap<String, EntryLoc> = HashMap::with_capacity(central.len());
+        let mut chrom_index: HashMap<String, u32> = HashMap::new();
+        for entry in central {
+            let method = EntryMethod::from_id(entry.method, &entry.name)?;
+
+            if let Some(rest) = entry.name.strip_prefix("fastsa/") {
+                if let Some((chrom, _)) = rest.split_once('/') {
+                    if !matches!(chrom, "metadata.json" | "config.json" | "strings") {
+                        let next = chrom_index.len() as u32;
+                        chrom_index.entry(chrom.to_string()).or_insert(next);
+                    }
+                }
+            }
+
+            entries.insert(
+                entry.name,
+                EntryLoc {
+                    header_start: entry.header_start,
+                    comp_size: entry.comp_size,
+                    method,
+                    data_start: OnceLock::new(),
+                },
+            );
+        }
+
+        // The prelude entries are the only ones read at open; each costs the
+        // one local-header read that the chunk entries now defer.
+        let header_read_count = AtomicU64::new(0);
+        let read_prelude = |name: &str| -> Result<Option<Vec<u8>>> {
+            read_entry_from(&mmap, &entries, &header_read_count, name)
+        };
 
         let metadata: Osa2Metadata = {
-            let mut entry = archive
-                .by_name("fastsa/metadata.json")
+            let buf = read_prelude("fastsa/metadata.json")?
                 .context("Missing fastsa/metadata.json")?;
-            let mut buf = String::new();
-            entry.read_to_string(&mut buf)?;
-            serde_json::from_str(&buf)?
+            serde_json::from_slice(&buf)?
         };
 
         let fields: Vec<Field> = {
-            let mut entry = archive
-                .by_name("fastsa/config.json")
-                .context("Missing fastsa/config.json")?;
-            let mut buf = String::new();
-            entry.read_to_string(&mut buf)?;
-            serde_json::from_str(&buf)?
+            let buf =
+                read_prelude("fastsa/config.json")?.context("Missing fastsa/config.json")?;
+            serde_json::from_slice(&buf)?
         };
 
         let mut string_tables: Vec<Vec<String>> = fields.iter().map(|_| Vec::new()).collect();
         for (i, field) in fields.iter().enumerate() {
             if field.ftype == FieldType::Categorical {
                 let name = format!("fastsa/strings/{}.txt", field.alias);
-                if let Ok(mut entry) = archive.by_name(&name) {
-                    let mut buf = String::new();
-                    entry.read_to_string(&mut buf)?;
-                    string_tables[i] = buf.lines().map(|l| l.to_string()).collect();
+                if let Some(buf) = read_prelude(&name)? {
+                    let text = String::from_utf8(buf)?;
+                    string_tables[i] = text.lines().map(|l| l.to_string()).collect();
                 }
             }
         }
@@ -224,44 +282,6 @@ impl Osa2Reader {
                 var32::CHUNK_BITS
             );
         }
-
-        // Single pass over the central directory: record each entry's data
-        // range and assign each chromosome directory a dense index.
-        let mut entries = HashMap::with_capacity(archive.len());
-        let mut chrom_index: HashMap<String, u32> = HashMap::new();
-        for i in 0..archive.len() {
-            let zf = archive.by_index(i)?;
-            let name = zf.name().to_string();
-            let method = match zf.compression() {
-                zip::CompressionMethod::Stored => EntryMethod::Stored,
-                zip::CompressionMethod::Deflated => EntryMethod::Deflated,
-                other => anyhow::bail!(
-                    "Unsupported ZIP compression {:?} for entry '{}' in .osa2",
-                    other,
-                    name
-                ),
-            };
-            let data_start = local_data_start(&mmap, zf.header_start())?;
-            let comp_size = zf.compressed_size();
-            entries.insert(
-                name.clone(),
-                EntryLoc {
-                    data_start,
-                    comp_size,
-                    method,
-                },
-            );
-
-            if let Some(rest) = name.strip_prefix("fastsa/") {
-                if let Some((chrom, _)) = rest.split_once('/') {
-                    if !matches!(chrom, "metadata.json" | "config.json" | "strings") {
-                        let next = chrom_index.len() as u32;
-                        chrom_index.entry(chrom.to_string()).or_insert(next);
-                    }
-                }
-            }
-        }
-        drop(archive);
 
         let sa_metadata = SaMetadata {
             name: metadata.name.clone(),
@@ -280,6 +300,7 @@ impl Osa2Reader {
             reader_id: NEXT_READER_ID.fetch_add(1, Ordering::Relaxed),
             local_cache: local_budget.map(|b| Mutex::new(ChunkCache::new(b))),
             chunk_load_count: AtomicU64::new(0),
+            header_read_count,
             metadata,
             sa_metadata,
             fields,
@@ -292,6 +313,19 @@ impl Osa2Reader {
     /// by benchmarks/tests to detect chunk-cache thrashing.
     pub fn chunk_load_count(&self) -> u64 {
         self.chunk_load_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of ZIP entries in the archive. Startup-cost diagnostic (issue
+    /// #78): the open path must stay O(1) random reads in this number.
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Number of ZIP local file headers parsed so far. Each is a random read
+    /// into the file, so a large count at open time is the startup stall of
+    /// issue #78.
+    pub fn header_read_count(&self) -> u64 {
+        self.header_read_count.load(Ordering::Relaxed)
     }
 
     /// The chunk cache this reader writes to: its private one if configured,
@@ -320,27 +354,7 @@ impl Osa2Reader {
     /// `Ok(None)` means the entry is absent (a legitimate "this chunk has no
     /// data for this field"); `Err` means the archive is corrupt/unreadable.
     fn read_entry(&self, name: &str) -> Result<Option<Vec<u8>>> {
-        let Some(loc) = self.entries.get(name) else {
-            return Ok(None);
-        };
-        let start = loc.data_start as usize;
-        let end = start
-            .checked_add(loc.comp_size as usize)
-            .ok_or_else(|| anyhow::anyhow!("entry '{}' data range overflow", name))?;
-        if end > self.mmap.len() {
-            anyhow::bail!("entry '{}' extends beyond .osa2 file", name);
-        }
-        let raw = &self.mmap[start..end];
-        match loc.method {
-            EntryMethod::Stored => Ok(Some(raw.to_vec())),
-            EntryMethod::Deflated => {
-                let mut out = Vec::new();
-                DeflateDecoder::new(raw)
-                    .read_to_end(&mut out)
-                    .with_context(|| format!("inflating ZIP entry '{}'", name))?;
-                Ok(Some(out))
-            }
-        }
+        read_entry_from(&self.mmap, &self.entries, &self.header_read_count, name)
     }
 
     /// Build a chunk by reading its files from the mmap. Pure (no cache access)
@@ -509,26 +523,54 @@ impl Osa2Reader {
     }
 }
 
-/// Compute the start offset of a ZIP entry's data from its local file header,
-/// parsed directly out of the mmap. Robust against the crate's lazily-set
-/// `data_start` (which panics if the entry hasn't been read) and avoids reading
-/// any entry data at open. Local file header layout: 4-byte signature,
-/// 22 bytes of fixed fields, then u16 name length and u16 extra length at
-/// offsets 26/28, followed by name + extra, then the data.
-fn local_data_start(mmap: &Mmap, header_start: u64) -> Result<u64> {
-    let h = header_start as usize;
-    let fixed_end = h
-        .checked_add(30)
-        .ok_or_else(|| anyhow::anyhow!("ZIP local header offset overflow"))?;
-    if fixed_end > mmap.len() {
-        anyhow::bail!("ZIP local header at {} extends beyond file", header_start);
+/// Read and decompress one ZIP entry out of `mmap`.
+///
+/// Free function rather than a method so `open_inner` can use it for the
+/// prelude entries before the reader exists. Resolving `data_start` is where
+/// the entry's local file header is finally touched - once per entry, memoized
+/// in the `OnceLock`, and only for entries that are actually read (issue #78).
+/// A race between two threads on the same entry just parses the same header
+/// twice and stores the same value.
+fn read_entry_from(
+    mmap: &Mmap,
+    entries: &HashMap<String, EntryLoc>,
+    header_read_count: &AtomicU64,
+    name: &str,
+) -> Result<Option<Vec<u8>>> {
+    let Some(loc) = entries.get(name) else {
+        return Ok(None);
+    };
+    let data_start = match loc.data_start.get() {
+        Some(&start) => start,
+        None => {
+            let start = crate::zipdir::local_data_start(mmap, loc.header_start)
+                .with_context(|| format!("locating ZIP entry '{}'", name))?;
+            header_read_count.fetch_add(1, Ordering::Relaxed);
+            let _ = loc.data_start.set(start);
+            start
+        }
+    };
+
+    let start: usize = data_start
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("entry '{}' data offset exceeds usize", name))?;
+    let end = start
+        .checked_add(loc.comp_size as usize)
+        .ok_or_else(|| anyhow::anyhow!("entry '{}' data range overflow", name))?;
+    if end > mmap.len() {
+        anyhow::bail!("entry '{}' extends beyond .osa2 file", name);
     }
-    if &mmap[h..h + 4] != b"PK\x03\x04" {
-        anyhow::bail!("bad ZIP local header signature at {}", header_start);
+    let raw = &mmap[start..end];
+    match loc.method {
+        EntryMethod::Stored => Ok(Some(raw.to_vec())),
+        EntryMethod::Deflated => {
+            let mut out = Vec::new();
+            DeflateDecoder::new(raw)
+                .read_to_end(&mut out)
+                .with_context(|| format!("inflating ZIP entry '{}'", name))?;
+            Ok(Some(out))
+        }
     }
-    let name_len = u16::from_le_bytes([mmap[h + 26], mmap[h + 27]]) as u64;
-    let extra_len = u16::from_le_bytes([mmap[h + 28], mmap[h + 29]]) as u64;
-    Ok(header_start + 30 + name_len + extra_len)
 }
 
 impl AnnotationProvider for Osa2Reader {

--- a/crates/fastvep-sa/src/zipdir.rs
+++ b/crates/fastvep-sa/src/zipdir.rs
@@ -1,0 +1,590 @@
+//! Minimal ZIP central-directory reader over a memory-mapped archive.
+//!
+//! **Why this exists (issue #78).** `.osa2` files are ZIP archives whose entry
+//! table the reader needs at `open`. Walking that table with
+//! `zip::ZipArchive::by_index` costs one *seek + read of the entry's local file
+//! header* per entry, because the crate resolves each entry's data offset
+//! eagerly. Local headers sit next to their data, so those reads are scattered
+//! across the whole (multi-GB) file: a per-chromosome gnomAD shard has a few
+//! thousand entries, and a 24-shard `--sa-dir` therefore paid ~100k random
+//! reads before annotation could start - 25+ minutes on rotational/network
+//! storage, and invisible because it happens before the progress meter.
+//!
+//! The central directory is a single contiguous region at the end of the file
+//! and holds everything the reader needs except each entry's local-header
+//! padding. Parsing it here, straight from the mmap, makes `open` a sequential
+//! read of that one region; the local header is then resolved lazily, on the
+//! first read of that entry, when its page is about to be touched anyway.
+//!
+//! Only what `.osa2` needs is implemented: no encryption, no multi-disk
+//! archives, no data descriptors. ZIP64 is supported because gnomAD-scale
+//! shards cross the 4 GiB offset boundary.
+
+use anyhow::{bail, Context, Result};
+
+const EOCD_SIG: u32 = 0x0605_4b50;
+const ZIP64_EOCD_LOCATOR_SIG: u32 = 0x0706_4b50;
+const ZIP64_EOCD_SIG: u32 = 0x0606_4b50;
+const CENTRAL_HEADER_SIG: u32 = 0x0201_4b50;
+pub(crate) const LOCAL_HEADER_SIG: u32 = 0x0403_4b50;
+
+const EOCD_FIXED_LEN: usize = 22;
+const ZIP64_EOCD_LOCATOR_LEN: usize = 20;
+const CENTRAL_HEADER_FIXED_LEN: usize = 46;
+pub(crate) const LOCAL_HEADER_FIXED_LEN: u64 = 30;
+
+/// The ZIP32 "value lives in the ZIP64 extra field" sentinel.
+const U32_SENTINEL: u32 = u32::MAX;
+const U16_SENTINEL: u16 = u16::MAX;
+
+/// One entry as described by the central directory. `data_start` is
+/// deliberately absent: deriving it requires the entry's *local* header, which
+/// is the random read this module exists to avoid.
+#[derive(Debug)]
+pub(crate) struct CentralEntry {
+    pub name: String,
+    pub header_start: u64,
+    pub comp_size: u64,
+    /// Raw ZIP compression method id (0 = stored, 8 = deflated).
+    pub method: u16,
+}
+
+/// Fixed-width little-endian read with an explicit bounds check. Offsets here
+/// can come from the file's own (possibly corrupt) fields, so the addition is
+/// checked rather than trusted.
+fn read_le<const N: usize>(buf: &[u8], at: usize) -> Result<[u8; N]> {
+    let end = at
+        .checked_add(N)
+        .filter(|&end| end <= buf.len())
+        .ok_or_else(|| anyhow::anyhow!("truncated ZIP structure at byte {}", at))?;
+    let mut b = [0u8; N];
+    b.copy_from_slice(&buf[at..end]);
+    Ok(b)
+}
+
+fn read_u16(buf: &[u8], at: usize) -> Result<u16> {
+    read_le::<2>(buf, at).map(u16::from_le_bytes)
+}
+
+fn read_u32(buf: &[u8], at: usize) -> Result<u32> {
+    read_le::<4>(buf, at).map(u32::from_le_bytes)
+}
+
+fn read_u64(buf: &[u8], at: usize) -> Result<u64> {
+    read_le::<8>(buf, at).map(u64::from_le_bytes)
+}
+
+/// Locate the end-of-central-directory record. The ZIP comment may be up to
+/// 64 KiB, so the record can sit that far from the end; scan backwards and
+/// accept the first candidate whose comment length lands exactly on EOF, which
+/// rules out a stray signature inside compressed data.
+fn find_eocd(mmap: &[u8]) -> Result<usize> {
+    if mmap.len() < EOCD_FIXED_LEN {
+        bail!("file is too small to be a ZIP archive ({} bytes)", mmap.len());
+    }
+    let max_back = (u16::MAX as usize + EOCD_FIXED_LEN).min(mmap.len());
+    let search_start = mmap.len() - max_back;
+    for pos in (search_start..=mmap.len() - EOCD_FIXED_LEN).rev() {
+        if read_u32(mmap, pos)? != EOCD_SIG {
+            continue;
+        }
+        let comment_len = read_u16(mmap, pos + 20)? as usize;
+        if pos + EOCD_FIXED_LEN + comment_len == mmap.len() {
+            return Ok(pos);
+        }
+    }
+    bail!("not a ZIP archive: no end-of-central-directory record found")
+}
+
+/// Where the central directory lives and how many records it holds.
+struct CentralDirectoryLocator {
+    offset: u64,
+    size: u64,
+    count: u64,
+    /// Whether `count` is the true record count. The ZIP32 footer clamps the
+    /// count to 65535, so an archive with exactly that many entries reports a
+    /// count that happens to equal the sentinel without being one.
+    count_is_exact: bool,
+    /// Byte position of whichever record terminates the central directory
+    /// (the ZIP64 EOCD if present, else the EOCD). Used to recover the real
+    /// directory position when the archive has prepended data.
+    directory_end: u64,
+}
+
+fn locate_central_directory(mmap: &[u8], eocd: usize) -> Result<CentralDirectoryLocator> {
+    let count32 = read_u16(mmap, eocd + 10)?;
+    let size32 = read_u32(mmap, eocd + 12)?;
+    let offset32 = read_u32(mmap, eocd + 16)?;
+
+    // The ZIP64 footer, when present, is authoritative - probe for it rather
+    // than inferring from the ZIP32 fields. Writers clamp all three of those
+    // to their maximum whether or not ZIP64 is in play, so a clamped value is
+    // not by itself proof of anything: an archive with exactly 65535 entries
+    // reports count32 == 0xFFFF and has no ZIP64 footer at all.
+    if let Some(z64) = find_zip64_eocd(mmap, eocd)? {
+        return Ok(CentralDirectoryLocator {
+            offset: read_u64(mmap, z64 + 48)?,
+            size: read_u64(mmap, z64 + 40)?,
+            count: read_u64(mmap, z64 + 32)?,
+            count_is_exact: true,
+            directory_end: z64 as u64,
+        });
+    }
+
+    // No ZIP64 footer, so the ZIP32 fields must be real. A clamped size or
+    // offset here means the archive genuinely needed ZIP64 and does not have
+    // it; a clamped count is only ambiguous, and `count` is advisory anyway.
+    if size32 == U32_SENTINEL || offset32 == U32_SENTINEL {
+        bail!("archive needs a ZIP64 end-of-central-directory record but has none");
+    }
+    Ok(CentralDirectoryLocator {
+        offset: offset32 as u64,
+        size: size32 as u64,
+        count: count32 as u64,
+        count_is_exact: count32 != U16_SENTINEL,
+        directory_end: eocd as u64,
+    })
+}
+
+/// Offset of the ZIP64 end-of-central-directory record, if this archive has
+/// one. The locator sits immediately before the ZIP32 EOCD and points at it.
+fn find_zip64_eocd(mmap: &[u8], eocd: usize) -> Result<Option<usize>> {
+    let Some(locator) = eocd.checked_sub(ZIP64_EOCD_LOCATOR_LEN) else {
+        return Ok(None);
+    };
+    if read_u32(mmap, locator)? != ZIP64_EOCD_LOCATOR_SIG {
+        return Ok(None);
+    }
+    let z64 = read_u64(mmap, locator + 8)?;
+    let z64: usize = z64
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("ZIP64 EOCD offset {} exceeds usize", z64))?;
+    if z64 >= mmap.len() || read_u32(mmap, z64)? != ZIP64_EOCD_SIG {
+        bail!("ZIP64 end-of-central-directory record not found at offset {}", z64);
+    }
+    Ok(Some(z64))
+}
+
+/// Byte range of the central directory within `mmap`.
+///
+/// The recorded offset is relative to the start of the ZIP data, which is not
+/// the start of the file for an archive with prepended bytes (a
+/// self-extracting stub, or anything concatenated in front). When the recorded
+/// offset does not land on a directory record, fall back to deriving the
+/// position from where the directory ends - the same recovery the `zip` crate
+/// performs, kept so such archives keep opening.
+fn central_directory_range(mmap: &[u8], loc: &CentralDirectoryLocator) -> Result<(usize, usize)> {
+    let size: usize = loc
+        .size
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("central directory size {} exceeds usize", loc.size))?;
+
+    let starts_a_record = |start: u64| -> bool {
+        let Ok(start) = usize::try_from(start) else {
+            return false;
+        };
+        match start.checked_add(size) {
+            Some(end) if end <= mmap.len() => {
+                size == 0 || read_u32(mmap, start).map(|s| s == CENTRAL_HEADER_SIG).unwrap_or(false)
+            }
+            _ => false,
+        }
+    };
+
+    let candidates = [Some(loc.offset), loc.directory_end.checked_sub(loc.size)];
+    for start in candidates.into_iter().flatten() {
+        if starts_a_record(start) {
+            let start = start as usize;
+            return Ok((start, start + size));
+        }
+    }
+    bail!(
+        "central directory not found at offset {} ({} bytes) in a {}-byte archive",
+        loc.offset,
+        loc.size,
+        mmap.len()
+    )
+}
+
+/// Parse every central-directory record in `mmap`.
+///
+/// Sequential over one contiguous region: no random access, no syscalls, and
+/// no local file headers touched.
+pub(crate) fn parse_central_directory(mmap: &[u8]) -> Result<Vec<CentralEntry>> {
+    let eocd = find_eocd(mmap)?;
+    let loc = locate_central_directory(mmap, eocd)?;
+    let (start, end) = central_directory_range(mmap, &loc)?;
+    let cd = &mmap[start..end];
+
+    // Every offset the directory records - its own and each local header's -
+    // is relative to the start of the ZIP data. Shift them all by however far
+    // that is from the start of the file (zero for anything this crate wrote).
+    let archive_offset = (start as u64).saturating_sub(loc.offset);
+
+    // `count` comes from the file, so it only pre-sizes the Vec - the loop
+    // below is bounded by the directory's byte length, not by this number.
+    let mut entries = Vec::with_capacity((loc.count as usize).min(1 << 16));
+    let mut at = 0usize;
+    while at + CENTRAL_HEADER_FIXED_LEN <= cd.len() {
+        if read_u32(cd, at)? != CENTRAL_HEADER_SIG {
+            bail!("bad central-directory record signature at offset {}", start + at);
+        }
+        let method = read_u16(cd, at + 10)?;
+        let comp_size32 = read_u32(cd, at + 20)?;
+        let uncomp_size32 = read_u32(cd, at + 24)?;
+        let name_len = read_u16(cd, at + 28)? as usize;
+        let extra_len = read_u16(cd, at + 30)? as usize;
+        let comment_len = read_u16(cd, at + 32)? as usize;
+        let header_start32 = read_u32(cd, at + 42)?;
+
+        let name_at = at + CENTRAL_HEADER_FIXED_LEN;
+        let extra_at = name_at + name_len;
+        let record_end = extra_at + extra_len + comment_len;
+        if record_end > cd.len() {
+            bail!("central-directory record at offset {} is truncated", start + at);
+        }
+
+        let name = std::str::from_utf8(&cd[name_at..extra_at])
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "central-directory entry at offset {} has a non-UTF-8 name",
+                    start + at
+                )
+            })?
+            .to_string();
+
+        let (comp_size, header_start) = resolve_zip64(
+            &cd[extra_at..extra_at + extra_len],
+            uncomp_size32,
+            comp_size32,
+            header_start32,
+        )
+        .with_context(|| format!("central-directory entry '{}'", name))?;
+
+        entries.push(CentralEntry {
+            name,
+            header_start: header_start.saturating_add(archive_offset),
+            comp_size,
+            method,
+        });
+        at = record_end;
+    }
+
+    // A short or otherwise wrong directory would silently truncate the entry
+    // table, and a missing entry reads back as "this chunk has no data for
+    // this field" - annotations would quietly disappear instead of the load
+    // failing. Cross-check against the count the footer declares.
+    if loc.count_is_exact && entries.len() as u64 != loc.count {
+        bail!(
+            "central directory declares {} entries but {} were readable in its {} bytes",
+            loc.count,
+            entries.len(),
+            end - start
+        );
+    }
+    if at != cd.len() {
+        bail!(
+            "central directory has {} trailing bytes after its last record",
+            cd.len() - at
+        );
+    }
+
+    Ok(entries)
+}
+
+/// Pull the full-width compressed size / local-header offset out of the ZIP64
+/// extended-information extra field.
+///
+/// The field packs values in a fixed order - uncompressed size, compressed
+/// size, local header offset, disk number - but which of them are present is
+/// not stated anywhere in the field itself. The spec says only the values that
+/// overflowed their ZIP32 slot appear, yet `zip`'s own writer emits all three
+/// u64s whenever `large_file` is set, sentinel or not. Reading purely by
+/// sentinel therefore mis-aligns on those archives and hands back an
+/// uncompressed size where a header offset belongs. Mirror `zip`'s reader
+/// exactly: a body of 24 bytes or more carries all three regardless.
+fn resolve_zip64(
+    extra: &[u8],
+    uncomp_size32: u32,
+    comp_size32: u32,
+    header_start32: u32,
+) -> Result<(u64, u64)> {
+    let mut comp_size = comp_size32 as u64;
+    let mut header_start = header_start32 as u64;
+    if comp_size32 != U32_SENTINEL && header_start32 != U32_SENTINEL {
+        return Ok((comp_size, header_start));
+    }
+
+    let mut at = 0usize;
+    while at + 4 <= extra.len() {
+        let id = read_u16(extra, at)?;
+        let len = read_u16(extra, at + 2)? as usize;
+        let body_at = at + 4;
+        let body_end = body_at
+            .checked_add(len)
+            .filter(|&e| e <= extra.len())
+            .ok_or_else(|| anyhow::anyhow!("ZIP extra field at offset {} is truncated", at))?;
+        if id == 0x0001 {
+            let body = &extra[body_at..body_end];
+            let all_present = len >= 24;
+            let mut cursor = 0usize;
+            if all_present || uncomp_size32 == U32_SENTINEL {
+                read_u64(body, cursor)?;
+                cursor += 8;
+            }
+            if all_present || comp_size32 == U32_SENTINEL {
+                comp_size = read_u64(body, cursor)?;
+                cursor += 8;
+            }
+            if all_present || header_start32 == U32_SENTINEL {
+                header_start = read_u64(body, cursor)?;
+            }
+            return Ok((comp_size, header_start));
+        }
+        at = body_end;
+    }
+
+    bail!("entry needs a ZIP64 extended-information field but none is present")
+}
+
+/// Offset of an entry's data, derived from its *local* file header.
+///
+/// Separate from the central directory on purpose: the local header's name and
+/// extra-field lengths can differ from the central copy, so this is the one
+/// piece that cannot be answered without touching the entry itself. Callers
+/// resolve it lazily, on first read of the entry.
+pub(crate) fn local_data_start(mmap: &[u8], header_start: u64) -> Result<u64> {
+    let h: usize = header_start
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("ZIP local header offset {} exceeds usize", header_start))?;
+    let fixed_end = h
+        .checked_add(LOCAL_HEADER_FIXED_LEN as usize)
+        .ok_or_else(|| anyhow::anyhow!("ZIP local header offset overflow"))?;
+    if fixed_end > mmap.len() {
+        bail!("ZIP local header at {} extends beyond file", header_start);
+    }
+    if read_u32(mmap, h)? != LOCAL_HEADER_SIG {
+        bail!("bad ZIP local header signature at {}", header_start);
+    }
+    let name_len = read_u16(mmap, h + 26)? as u64;
+    let extra_len = read_u16(mmap, h + 28)? as u64;
+    Ok(header_start + LOCAL_HEADER_FIXED_LEN + name_len + extra_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    /// Build a small in-memory ZIP with the same writer `.osa2` uses, then
+    /// check the hand-rolled parser agrees with the `zip` crate on every entry.
+    fn round_trip(names_and_bodies: &[(&str, Vec<u8>)], large: bool) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated)
+                .large_file(large);
+            for (name, body) in names_and_bodies {
+                zw.start_file(*name, opts).unwrap();
+                zw.write_all(body).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    fn assert_parity(buf: &[u8]) {
+        let parsed = parse_central_directory(buf).unwrap();
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        assert_eq!(parsed.len(), archive.len(), "entry count");
+        for (i, entry) in parsed.iter().enumerate() {
+            let zf = archive.by_index(i).unwrap();
+            assert_eq!(entry.name, zf.name(), "name at {}", i);
+            assert_eq!(entry.comp_size, zf.compressed_size(), "comp_size of {}", entry.name);
+            assert_eq!(entry.header_start, zf.header_start(), "header_start of {}", entry.name);
+            let expected_method = match zf.compression() {
+                zip::CompressionMethod::Stored => 0u16,
+                zip::CompressionMethod::Deflated => 8u16,
+                other => panic!("unexpected compression {other:?}"),
+            };
+            assert_eq!(entry.method, expected_method, "method of {}", entry.name);
+            let expected_start = zf.data_start();
+            drop(zf);
+            assert_eq!(
+                local_data_start(buf, entry.header_start).unwrap(),
+                expected_start,
+                "data_start of {}",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn parses_a_plain_archive() {
+        let buf = round_trip(
+            &[
+                ("fastsa/metadata.json", b"{\"a\":1}".to_vec()),
+                ("fastsa/chr1/0/var32.bin", vec![7u8; 4096]),
+                ("fastsa/chr1/0/allAf.bin", vec![9u8; 1024]),
+            ],
+            false,
+        );
+        assert_parity(&buf);
+    }
+
+    #[test]
+    fn parses_zip64_entries() {
+        // `large_file(true)` forces ZIP64 extra fields on every entry, which is
+        // the layout a multi-GB gnomAD shard produces.
+        let buf = round_trip(
+            &[
+                ("fastsa/metadata.json", b"{}".to_vec()),
+                ("fastsa/chr1/0/var32.bin", vec![3u8; 8192]),
+            ],
+            true,
+        );
+        assert_parity(&buf);
+    }
+
+    #[test]
+    fn parses_archive_with_trailing_comment() {
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            zw.set_comment("a comment that follows the EOCD record");
+            zw.start_file("fastsa/metadata.json", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            zw.write_all(b"{}").unwrap();
+            zw.finish().unwrap();
+        }
+        assert_parity(&buf);
+    }
+
+    /// An archive with bytes glued in front of it records offsets relative to
+    /// the ZIP data, not the file. The `zip` crate recovers from this, so the
+    /// hand-rolled parser must too or such files would stop opening.
+    #[test]
+    fn parses_an_archive_with_prepended_data() {
+        let inner = round_trip(
+            &[
+                ("fastsa/metadata.json", b"{}".to_vec()),
+                ("fastsa/chr1/0/var32.bin", vec![5u8; 2048]),
+            ],
+            false,
+        );
+        let mut buf = vec![0xAAu8; 4096];
+        buf.extend_from_slice(&inner);
+
+        let parsed = parse_central_directory(&buf).unwrap();
+        assert_eq!(parsed.len(), 2);
+        for entry in &parsed {
+            // Offsets must be file-relative, so each one lands on a real local
+            // header past the prepended block.
+            assert!(entry.header_start >= 4096, "{} not shifted", entry.name);
+            local_data_start(&buf, entry.header_start).unwrap();
+        }
+    }
+
+    /// The ZIP32 footer clamps its entry count to 65535, so an archive with
+    /// exactly that many entries reports the sentinel while having no ZIP64
+    /// footer at all. Reading the clamp as "this is ZIP64" rejected the file -
+    /// and `load_sa_providers` downgrades an open failure to a warning, so the
+    /// shard would have been dropped silently.
+    #[test]
+    fn parses_archives_around_the_zip32_entry_clamp() {
+        for n in [65534usize, 65535, 65536] {
+            let mut buf = Vec::new();
+            {
+                let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+                let opts = zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Stored);
+                for i in 0..n {
+                    zw.start_file(format!("e{i}"), opts).unwrap();
+                }
+                zw.finish().unwrap();
+            }
+            let parsed = parse_central_directory(&buf)
+                .unwrap_or_else(|e| panic!("{n}-entry archive failed to parse: {e}"));
+            assert_eq!(parsed.len(), n, "entry count for a {n}-entry archive");
+        }
+    }
+
+    /// `zip`'s writer emits all three ZIP64 u64s whenever `large_file` is set,
+    /// even for values that fit in 32 bits. Picking fields by sentinel alone
+    /// mis-aligns on those and returns the uncompressed size as the header
+    /// offset.
+    #[test]
+    fn zip64_extra_field_of_full_length_holds_all_three_values() {
+        let mut extra = Vec::new();
+        extra.extend_from_slice(&7u64.to_le_bytes()); // uncompressed size
+        extra.extend_from_slice(&11u64.to_le_bytes()); // compressed size
+        extra.extend_from_slice(&0x1_0000_0000u64.to_le_bytes()); // header start
+        let field = {
+            let mut f = vec![0x01, 0x00, 24, 0x00];
+            f.extend_from_slice(&extra);
+            f
+        };
+        // Sizes fit in 32 bits; only the header offset is a sentinel.
+        let (comp_size, header_start) =
+            resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
+        assert_eq!(comp_size, 11);
+        assert_eq!(header_start, 0x1_0000_0000);
+    }
+
+    /// The spec-minimal form: only the overflowed value is present.
+    #[test]
+    fn zip64_extra_field_of_minimal_length_holds_only_the_overflowed_value() {
+        let mut field = vec![0x01, 0x00, 8, 0x00];
+        field.extend_from_slice(&0x2_0000_0000u64.to_le_bytes());
+        let (comp_size, header_start) =
+            resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
+        assert_eq!(comp_size, 11);
+        assert_eq!(header_start, 0x2_0000_0000);
+    }
+
+    /// A directory that parses into fewer records than the footer declares
+    /// must fail the load, not yield a short entry table whose missing entries
+    /// read back as "this field has no data".
+    #[test]
+    fn rejects_a_directory_shorter_than_its_declared_count() {
+        let mut buf = round_trip(
+            &[
+                ("a.bin", vec![1u8; 64]),
+                ("b.bin", vec![2u8; 64]),
+                ("c.bin", vec![3u8; 64]),
+            ],
+            false,
+        );
+        assert_eq!(parse_central_directory(&buf).unwrap().len(), 3);
+
+        // Shrink the recorded directory size so the last record falls outside.
+        let eocd = find_eocd(&buf).unwrap();
+        let size = read_u32(&buf, eocd + 12).unwrap();
+        buf[eocd + 12..eocd + 16].copy_from_slice(&(size / 2).to_le_bytes());
+        let err = parse_central_directory(&buf).unwrap_err().to_string();
+        assert!(err.contains("declares 3 entries") || err.contains("trailing bytes"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_non_zip_file() {
+        let err = parse_central_directory(&[0u8; 512]).unwrap_err().to_string();
+        assert!(err.contains("no end-of-central-directory"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_a_truncated_file() {
+        let err = parse_central_directory(b"PK").unwrap_err().to_string();
+        assert!(err.contains("too small"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_a_corrupt_central_directory() {
+        let mut buf = round_trip(&[("a.bin", vec![1u8; 64])], false);
+        // Corrupt the first central-directory record signature.
+        let eocd = find_eocd(&buf).unwrap();
+        let cd_off = read_u32(&buf, eocd + 16).unwrap() as usize;
+        buf[cd_off] = 0x00;
+        assert!(parse_central_directory(&buf).is_err());
+    }
+}

--- a/crates/fastvep-sa/tests/issue_78_open_cost.rs
+++ b/crates/fastvep-sa/tests/issue_78_open_cost.rs
@@ -1,0 +1,175 @@
+//! Issue #78: opening an `.osa2` must not scale with the number of ZIP entries
+//! in random I/O.
+//!
+//! The reported symptom was a 25-30 minute silent stall before annotation
+//! started after adding per-chromosome gnomAD shards to `--sa-dir`. The cause
+//! was `open` resolving every entry's data offset from its *local* file header,
+//! which is one random read per entry scattered across a multi-GB file. These
+//! tests pin the two halves of the contract: `open` touches a constant number
+//! of local headers regardless of archive size, and the deferred resolution
+//! still yields byte-identical lookups.
+
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2StreamWriter};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// Multiple value columns so each chunk becomes several ZIP entries, the way a
+/// real gnomAD shard does.
+fn fields() -> Vec<Field> {
+    (0..4)
+        .map(|i| Field {
+            field: format!("F{i}"),
+            alias: format!("f{i}"),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: format!("field {i}"),
+        })
+        .collect()
+}
+
+fn metadata(chunk_bits: u32) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "issue78".into(),
+        version: "test".into(),
+        assembly: "GRCh38".into(),
+        json_key: "issue78".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits,
+        description: String::new(),
+    }
+}
+
+/// One record every `1 << chunk_bits` bases, so `n_chunks` chunks are emitted
+/// and the entry count grows linearly with `n_chunks`.
+fn build(dir: &Path, name: &str, n_chunks: u32, chunk_bits: u32) -> PathBuf {
+    let flds = fields();
+    let path = dir.join(name);
+    let file = std::io::BufWriter::new(std::fs::File::create(&path).unwrap());
+    let mut writer = Osa2StreamWriter::new(file, &metadata(chunk_bits), flds.clone()).unwrap();
+    for c in 0..n_chunks {
+        for k in 0..4u32 {
+            let position = (c << chunk_bits) + 10 + k;
+            writer
+                .push(Osa2Record {
+                    chrom: "chr1".into(),
+                    position,
+                    ref_allele: b"A".to_vec(),
+                    alt_allele: b"G".to_vec(),
+                    values: (0..flds.len()).map(|f| position + f as u32).collect(),
+                    json_blob: None,
+                })
+                .unwrap();
+        }
+    }
+    writer.finish().unwrap();
+    path
+}
+
+/// The core regression: a 16x bigger archive must cost the *same* number of
+/// local-header reads at open. Before the fix this was one per entry.
+#[test]
+fn open_cost_is_independent_of_entry_count() {
+    let dir = TempDir::new().unwrap();
+    let small = Osa2Reader::open(&build(dir.path(), "small.osa2", 8, 12)).unwrap();
+    let big = Osa2Reader::open(&build(dir.path(), "big.osa2", 128, 12)).unwrap();
+
+    assert!(
+        big.entry_count() > small.entry_count() * 8,
+        "fixture should scale: {} vs {}",
+        small.entry_count(),
+        big.entry_count()
+    );
+    assert_eq!(
+        small.header_read_count(),
+        big.header_read_count(),
+        "open must read a constant number of local headers, not one per entry \
+         (small={} entries, big={} entries)",
+        small.entry_count(),
+        big.entry_count()
+    );
+    // Only the metadata + config prelude is read at open.
+    assert!(
+        big.header_read_count() <= 4,
+        "open read {} local headers; expected only the prelude entries",
+        big.header_read_count()
+    );
+}
+
+/// Deferring the offset resolution must not change what a lookup returns, and
+/// a repeated lookup must not re-parse the header it already memoized.
+#[test]
+fn deferred_offsets_still_resolve_correctly() {
+    let dir = TempDir::new().unwrap();
+    let reader = Osa2Reader::open(&build(dir.path(), "q.osa2", 64, 12)).unwrap();
+
+    let mut seen = 0;
+    for c in 0..64u32 {
+        for k in 0..4u32 {
+            let position = ((c << 12) + 10 + k) as u64;
+            let value = reader
+                .annotate_position("chr1", position, "A", "G")
+                .unwrap()
+                .unwrap_or_else(|| panic!("missing annotation at chr1:{position}"));
+            let AnnotationValue::Json(json) = value else {
+                panic!("expected an allele-matched JSON value");
+            };
+            for f in 0..4u32 {
+                assert!(
+                    json.contains(&format!("\"f{f}\":{}", position as u32 + f)),
+                    "value column f{f} wrong at chr1:{position}: {json}"
+                );
+            }
+            seen += 1;
+        }
+    }
+    assert_eq!(seen, 256);
+
+    // A miss must stay a miss, not become an error, once offsets are lazy.
+    assert!(reader
+        .annotate_position("chr1", 999_999_999, "A", "G")
+        .unwrap()
+        .is_none());
+
+    let after_first_pass = reader.header_read_count();
+    for c in 0..64u32 {
+        reader
+            .annotate_position("chr1", ((c << 12) + 10) as u64, "A", "G")
+            .unwrap();
+    }
+    assert_eq!(
+        after_first_pass,
+        reader.header_read_count(),
+        "a second pass must reuse the memoized data offsets"
+    );
+}
+
+/// Concurrent first-touch of the same entries must not deadlock, double-count
+/// incorrectly, or produce wrong values - the `OnceLock` fill is racy by design.
+#[test]
+fn concurrent_first_touch_is_consistent() {
+    use rayon::prelude::*;
+
+    let dir = TempDir::new().unwrap();
+    let reader = Osa2Reader::open(&build(dir.path(), "par.osa2", 64, 12)).unwrap();
+
+    let hits: usize = (0..64u32)
+        .into_par_iter()
+        .flat_map(|c| (0..4u32).into_par_iter().map(move |k| ((c << 12) + 10 + k) as u64))
+        .map(|position| {
+            reader
+                .annotate_position("chr1", position, "A", "G")
+                .unwrap()
+                .is_some() as usize
+        })
+        .sum();
+    assert_eq!(hits, 256);
+}


### PR DESCRIPTION
Adding per-chromosome gnomAD `.osa2` shards to `--sa-dir` added 25-30
minutes of silent pre-startup time before annotation began.

Root cause: `Osa2Reader::open` walked the ZIP entry table with
`zip::ZipArchive::by_index`, which eagerly resolves each entry's data
offset from its *local* file header. Local headers sit next to their
data, so that walk is one random read per entry scattered across the
whole multi-GB file. A gnomAD shard holds ~650-3,400 entries (one per
1 Mbp chunk per field column), so a 23-shard `--sa-dir` did ~41,000
random reads before the first variant was annotated. On rotational or
network storage that is ~18 ms each, which is exactly the reported
stall. It was invisible because `load_sa_providers` logs through
`tracing`, and the CLI installs no subscriber.

- `fastvep-sa/src/zipdir.rs` (new): parse the ZIP central directory
  straight from the mmap. It is one contiguous region at the end of the
  file, so open becomes a sequential read. Handles ZIP64 (gnomAD shards
  cross 4 GiB) and archives with prepended data, matching what the `zip`
  crate tolerated. Unit tests assert field-by-field parity with
  `zip::ZipArchive`, including the 65535-entry ZIP32 count clamp and both
  ZIP64 extra-field encodings.
- `reader_v2.rs`: `data_start` moves into a `OnceLock`, resolved on the
  first read of an entry, when its page is about to be touched anyway.
  Adds `entry_count()` / `header_read_count()` diagnostics next to the
  existing `chunk_load_count()`.
- `fastvep-annotate`: open `--sa-dir` sources in parallel (latency-bound,
  and the per-chromosome deployment has 200+ shards) and return them in
  sorted-path order, so supplementary column order no longer depends on
  `read_dir` order.
- `fastvep-cli`: report the load on stderr alongside the other startup
  steps, so this can never be a silent stall again.

Measured on 23 gnomAD-shaped shards, 12.8 GB, 41,386 ZIP entries, cold
page cache, local NVMe:

  open       6.072 s -> 0.022 s   (276x)
  random reads at open   41,386 -> 46
  end-to-end annotate     81.7 s -> 74.2 s, output byte-identical

One behavior change: a corrupt local header for an individual entry now
surfaces at read time rather than at open, which is inherent to not
touching those headers at startup.
