### PR TITLE
fix(sa): finish the .osa2 migration and fix two v2 record-fidelity bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ fastvep annotate -i tests/test.vcf --gff3 tests/test.gff3 --hgvs --output-format
 ### 4. Build supplementary annotation databases
 
 ```bash
-# Supported sources build the smaller, faster v2 `.osa2` format automatically
-# (`--format auto` is the default); pass `--format osa` to force v1 `.osa`.
+# Every allele-level source builds the smaller, faster v2 `.osa2` format
+# automatically (`--format auto` is the default); pass `--format osa` to force
+# v1 `.osa`. Already have `.osa` files? `fastvep sa-convert` upgrades them in
+# place of a re-download.
 
 # Build ClinVar annotation database (writes clinvar.osa2)
 fastvep sa-build --source clinvar --input clinvar.vcf.gz --output clinvar
@@ -107,8 +109,15 @@ fastvep sa-build --source alphamissense --input AlphaMissense_hg38.tsv.gz --outp
 # chromosome, not a single combined download)
 fastvep sa-build --source phylop --input hg38.phyloP100way.wigFix.gz --output phylop
 
-# Build SpliceAI predictions
+# Build SpliceAI predictions (writes spliceai.osa2). The densest source
+# fastVEP ships against, and the one v2 helps most: its eight delta
+# scores/positions become numeric columns and the gene symbol a string-table
+# index, for 0.14x-0.56x the v1 size depending on how much the scores vary.
 fastvep sa-build --source spliceai --input spliceai_scores.vcf.gz --output spliceai
+
+# Upgrade a v1 database built before .osa2 became the default, without
+# re-downloading the upstream release (writes dbsnp.osa2 alongside it)
+fastvep sa-convert --input sa_databases/dbsnp.osa
 ```
 
 ### 5. Annotate with supplementary databases
@@ -174,7 +183,7 @@ samtools faidx Homo_sapiens.GRCh38.dna.primary_assembly.fa
 
 ### Step 2: Build supplementary annotation databases
 
-Each supplementary database (ClinVar, gnomAD, etc.) is built in **two steps** — *download the source file*, then run `fastvep sa-build` to convert it into the fastSA `.osa` + `.osa.idx` pair. **`sa-build` is a converter, not a downloader; if you skip the download, the resulting `.osa` will be empty and your annotations will silently come back blank.** After each build, check that the `.osa` size matches the expected magnitude (column below); a few-KB `.osa` is the tell that the source file wasn't real.
+Each supplementary database (ClinVar, gnomAD, etc.) is built in **two steps** — *download the source file*, then run `fastvep sa-build` to convert it into a fastSA database (a `.osa2` file by default; a `.osa` + `.osa.idx` pair under `--format osa`). **`sa-build` is a converter, not a downloader; if you skip the download, the resulting database will be empty and your annotations will silently come back blank.** After each build, check that the file size matches the expected magnitude (column below); a few-KB database is the tell that the source file wasn't real.
 
 ```bash
 mkdir -p sa_databases
@@ -461,11 +470,25 @@ objects will be heterogeneous.
 |------|-------------|---------|
 | `--source` | Source type (clinvar, gnomad, dbsnp, cosmic, onekg, topmed, mitomap, phylop, gerp, dann, revel, spliceai, primateai, dbnsfp, omim, gnomad_genes, clinvar_protein, custom_vcf, custom_bed, custom) | *required* |
 | `-i, --input` | Input file (VCF/TSV/wigFix/BED, supports .gz) | *required* |
-| `-o, --output` | Output base path (creates .osa + .osa.idx, or .osi for BED) | *required* |
+| `-o, --output` | Output base path (creates .osa2 by default; .osa + .osa.idx under `--format osa`, .osi for BED, .oga for gene-level sources) | *required* |
 | `--assembly` | Genome assembly | `GRCh38` |
 | `--name` | Display + JSON-key name for `custom_*` sources | derived from input filename |
 | `--info-fields` | Comma-separated INFO keys to extract for `custom_vcf` | all INFO keys |
-| `--format` | On-disk format: `auto` (default), `osa` (v1), or `osa2` (v2). `auto` builds the smaller, faster v2 `.osa2` for the sources that support it and v1 `.osa` for the rest — the best format per source, no need to choose. See [Choosing v1 vs v2](docs/SUPPLEMENTARY_ANNOTATIONS.md#choosing-v1-vs-v2---format) for when to override. | `auto` |
+| `--format` | On-disk format: `auto` (default), `osa` (v1), or `osa2` (v2). Every allele-level source has a v2 encoder, so `auto` builds the smaller, faster `.osa2` for all of them; gene- and interval-level sources have no v2 form and build `.oga`/`.osi` regardless. See [Choosing v1 vs v2](docs/SUPPLEMENTARY_ANNOTATIONS.md#choosing-v1-vs-v2---format) for when to force `osa`. | `auto` |
+
+### `fastvep sa-convert`
+
+Upgrades an existing v1 `.osa` database to v2 `.osa2` without re-downloading and
+re-parsing the upstream source. Preserves the record set, every record's JSON
+payload byte for byte, and the database's identity and matching semantics — see
+[Converting an existing v1 database](docs/SUPPLEMENTARY_ANNOTATIONS.md#converting-an-existing-v1-database-sa-convert)
+for the one caveat about column-oriented sources.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-i, --input` | Input v1 `.osa` file (its `.osa.idx` must sit alongside it) | *required* |
+| `-o, --output` | Output base path (`.osa2` appended) | input path with the extension replaced |
+| `--no-progress` | Suppress periodic progress output | off |
 
 ### `fastvep filter`
 
@@ -635,8 +658,14 @@ The `.osa2` format (echtvar-inspired chunked binary; `--format auto` default) st
 
 | Source | v1 (.osa) | v2 (.osa2) | Ratio |
 |--------|-----------|-----------|-------|
-| ClinVar (4.44M records) | 48.1 MB | 38.9 MB | 0.81× |
+| ClinVar (4.44M records) | 48.1 MB | 39.0 MB | 0.81× |
 | REVEL (chr1, 8.25M records) | 40.5 MB | 19.0 MB | 0.47× |
+| REVEL (chr22, 1.78M records) | 8.7 MB | 3.8 MB | 0.44× |
+| SpliceAI (chr22, 828K records) | 4.8 MB | 2.7 MB | 0.56× |
+| gnomAD (chr22, 852K records) | 15.4 MB | 12.9 MB | 0.84× |
+| PhyloP (chr22, 852K records) | 3.1 MB | 1.4 MB | 0.45× |
+
+Annotating 308,740 real chr22 variants against all five chr22/ClinVar databases at once (8.3M records total): **12.7 s from the `.osa` set, 8.5 s from the `.osa2` set — 1.50×**, md5-identical output. Every record of all five databases was queried through both readers and compared byte for byte (8,318,903 keys, zero differences).
 
 ## Citation
 

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -30,7 +30,6 @@ use rayon::prelude::*;
 use std::fs::File;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
 
 /// Pre-loaded annotation context shared by web and CLI.
 ///
@@ -43,9 +42,15 @@ pub struct AnnotationContext {
     pub gff3_source: Option<String>,
     pub distance: u64,
     pub hgvs: bool,
-    /// Supplementary annotation providers (ClinVar, gnomAD, etc.)
-    /// Wrapped in Mutex because SA readers use internal caches that need &mut.
-    pub sa_providers: Vec<Mutex<Box<dyn AnnotationProvider>>>,
+    /// Supplementary annotation providers (ClinVar, gnomAD, etc.).
+    ///
+    /// Held unwrapped: every `AnnotationProvider` method takes `&self` and the
+    /// trait requires `Send + Sync`, so concurrent lookups need no external
+    /// lock — the readers own the synchronization for their internal caches.
+    /// These used to be `Mutex<Box<dyn AnnotationProvider>>`, which serialized
+    /// every lookup of every provider across concurrent `/annotate` requests
+    /// (and which the CLI pipeline worked around by immediately unwrapping).
+    pub sa_providers: Vec<Box<dyn AnnotationProvider>>,
     /// Gene-level annotation providers (OMIM, gnomAD gene constraints, ClinVar protein index).
     pub gene_providers: Vec<fastvep_sa::gene::GeneIndex>,
     /// ACMG-AMP classification configuration (None = disabled).
@@ -203,10 +208,7 @@ impl AnnotationContext {
     pub fn sa_source_names(&self) -> Vec<String> {
         self.sa_providers
             .iter()
-            .filter_map(|m| {
-                let guard = m.lock().ok()?;
-                Some(guard.name().to_string())
-            })
+            .map(|p| p.name().to_string())
             .collect()
     }
 
@@ -306,6 +308,17 @@ impl AnnotationContext {
             .unwrap_or_default();
 
         let mut variants = vcf_parser.read_all()?;
+
+        // gnomAD stores left-aligned, parsimonious alleles, so its queries are
+        // normalized against the reference (see the SA block below). Whether that
+        // applies depends only on the loaded context, not on the variant, so it
+        // is resolved once here instead of re-scanning every provider for every
+        // variant.
+        let has_gnomad = self.seq_provider.is_some()
+            && self
+                .sa_providers
+                .iter()
+                .any(|sa| sa.json_key() == "gnomad");
 
         for vf in &mut variants {
             let chrom = &vf.position.chromosome;
@@ -645,17 +658,11 @@ impl AnnotationContext {
             if !self.sa_providers.is_empty() {
                 let chrom = &vf.position.chromosome;
                 let ref_str = vf.ref_allele.to_string();
-                // gnomAD stores left-aligned, parsimonious alleles; normalize the
-                // query to its minimal representation so indels (especially in
-                // repeats) match instead of silently missing — which otherwise
-                // makes PM2 misfire on common variants. Only when a reference and
-                // a gnomAD provider are present; applied only to the gnomAD lookup
-                // (every other source keeps the existing query unchanged).
-                let has_gnomad = self.seq_provider.is_some()
-                    && self
-                        .sa_providers
-                        .iter()
-                        .any(|sa| sa.lock().unwrap().json_key() == "gnomad");
+                // Normalize the gnomAD query to its minimal representation so
+                // indels (especially in repeats) match instead of silently
+                // missing — which otherwise makes PM2 misfire on common
+                // variants. Applied only to the gnomAD lookup; every other
+                // source keeps the query unchanged.
                 let mut allele_results: std::collections::HashMap<
                     String,
                     Vec<(String, String)>,
@@ -681,8 +688,7 @@ impl AnnotationContext {
                         };
                         let mut results: Vec<(String, String)> = Vec::new();
                         for sa in &self.sa_providers {
-                            let sa_guard = sa.lock().unwrap();
-                            let (q_pos, q_ref, q_alt) = if sa_guard.json_key() == "gnomad" {
+                            let (q_pos, q_ref, q_alt) = if sa.json_key() == "gnomad" {
                                 match &gnomad_norm {
                                     Some(n) => {
                                         (n.pos, n.ref_allele.as_str(), n.alt_allele.as_str())
@@ -693,7 +699,7 @@ impl AnnotationContext {
                                 (vf.position.start, ref_str.as_str(), alt_str.as_str())
                             };
                             if let Ok(Some(ann)) =
-                                sa_guard.annotate_position(chrom, q_pos, q_ref, q_alt)
+                                sa.annotate_position(chrom, q_pos, q_ref, q_alt)
                             {
                                 let json_str = match ann {
                                     AnnotationValue::Json(j) => j,
@@ -702,7 +708,7 @@ impl AnnotationContext {
                                         format!("[{}]", v.join(","))
                                     }
                                 };
-                                results.push((sa_guard.json_key().to_string(), json_str));
+                                results.push((sa.json_key().to_string(), json_str));
                             }
                         }
                         allele_results.insert(alt_str, results);
@@ -1234,7 +1240,7 @@ fn enrich_compound_het(
 /// the file names rather than on directory iteration order.
 pub fn load_sa_providers(
     sa_dir: &Path,
-) -> Result<Vec<Mutex<Box<dyn AnnotationProvider>>>> {
+) -> Result<Vec<Box<dyn AnnotationProvider>>> {
     use fastvep_sa::interval::OsiReader;
     use fastvep_sa::reader::SaReader;
     use fastvep_sa::reader_v2::Osa2Reader;
@@ -1252,7 +1258,7 @@ pub fn load_sa_providers(
 
     // A source that fails to open is skipped with a warning, as before; only
     // the directory walk itself is fatal.
-    let providers: Vec<Mutex<Box<dyn AnnotationProvider>>> = paths
+    let providers: Vec<Box<dyn AnnotationProvider>> = paths
         .par_iter()
         .filter_map(|path| {
             let ext = path.extension().and_then(|e| e.to_str());
@@ -1269,7 +1275,7 @@ pub fn load_sa_providers(
             match opened {
                 Ok((kind, provider)) => {
                     tracing::info!("Loaded {}: {} ({})", kind, provider.name(), path.display());
-                    Some(Mutex::new(provider))
+                    Some(provider)
                 }
                 Err(e) => {
                     tracing::warn!("Could not load {}: {}", path.display(), e);

--- a/crates/fastvep-annotate/tests/sa_provider_loading.rs
+++ b/crates/fastvep-annotate/tests/sa_provider_loading.rs
@@ -68,7 +68,7 @@ fn providers_are_ordered_by_path() {
     let providers = load_sa_providers(dir.path()).unwrap();
     let keys: Vec<String> = providers
         .iter()
-        .map(|p| p.lock().unwrap().json_key().to_string())
+        .map(|p| p.json_key().to_string())
         .collect();
 
     // Sorted by file name, which is lexicographic - chr1 < chr2 < chr21 < chr9.
@@ -89,7 +89,7 @@ fn an_unopenable_source_is_skipped_not_fatal() {
     let providers = load_sa_providers(dir.path()).unwrap();
     let keys: Vec<String> = providers
         .iter()
-        .map(|p| p.lock().unwrap().json_key().to_string())
+        .map(|p| p.json_key().to_string())
         .collect();
     assert_eq!(keys, vec!["good_a", "good_c"]);
 }

--- a/crates/fastvep-annotate/tests/sa_providers_are_concurrent.rs
+++ b/crates/fastvep-annotate/tests/sa_providers_are_concurrent.rs
@@ -1,0 +1,123 @@
+//! `AnnotationContext::sa_providers` must allow genuinely concurrent lookups.
+//!
+//! The providers used to be stored as `Vec<Mutex<Box<dyn AnnotationProvider>>>`
+//! and the library/web annotate path locked each one per allele per variant, so
+//! concurrent `/annotate` requests serialized on every source in turn - even
+//! though every `AnnotationProvider` method takes `&self` and the trait requires
+//! `Send + Sync`. (The CLI pipeline sidestepped it by unwrapping the mutexes
+//! immediately after loading, which is the tell that they were never needed.)
+//!
+//! This is proved without timing: the provider below blocks inside
+//! `annotate_position` until every worker has entered it. Under an external
+//! per-provider mutex the first worker in would wait for peers that cannot
+//! acquire the lock, so the rendezvous could never complete.
+
+use anyhow::Result;
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, SaMetadata};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const WORKERS: usize = 8;
+
+/// How long a worker waits for its peers before giving up. Only reached when the
+/// providers serialize, in which case the whole test costs `WORKERS` × this and
+/// then fails.
+const RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Default)]
+struct Counters {
+    /// Monotonic: how many callers have ever entered. Drives the rendezvous, so
+    /// a worker that has already been released cannot un-release its peers.
+    arrived: AtomicUsize,
+    /// Up on entry, down on exit: current occupancy.
+    inside: AtomicUsize,
+    /// High-water mark of `inside` - the actual measure of simultaneity.
+    peak_inside: AtomicUsize,
+}
+
+/// Counts how many callers are inside `annotate_position` at once and refuses to
+/// return until all of them are, or the deadline passes.
+struct RendezvousProvider {
+    metadata: SaMetadata,
+    counters: Arc<Counters>,
+}
+
+impl RendezvousProvider {
+    fn new(counters: Arc<Counters>) -> Self {
+        Self {
+            metadata: SaMetadata {
+                name: "Rendezvous".into(),
+                version: "1".into(),
+                description: "test".into(),
+                assembly: "GRCh38".into(),
+                json_key: "rendezvous".into(),
+                match_by_allele: true,
+                is_array: false,
+                is_positional: false,
+            },
+            counters,
+        }
+    }
+}
+
+impl AnnotationProvider for RendezvousProvider {
+    fn name(&self) -> &str {
+        &self.metadata.name
+    }
+    fn json_key(&self) -> &str {
+        &self.metadata.json_key
+    }
+    fn metadata(&self) -> &SaMetadata {
+        &self.metadata
+    }
+
+    fn annotate_position(
+        &self,
+        _chrom: &str,
+        _pos: u64,
+        _ref_allele: &str,
+        _alt_allele: &str,
+    ) -> Result<Option<AnnotationValue>> {
+        self.counters.arrived.fetch_add(1, Ordering::SeqCst);
+        let now = self.counters.inside.fetch_add(1, Ordering::SeqCst) + 1;
+        self.counters.peak_inside.fetch_max(now, Ordering::SeqCst);
+
+        // Bounded rendezvous: wait for everyone, but give up after
+        // `RENDEZVOUS_TIMEOUT` so a regression fails the assertion below instead
+        // of hanging the suite. `inside` is decremented on the way out, so
+        // `peak_inside` measures true simultaneity - serialized callers each see
+        // a count of 1 no matter how many of them eventually run.
+        let deadline = Instant::now() + RENDEZVOUS_TIMEOUT;
+        while self.counters.arrived.load(Ordering::SeqCst) < WORKERS && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        self.counters.inside.fetch_sub(1, Ordering::SeqCst);
+        Ok(None)
+    }
+}
+
+#[test]
+fn all_providers_can_be_queried_at_once() {
+    let counters = Arc::new(Counters::default());
+    // Exactly the storage shape `AnnotationContext::sa_providers` uses.
+    let providers: Vec<Box<dyn AnnotationProvider>> =
+        vec![Box::new(RendezvousProvider::new(Arc::clone(&counters)))];
+
+    std::thread::scope(|scope| {
+        for _ in 0..WORKERS {
+            scope.spawn(|| {
+                for sa in &providers {
+                    sa.annotate_position("chr1", 100, "A", "G").unwrap();
+                }
+            });
+        }
+    });
+
+    let peak = counters.peak_inside.load(Ordering::SeqCst);
+    assert_eq!(
+        peak, WORKERS,
+        "expected all {WORKERS} workers inside annotate_position simultaneously, \
+         peaked at {peak}; providers are being serialized"
+    );
+}

--- a/crates/fastvep-cache/src/annotation.rs
+++ b/crates/fastvep-cache/src/annotation.rs
@@ -74,28 +74,22 @@ pub trait AnnotationProvider: Send + Sync {
 
     /// Pre-load data for a batch of positions on a chromosome.
     ///
-    /// Called before the parallel annotation phase to decompress and cache
-    /// relevant blocks. The default implementation is a no-op.
-    fn preload(&self, _chrom: &str, _positions: &[u64]) -> Result<()> {
-        Ok(())
-    }
-
-    /// Annotate a batch of variants on the same chromosome in a single call.
+    /// Called once per (provider, chromosome) before the parallel annotation
+    /// phase so the blocks/chunks the batch will touch are decompressed into the
+    /// shared cache up front, on one thread, instead of being raced for by the
+    /// workers. The default implementation is a no-op; the `.osa` and `.osa2`
+    /// readers both override it.
     ///
-    /// Default implementation calls `annotate_position()` in a loop.
-    /// High-performance readers (e.g., Osa2Reader) can override this to
-    /// load chunks once and serve multiple queries.
-    fn annotate_batch(
-        &self,
-        chrom: &str,
-        variants: &[(u64, &str, &str)], // (pos, ref_allele, alt_allele)
-        results: &mut Vec<Option<AnnotationValue>>,
-    ) -> Result<()> {
-        results.clear();
-        results.reserve(variants.len());
-        for &(pos, ref_a, alt_a) in variants {
-            results.push(self.annotate_position(chrom, pos, ref_a, alt_a)?);
-        }
+    /// This is the only bulk entry point. There is deliberately no
+    /// `annotate_batch`: the annotate pipeline cannot form a per-chromosome
+    /// batch of *lookups* because the allele set for a variant is only known
+    /// after consequence prediction, and gnomAD's queries are normalized
+    /// per variant against the reference. A batch method existed here for a
+    /// while as an unused default-implemented stub whose doc claimed the v2
+    /// reader overrode it to "load chunks once and serve multiple queries" -
+    /// nothing called it and nothing overrode it. `preload` is what actually
+    /// delivers the load-once behaviour.
+    fn preload(&self, _chrom: &str, _positions: &[u64]) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -227,6 +227,22 @@ enum Commands {
         no_progress: bool,
     },
 
+    /// Convert an existing v1 `.osa` supplementary annotation database to v2 `.osa2`
+    SaConvert {
+        /// Input v1 `.osa` file (its `.osa.idx` must sit alongside it)
+        #[arg(short, long)]
+        input: String,
+
+        /// Output base path (`.osa2` is appended). Defaults to the input path
+        /// with its extension replaced, i.e. `foo.osa` -> `foo.osa2`.
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Suppress periodic progress output
+        #[arg(long, default_value_t = false)]
+        no_progress: bool,
+    },
+
     /// Filter annotated VEP output
     Filter {
         /// Input file (VEP-annotated VCF)
@@ -325,6 +341,21 @@ fn main() -> Result<()> {
                 &info_fields,
                 !no_progress,
             )?
+        }
+        Commands::SaConvert {
+            input,
+            output,
+            no_progress,
+        } => {
+            // Default the output alongside the input: `foo.osa` -> `foo.osa2`.
+            // `run_sa_convert` appends the extension, so hand it the stem.
+            let output = output.unwrap_or_else(|| {
+                std::path::Path::new(&input)
+                    .with_extension("")
+                    .to_string_lossy()
+                    .into_owned()
+            });
+            pipeline::run_sa_convert(&input, &output, !no_progress)?
         }
         Commands::Filter {
             input,

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -316,19 +316,15 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
         None
     };
 
-    // Load supplementary annotation providers from --sa-dir
-    // Shared load_sa_providers returns Mutex-wrapped providers; unwrap for batch pipeline
-    // (batch pipeline processes variants sequentially per chunk, no concurrent access).
+    // Load supplementary annotation providers from --sa-dir.
+    //
     // Reported on stderr like the other startup steps: this is the one that
     // scales with the number of files in --sa-dir, so a slow shared filesystem
     // shows up here rather than as a silent stall before the progress meter
     // (issue #78). `tracing` has no subscriber installed in the CLI.
     let sa_providers: Vec<Box<dyn AnnotationProvider>> = if let Some(ref dir) = config.sa_dir {
         let t0 = std::time::Instant::now();
-        let loaded: Vec<Box<dyn AnnotationProvider>> = load_sa_providers(Path::new(dir))?
-            .into_iter()
-            .map(|m| m.into_inner().unwrap())
-            .collect();
+        let loaded = load_sa_providers(Path::new(dir))?;
         eprintln!(
             "Loaded {} supplementary annotation source(s) from {} in {:.1}s",
             loaded.len(),
@@ -492,6 +488,12 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
         .iter()
         .map(|sa| sa.json_key().to_string())
         .collect();
+    // Whether gnomAD queries get reference-normalized (see the SA attach loop
+    // below) depends only on which providers loaded and whether a FASTA is
+    // present — never on the variant. Resolved once here rather than re-scanning
+    // every provider for every allele of every variant inside the parallel loop.
+    let normalize_gnomad_queries =
+        seq_provider.is_some() && sa_providers.iter().any(|sa| sa.json_key() == "gnomad");
     let gene_json_keys: Vec<String> = gene_providers
         .iter()
         .map(|gp| gp.json_key().to_string())
@@ -1233,9 +1235,7 @@ pub fn run_annotate(config: AnnotateConfig) -> Result<()> {
                         // gnomAD's minimal representation — only when a gnomAD
                         // provider and a reference are present, and applied only
                         // to the gnomAD lookup (other sources keep the raw key).
-                        let gnomad_norm = if seq_provider.is_some()
-                            && sa_providers.iter().any(|sa| sa.json_key() == "gnomad")
-                        {
+                        let gnomad_norm = if normalize_gnomad_queries {
                             seq_provider.as_ref().map(|sp| {
                                 fastvep_cache::normalize::normalize_variant(
                                     &**sp,
@@ -2666,9 +2666,17 @@ pub fn run_sa_build(
 /// message — adding a source to v2 means adding it here plus a match arm in
 /// [`run_sa_build_v2`]. Includes the `1000g` alias of `onekg`.
 ///
-/// Gene-level (`.oga`) and `custom_*` sources are absent because v2 is a
-/// variant-level container. Positional per-base scores (PhyloP/GERP/DANN) ARE
-/// supported — keyed by coordinate via `var32::positional_key`.
+/// This is every variant-level source, so `--format auto` builds v2 for all of
+/// them and the v1 `.osa` writer is reachable only via an explicit
+/// `--format osa`. Absent by nature, not by omission:
+///
+/// * gene-level sources (`omim`, `gnomad_genes`, `clinvar_protein`) are keyed by
+///   gene symbol and build `.oga`;
+/// * `custom_bed` is interval-keyed and builds `.osi`.
+///
+/// v2 is a variant-level container, so neither has a v2 form. Positional
+/// per-base scores (PhyloP/GERP/DANN) ARE supported — keyed by coordinate via
+/// `var32::positional_key`.
 pub const OSA2_SUPPORTED_SOURCES: &[&str] = &[
     "gnomad",
     "onekg",
@@ -2684,11 +2692,48 @@ pub const OSA2_SUPPORTED_SOURCES: &[&str] = &[
     "phylop",
     "gerp",
     "dann",
+    "spliceai",
+    "mitomap",
+    "custom_vcf",
 ];
+
+/// The subset of [`OSA2_SUPPORTED_SOURCES`] whose v2 encoder decomposes the
+/// payload into parallel u32 value columns (plus, for some, a categorical string
+/// table). The rest store one whole-record JSON blob per variant, because their
+/// payloads are high-cardinality ID strings or nested arrays that the numeric
+/// layout cannot represent — see [`fastvep_sa::writer_v2::raw_json_blob_fields`].
+///
+/// The distinction matters to `sa-convert`: a `.osa` retains no field schema, so
+/// a conversion can only ever produce the blob encoding. For a source in this
+/// list, rebuilding from upstream yields a materially smaller file and the tool
+/// says so; for the others, converting is equivalent to a rebuild.
+pub const OSA2_DECOMPOSED_SOURCES: &[&str] =
+    &["gnomad", "onekg", "1000g", "topmed", "alphamissense", "spliceai"];
 
 /// Whether `--format osa2` (and `--format auto`) can build this source to v2.
 pub fn source_supports_osa2(source: &str) -> bool {
     OSA2_SUPPORTED_SOURCES.contains(&source)
+}
+
+/// Whether this source's v2 encoder decomposes into numeric columns rather than
+/// storing whole-record JSON blobs. See [`OSA2_DECOMPOSED_SOURCES`].
+pub fn source_has_decomposed_osa2(source: &str) -> bool {
+    OSA2_DECOMPOSED_SOURCES.contains(&source)
+}
+
+/// Recover the `--source` name from a database's `json_key`.
+///
+/// Most sources use their own name as the key, but several camel-case it
+/// (`alphaMissense`, `oneKg`, `primateAI`, `spliceAI`), so the match is
+/// case-insensitive. Returns `None` for a key that is not a built-in source —
+/// notably a `custom_vcf` database, whose key is whatever the user passed to
+/// `--name`.
+pub fn source_from_json_key(json_key: &str) -> Option<&'static str> {
+    let lowered = json_key.to_ascii_lowercase();
+    OSA2_SUPPORTED_SOURCES
+        .iter()
+        .copied()
+        .find(|s| *s == lowered.as_str())
 }
 
 /// Dispatch `sa-build` to the v1 or v2 builder according to `--format`:
@@ -2712,10 +2757,12 @@ pub fn run_sa_build_format(
         "osa" | "v1" => {
             run_sa_build(source, input, output, assembly, name, info_fields, show_progress)
         }
-        "osa2" | "v2" => run_sa_build_v2(source, input, output, assembly, show_progress),
+        "osa2" | "v2" => {
+            run_sa_build_v2(source, input, output, assembly, name, info_fields, show_progress)
+        }
         "auto" => {
             if source_supports_osa2(source) {
-                run_sa_build_v2(source, input, output, assembly, show_progress)
+                run_sa_build_v2(source, input, output, assembly, name, info_fields, show_progress)
             } else {
                 run_sa_build(source, input, output, assembly, name, info_fields, show_progress)
             }
@@ -2742,11 +2789,13 @@ pub fn run_sa_build_v2(
     input: &str,
     output: &str,
     assembly: &str,
+    name: Option<&str>,
+    info_fields: &[String],
     show_progress: bool,
 ) -> Result<()> {
     use fastvep_sa::sources::{
-        alphamissense, clinvar, cosmic, dbnsfp, dbsnp, gnomad, onekg, primateai, revel, scores,
-        topmed,
+        alphamissense, clinvar, cosmic, dbnsfp, dbsnp, gnomad, mitomap, onekg, primateai, revel,
+        scores, spliceai, topmed,
     };
 
     let (chrom_list, chrom_map) = standard_chrom_map(assembly);
@@ -2830,6 +2879,87 @@ pub fn run_sa_build_v2(
                 &alphamissense::alphamissense_osa2_metadata(assembly),
                 alphamissense::alphamissense_osa2_fields(),
                 &alphamissense::alphamissense_string_tables(),
+                records,
+                meter,
+                input,
+                assembly,
+            )
+        }
+        // SpliceAI: eight numeric columns (four delta scores, four delta
+        // positions) plus a categorical gene symbol. The densest source fastVEP
+        // ships against, so the column layout matters most here; the gene
+        // vocabulary is only known once the input has streamed past, hence the
+        // deferred string table.
+        "spliceai" => {
+            eprintln!("Building spliceai .osa2: {} -> {}", input, out_path.display());
+            let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
+            let genes = spliceai::GeneInterner::new();
+            let records =
+                spliceai::iter_spliceai_osa2(buf_reader, &chrom_map, &chrom_list, genes.clone());
+            finish_osa2_build_deferred(
+                &out_path,
+                &spliceai::spliceai_osa2_metadata(assembly),
+                spliceai::spliceai_osa2_fields(),
+                records,
+                meter,
+                input,
+                assembly,
+                move || genes.string_tables(),
+            )
+        }
+        // MitoMap: whole-record JSON blob (free-text disease + review status).
+        // A few thousand records; wired to v2 for format uniformity rather than
+        // speed. See `mitomap_osa2_metadata`.
+        "mitomap" => {
+            eprintln!("Building mitomap .osa2: {} -> {}", input, out_path.display());
+            let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
+            let v1 = mitomap::parse_mitomap(buf_reader, &chrom_map)?;
+            let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
+            finish_osa2_build(
+                &out_path,
+                &mitomap::mitomap_osa2_metadata(assembly),
+                fastvep_sa::writer_v2::raw_json_blob_fields(),
+                &[],
+                records,
+                meter,
+                input,
+                assembly,
+            )
+        }
+        // Custom user VCF: whole-record JSON blob, since the INFO schema is
+        // whatever the file carries. Keyed by the user's `--name`.
+        "custom_vcf" => {
+            let resolved_name = resolve_custom_name(name, input);
+            eprintln!(
+                "Building custom_vcf .osa2: {} -> {} (name={}, info_fields={})",
+                input,
+                out_path.display(),
+                resolved_name,
+                if info_fields.is_empty() {
+                    "<all>".to_string()
+                } else {
+                    info_fields.join(",")
+                }
+            );
+            let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
+            let mut v1 = fastvep_sa::custom::parse_custom_vcf(
+                buf_reader,
+                &chrom_map,
+                &resolved_name,
+                info_fields,
+            )?;
+            // `parse_custom_vcf` already returns (chrom_idx, position) order, but
+            // the v2 streaming writer *hard-fails* on a reopened chunk rather
+            // than degrading, so re-establish the ordering at the boundary
+            // instead of depending on a cross-crate invariant. A no-op on
+            // already-sorted input; same belt-and-braces as the onekg arm above.
+            v1.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+            let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
+            finish_osa2_build(
+                &out_path,
+                &fastvep_sa::custom::custom_vcf_osa2_metadata(&resolved_name, assembly),
+                fastvep_sa::writer_v2::raw_json_blob_fields(),
+                &[],
                 records,
                 meter,
                 input,
@@ -3068,11 +3198,46 @@ fn finish_osa2_build(
     fields: Vec<fastvep_sa::fields::Field>,
     string_tables: &[(usize, Vec<String>)],
     records: impl Iterator<Item = Result<fastvep_sa::writer_v2::Osa2Record>>,
-    mut meter: crate::progress::ProgressMeter,
+    meter: crate::progress::ProgressMeter,
     input: &str,
     assembly: &str,
 ) -> Result<()> {
-    let n = match write_osa2_stream(out_path, metadata, fields, string_tables, records, &mut meter) {
+    let tables = string_tables.to_vec();
+    finish_osa2_build_deferred(
+        out_path,
+        metadata,
+        fields,
+        records,
+        meter,
+        input,
+        assembly,
+        move || tables,
+    )
+}
+
+/// As [`finish_osa2_build`], but the categorical string tables are produced by
+/// `string_tables` *after* every record has streamed past.
+///
+/// Needed by sources whose categorical vocabulary is only discovered while
+/// reading (SpliceAI's gene symbols), as opposed to a fixed table known up front
+/// (AlphaMissense's three classes). The `.osa2` string table is global to the
+/// archive and written during `finish`, so collecting it during the stream and
+/// handing it over at the end is exactly the ordering the format wants.
+#[allow(clippy::too_many_arguments)]
+fn finish_osa2_build_deferred<F>(
+    out_path: &Path,
+    metadata: &fastvep_sa::writer_v2::Osa2Metadata,
+    fields: Vec<fastvep_sa::fields::Field>,
+    records: impl Iterator<Item = Result<fastvep_sa::writer_v2::Osa2Record>>,
+    mut meter: crate::progress::ProgressMeter,
+    input: &str,
+    assembly: &str,
+    string_tables: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Vec<(usize, Vec<String>)>,
+{
+    let n = match write_osa2_stream(out_path, metadata, fields, records, &mut meter, string_tables) {
         Ok(n) => n,
         Err(e) => {
             let _ = std::fs::remove_file(out_path);
@@ -3097,22 +3262,22 @@ fn finish_osa2_build(
 
 /// Core streaming loop: create the `.osa2` writer, push every record, finish.
 /// Returns the number of records written.
-fn write_osa2_stream(
+fn write_osa2_stream<F>(
     out_path: &Path,
     metadata: &fastvep_sa::writer_v2::Osa2Metadata,
     fields: Vec<fastvep_sa::fields::Field>,
-    string_tables: &[(usize, Vec<String>)],
     records: impl Iterator<Item = Result<fastvep_sa::writer_v2::Osa2Record>>,
     meter: &mut crate::progress::ProgressMeter,
-) -> Result<u64> {
+    string_tables: F,
+) -> Result<u64>
+where
+    F: FnOnce() -> Vec<(usize, Vec<String>)>,
+{
     use fastvep_sa::writer_v2::Osa2StreamWriter;
 
     let out_file = std::fs::File::create(out_path)
         .with_context(|| format!("Creating {}", out_path.display()))?;
     let mut writer = Osa2StreamWriter::new(BufWriter::new(out_file), metadata, fields)?;
-    for (field_idx, table) in string_tables {
-        writer.set_string_table(*field_idx, table.clone());
-    }
 
     let mut n = 0u64;
     for record in records {
@@ -3121,8 +3286,166 @@ fn write_osa2_stream(
         writer.push(record)?;
         n += 1;
     }
+    // Resolved after the stream so a source that interns its categorical
+    // vocabulary while reading hands over the completed table. `finish` writes
+    // the tables into the archive, so this still lands before finalization.
+    for (field_idx, table) in string_tables() {
+        writer.set_string_table(field_idx, table);
+    }
     writer.finish()?;
     Ok(n)
+}
+
+/// Transcode an existing v1 `.osa` database into a v2 `.osa2`, in place of
+/// re-downloading and re-parsing the upstream source.
+///
+/// Every variant-level source now builds v2 by default, but a `--sa-dir`
+/// assembled before that change is full of `.osa` files whose upstream releases
+/// may be large (dbSNP, SpliceAI), slow to fetch, or no longer available at the
+/// exact version that was built. Rebuilding from source is not always an option,
+/// so this reads the `.osa` and writes the equivalent `.osa2`.
+///
+/// **What is preserved:** the record set and every record's JSON payload, byte
+/// for byte, plus the database's identity and matching semantics (`json_key`,
+/// `name`, `version`, `description`, `assembly`, `match_by_allele`, `is_array`,
+/// `is_positional`). Queries against the converted file return exactly what the
+/// `.osa` returned.
+///
+/// **What is not:** the records are stored as whole-record JSON blobs, because
+/// that is all a `.osa` retains — it has no field schema to recover a numeric
+/// column layout from. A conversion therefore gets v2's chunked index, its
+/// mmap-and-inflate read path, and its chunk-level zstd, but *not* the parallel
+/// u32 columns that [`OSA2_DECOMPOSED_SOURCES`] build natively. Which encoding
+/// ends up smaller is data-dependent (blob columns zstd well when adjacent
+/// records are similar; value columns win when the payload is genuinely
+/// numeric), so the tool points at the rebuild without promising a size win.
+pub fn run_sa_convert(input: &str, output: &str, show_progress: bool) -> Result<()> {
+    use fastvep_sa::reader::SaReader;
+    use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record};
+
+    let in_path = Path::new(input);
+    match in_path.extension().and_then(|e| e.to_str()) {
+        Some("osa") => {}
+        Some("osa2") => anyhow::bail!(
+            "{} is already a v2 .osa2 database; nothing to convert.",
+            input
+        ),
+        Some(other @ ("osi" | "oga")) => anyhow::bail!(
+            "sa-convert only converts variant-level .osa databases. '{}' is a .{} file \
+             ({}), and v2 is a variant-level container with no equivalent form — keep \
+             using it as-is.",
+            input,
+            other,
+            if other == "osi" { "interval-level" } else { "gene-level" }
+        ),
+        _ => anyhow::bail!(
+            "sa-convert expects a v1 '.osa' input; got '{}'.",
+            input
+        ),
+    }
+
+    let out_path = Path::new(output).with_extension("osa2");
+    if out_path == in_path {
+        anyhow::bail!("--output would overwrite the input ({})", in_path.display());
+    }
+
+    let reader = SaReader::open(in_path)
+        .with_context(|| format!("Opening v1 database {}", in_path.display()))?;
+    let header = reader.header().clone();
+
+    eprintln!(
+        "Converting {} -> {} (source={}, key={})",
+        in_path.display(),
+        out_path.display(),
+        header.name,
+        header.json_key
+    );
+    match source_from_json_key(&header.json_key) {
+        Some(src) if source_has_decomposed_osa2(src) => eprintln!(
+            "note: '{src}' has a column-oriented v2 encoder. This conversion preserves every \
+             payload exactly, but can only store them as JSON blobs — a .osa retains no field \
+             schema to rebuild the columns from. If you still have the upstream release, \
+             `sa-build --source {src} --format osa2` gives you the column encoding instead; \
+             which of the two is smaller depends on the data, so compare if size matters."
+        ),
+        Some(src) => eprintln!(
+            "note: '{src}' stores whole-record JSON blobs in v2 as well, so this conversion is \
+             equivalent to rebuilding from the upstream release."
+        ),
+        None => {}
+    }
+
+    let metadata = Osa2Metadata {
+        format_version: 2,
+        name: header.name.clone(),
+        version: header.version.clone(),
+        assembly: header.assembly.clone(),
+        json_key: header.json_key.clone(),
+        match_by_allele: header.match_by_allele,
+        is_array: header.is_array,
+        is_positional: header.is_positional,
+        chunk_bits: 20,
+        description: header.description.clone(),
+    };
+
+    // The `.osa` is the progress denominator: `iter_records` walks it once, so
+    // bytes-of-input is a faithful measure of how far along the conversion is.
+    let total = std::fs::metadata(in_path).map(|m| m.len()).unwrap_or(0);
+    let mut meter = if show_progress && total > 0 {
+        crate::progress::ProgressMeter::new(true)
+    } else {
+        crate::progress::ProgressMeter::new(false)
+    };
+
+    let records = reader.iter_records().map(|r| {
+        let (chrom, entry) = r?;
+        Ok(Osa2Record {
+            chrom: chrom.to_string(),
+            position: entry.position,
+            ref_allele: entry.ref_allele.into_bytes(),
+            alt_allele: entry.alt_allele.into_bytes(),
+            values: Vec::new(),
+            json_blob: Some(entry.json),
+        })
+    });
+
+    // Same crash-safety contract as the builders: a partial `.osa2` is removed
+    // so a failed conversion never leaves a corrupt database behind.
+    let n = match write_osa2_stream(
+        &out_path,
+        &metadata,
+        fastvep_sa::writer_v2::raw_json_blob_fields(),
+        records,
+        &mut meter,
+        Vec::new,
+    ) {
+        Ok(n) => n,
+        Err(e) => {
+            let _ = std::fs::remove_file(&out_path);
+            return Err(e);
+        }
+    };
+    meter.finish();
+
+    if n == 0 {
+        eprintln!(
+            "warning: {} contained 0 records; wrote an empty .osa2.",
+            in_path.display()
+        );
+    }
+    let in_bytes = std::fs::metadata(in_path).map(|m| m.len()).unwrap_or(0)
+        + std::fs::metadata(in_path.with_extension("osa.idx"))
+            .map(|m| m.len())
+            .unwrap_or(0);
+    let out_bytes = std::fs::metadata(&out_path).map(|m| m.len()).unwrap_or(0);
+    eprintln!(
+        "Wrote: {} ({} records, {} -> {})",
+        out_path.display(),
+        crate::progress::fmt_count(n),
+        crate::progress::fmt_bytes(in_bytes),
+        crate::progress::fmt_bytes(out_bytes)
+    );
+    Ok(())
 }
 
 /// Classify a `--source custom` input as either `custom_vcf` or

--- a/crates/fastvep-cli/src/progress.rs
+++ b/crates/fastvep-cli/src/progress.rs
@@ -139,6 +139,24 @@ impl ProgressMeter {
     }
 }
 
+/// Human-readable byte count with a binary-prefix unit (`1.5 GiB`). For
+/// reporting file sizes in build/convert summaries, where an exact byte count is
+/// noise.
+pub fn fmt_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[0])
+    } else {
+        format!("{:.1} {}", value, UNITS[unit])
+    }
+}
+
 pub fn fmt_count(n: u64) -> String {
     let s = n.to_string();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
@@ -154,6 +172,21 @@ pub fn fmt_count(n: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fmt_bytes_scales_and_stops_at_tib() {
+        assert_eq!(fmt_bytes(0), "0 B");
+        assert_eq!(fmt_bytes(512), "512 B");
+        assert_eq!(fmt_bytes(1024), "1.0 KiB");
+        assert_eq!(fmt_bytes(1536), "1.5 KiB");
+        assert_eq!(fmt_bytes(5 * 1024 * 1024), "5.0 MiB");
+        assert_eq!(fmt_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
+        assert_eq!(fmt_bytes(2 * 1024_u64.pow(4)), "2.0 TiB");
+        // TiB is the largest unit, so beyond it the number keeps growing rather
+        // than a unit being invented.
+        assert_eq!(fmt_bytes(2048 * 1024_u64.pow(4)), "2048.0 TiB");
+        assert_eq!(fmt_bytes(u64::MAX), "16777216.0 TiB");
+    }
 
     #[test]
     fn fmt_count_commas() {

--- a/crates/fastvep-cli/tests/sa_build_osa2.rs
+++ b/crates/fastvep-cli/tests/sa_build_osa2.rs
@@ -56,6 +56,8 @@ fn gnomad_osa2_build_round_trips() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -158,6 +160,8 @@ fn assert_v1_v2_parity(source: &str, vcf: &str, sites: &[(&str, u64, &str, &str)
         input.to_str().unwrap(),
         v2_base.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -251,6 +255,8 @@ fn alphamissense_osa2_round_trips_score_and_class() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -326,6 +332,8 @@ fn dbsnp_osa2_stores_id_and_maf() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -384,6 +392,8 @@ fn cosmic_osa2_stores_id_gene_count() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -440,6 +450,8 @@ fn clinvar_osa2_preserves_arrays_and_is_array_flag() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -502,6 +514,8 @@ fn revel_osa2_stores_score() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -548,6 +562,8 @@ fn primateai_osa2_stores_score() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -592,6 +608,8 @@ fn dbnsfp_osa2_stores_predictions() {
         input.to_str().unwrap(),
         output.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -640,6 +658,8 @@ fn assert_v1_v2_positional_parity(source: &str, data: &str, sites: &[(&str, u64,
         input.to_str().unwrap(),
         v2_base.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -708,6 +728,8 @@ fn positional_lookup_ignores_alleles() {
         input.to_str().unwrap(),
         out.to_str().unwrap(),
         "GRCh38",
+        None,
+        &[],
         false,
     )
     .unwrap();
@@ -732,31 +754,37 @@ fn osa2_rejects_unsupported_source() {
     fs::write(&input, GNOMAD_VCF).unwrap();
     let output = dir.path().join("out");
 
-    // mitomap has no v2 encoder — forcing --format osa2 must error, not
-    // silently build v1.
-    let err = run_sa_build_v2(
-        "mitomap",
-        input.to_str().unwrap(),
-        output.to_str().unwrap(),
-        "GRCh38",
-        false,
-    )
-    .unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("currently supported for --source gnomad"),
-        "expected source-gating error, got: {err}"
-    );
-    assert!(
-        !output.with_extension("osa2").exists(),
-        "no file on rejected build"
-    );
+    // Gene-level (`.oga`) and interval (`.osi`) sources have no v2 form at all —
+    // v2 is a variant-level container. Forcing `--format osa2` on one must
+    // error, not silently build something else.
+    for source in ["omim", "gnomad_genes", "clinvar_protein", "custom_bed"] {
+        let err = run_sa_build_v2(
+            source,
+            input.to_str().unwrap(),
+            output.to_str().unwrap(),
+            "GRCh38",
+            None,
+            &[],
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("currently supported for --source gnomad"),
+            "expected source-gating error for {source}, got: {err}"
+        );
+        assert!(
+            !output.with_extension("osa2").exists(),
+            "no file on rejected build of {source}"
+        );
+    }
 }
 
 #[test]
 fn source_supports_osa2_membership() {
-    // Numeric, blob, and positional sources are v2-capable; gene-level,
-    // MitoMap, SpliceAI, and custom sources are not.
+    // Every variant-level source is v2-capable. The exceptions are structural:
+    // gene-keyed sources build `.oga` and interval-keyed `custom_bed` builds
+    // `.osi`, neither of which v2 (a variant-level container) can represent.
     for s in [
         "gnomad",
         "onekg",
@@ -772,68 +800,488 @@ fn source_supports_osa2_membership() {
         "phylop",
         "gerp",
         "dann",
+        "spliceai",
+        "mitomap",
+        "custom_vcf",
     ] {
         assert!(source_supports_osa2(s), "{s} should support osa2");
     }
-    for s in ["mitomap", "spliceai", "omim", "gnomad_genes", "custom_vcf"] {
+    for s in ["omim", "gnomad_genes", "clinvar_protein", "custom_bed"] {
         assert!(!source_supports_osa2(s), "{s} should NOT support osa2");
     }
 }
 
+// SpliceAI VCF: two-decimal delta scores, signed delta positions, a multi-gene
+// site (two entries for one ALT), a multi-ALT site, and a multi-base ref/alt row
+// to exercise the long-variant (kmer16) path alongside the categorical gene
+// column.
+const SPLICEAI_VCF: &str = "\
+##fileformat=VCFv4.2
+##INFO=<ID=SpliceAI,Number=.,Type=String,Description=\"SpliceAI\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t100\t.\tA\tG\t.\t.\tSpliceAI=G|BRCA1|0.01|0.00|0.85|0.00|5|-28|2|-13
+chr1\t100\t.\tA\tT\t.\t.\tSpliceAI=T|BRCA1|0.00|0.42|0.00|0.07|-3|11|0|4
+chr1\t300\t.\tC\tA\t.\t.\tSpliceAI=A|GENEX|0.55|0.00|0.00|0.00|1|0|0|0,A|GENEY|0.99|0.00|0.00|0.00|2|0|0|0
+chr2\t200\t.\tGATTACA\tG\t.\t.\tSpliceAI=G|TP53|0.00|0.73|0.00|0.00|0|-9|0|0
+";
+
 #[test]
-fn format_auto_picks_v2_for_supported_and_v1_for_others() {
+fn spliceai_v1_v2_output_parity() {
+    // Every field at every site must match between v1 .osa and v2 .osa2 —
+    // the eight numeric columns, the categorical gene, negative delta
+    // positions, and the long (indel-shaped) variant.
+    assert_v1_v2_parity(
+        "spliceai",
+        SPLICEAI_VCF,
+        &[
+            ("chr1", 100, "A", "G"),
+            ("chr1", 100, "A", "T"),
+            ("chr1", 300, "C", "A"), // multi-gene site
+            ("chr2", 200, "GATTACA", "G"), // long variant
+        ],
+    );
+}
+
+#[test]
+fn spliceai_osa2_round_trips_scores_positions_and_gene() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("spliceai.vcf");
+    let output = dir.path().join("spliceai"); // builder appends .osa2
+    fs::write(&input, SPLICEAI_VCF).unwrap();
+
+    run_sa_build_v2(
+        "spliceai",
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let osa2 = output.with_extension("osa2");
+    assert!(osa2.exists(), ".osa2 file should be created");
+    let reader = Osa2Reader::open(&osa2).unwrap();
+    assert_eq!(reader.json_key(), "spliceAI");
+    assert!(reader.metadata().match_by_allele);
+    assert!(!reader.metadata().is_positional);
+
+    let j = json_at(&reader, "chr1", 100, "A", "G").expect("chr1:100 A>G annotated");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["gene"], "BRCA1", "gene came back from the string table: {j}");
+    assert!((v["dsDg"].as_f64().unwrap() - 0.85).abs() < 1e-6, "{j}");
+    assert!((v["dsAg"].as_f64().unwrap() - 0.01).abs() < 1e-6, "{j}");
+    assert_eq!(v["dpAg"].as_i64(), Some(5), "{j}");
+    // Negative delta positions must survive zigzag encoding.
+    assert_eq!(v["dpAl"].as_i64(), Some(-28), "{j}");
+    assert_eq!(v["dpDl"].as_i64(), Some(-13), "{j}");
+
+    // A second allele at the same position resolves independently.
+    let j = json_at(&reader, "chr1", 100, "A", "T").expect("chr1:100 A>T annotated");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert!((v["dsAl"].as_f64().unwrap() - 0.42).abs() < 1e-6, "{j}");
+    assert_eq!(v["dpAg"].as_i64(), Some(-3), "{j}");
+
+    // Multi-gene site keeps the first entry, matching what v1's reader returns.
+    let j = json_at(&reader, "chr1", 300, "C", "A").expect("chr1:300 C>A annotated");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["gene"], "GENEX", "first gene of the pair wins: {j}");
+    assert!((v["dsAg"].as_f64().unwrap() - 0.55).abs() < 1e-6, "{j}");
+
+    // Long variant on another chromosome, with its own gene table entry.
+    let j = json_at(&reader, "chr2", 200, "GATTACA", "G").expect("chr2:200 indel annotated");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["gene"], "TP53", "{j}");
+    assert!((v["dsAl"].as_f64().unwrap() - 0.73).abs() < 1e-6, "{j}");
+    assert_eq!(v["dpAl"].as_i64(), Some(-9), "{j}");
+
+    // A variant that is not in the database misses.
+    assert!(json_at(&reader, "chr1", 100, "A", "C").is_none());
+}
+
+#[test]
+fn spliceai_json_from_both_formats_deserializes_for_the_acmg_classifier() {
+    // Routing SpliceAI's v1 JSON through `format_value` renders the delta
+    // scores in scientific notation (`8.500000e-1`). The ACMG classifier reads
+    // them via `SpliceAiData`, so pin the contract at the seam: both builders'
+    // output must deserialize to the same numbers the input carried.
+    use fastvep_classification::sa_extract::SpliceAiData;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.vcf");
+    fs::write(&input, SPLICEAI_VCF).unwrap();
+    let v1_base = dir.path().join("v1");
+    let v2_base = dir.path().join("v2");
+    run_sa_build(
+        "spliceai",
+        input.to_str().unwrap(),
+        v1_base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+    run_sa_build_v2(
+        "spliceai",
+        input.to_str().unwrap(),
+        v2_base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+    let v1 = SaReader::open(&v1_base.with_extension("osa")).unwrap();
+    let v2 = Osa2Reader::open(&v2_base.with_extension("osa2")).unwrap();
+
+    for reader in [&v1 as &dyn AnnotationProvider, &v2 as &dyn AnnotationProvider] {
+        let json = match reader.annotate_position("chr1", 100, "A", "G").unwrap() {
+            Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => j,
+            other => panic!("expected an annotation, got {other:?}"),
+        };
+        let data: SpliceAiData = serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("SpliceAiData must parse {json}: {e}"));
+        assert_eq!(data.gene.as_deref(), Some("BRCA1"), "{json}");
+        assert!((data.ds_dg.unwrap() - 0.85).abs() < 1e-6, "{json}");
+        assert!((data.ds_ag.unwrap() - 0.01).abs() < 1e-6, "{json}");
+        assert_eq!(data.dp_al, Some(-28), "{json}");
+        assert!((data.max_delta_score().unwrap() - 0.85).abs() < 1e-6, "{json}");
+    }
+}
+
+#[test]
+fn spliceai_osa2_is_much_smaller_than_osa() {
+    // The reason SpliceAI was worth converting: eight u32 columns plus a gene
+    // index beat a repeated ~120-byte JSON object per record. Build the same
+    // input both ways and require v2 to win on bytes.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("spliceai.vcf");
+
+    let mut vcf = String::from(
+        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n",
+    );
+    for i in 0..20_000u32 {
+        let pos = 1000 + i * 3;
+        let gene = format!("GENE{}", i % 200);
+        vcf.push_str(&format!(
+            "chr1\t{pos}\t.\tA\tG\t.\t.\tSpliceAI=G|{gene}|0.{:02}|0.00|0.{:02}|0.00|{}|-{}|2|-13\n",
+            i % 100,
+            (i / 7) % 100,
+            i % 50,
+            i % 40
+        ));
+    }
+    fs::write(&input, &vcf).unwrap();
+
+    let v1_base = dir.path().join("v1");
+    let v2_base = dir.path().join("v2");
+    run_sa_build(
+        "spliceai",
+        input.to_str().unwrap(),
+        v1_base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+    run_sa_build_v2(
+        "spliceai",
+        input.to_str().unwrap(),
+        v2_base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let v1_bytes = fs::metadata(v1_base.with_extension("osa")).unwrap().len()
+        + fs::metadata(v1_base.with_extension("osa.idx")).unwrap().len();
+    let v2_bytes = fs::metadata(v2_base.with_extension("osa2")).unwrap().len();
+    assert!(
+        v2_bytes < v1_bytes,
+        "v2 should be smaller: v1={v1_bytes} bytes, v2={v2_bytes} bytes"
+    );
+
+    // And the values still round-trip after all that encoding.
+    let reader = Osa2Reader::open(&v2_base.with_extension("osa2")).unwrap();
+    let j = json_at(&reader, "chr1", 1000, "A", "G").expect("first record present");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["gene"], "GENE0", "{j}");
+    let last_pos = 1000 + 19_999 * 3;
+    let j = json_at(&reader, "chr1", last_pos as u64, "A", "G").expect("last record present");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["gene"], format!("GENE{}", 19_999 % 200), "{j}");
+}
+
+const MITOMAP_TSV: &str = "\
+Position\tRef\tAlt\tDisease\tStatus
+3243\tA\tG\tMELAS\tConfirmed
+8344\tA\tG\tMERRF\tConfirmed
+8993\tT\tG\tLeigh Disease\tReported
+";
+
+#[test]
+fn mitomap_v1_v2_output_parity() {
+    assert_v1_v2_parity(
+        "mitomap",
+        MITOMAP_TSV,
+        &[
+            ("chrM", 3243, "A", "G"),
+            ("chrM", 8344, "A", "G"),
+            ("chrM", 8993, "T", "G"),
+        ],
+    );
+}
+
+#[test]
+fn mitomap_osa2_round_trips_free_text_payload() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("mitomap.tsv");
+    let output = dir.path().join("mitomap");
+    fs::write(&input, MITOMAP_TSV).unwrap();
+
+    run_sa_build_v2(
+        "mitomap",
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let reader = Osa2Reader::open(&output.with_extension("osa2")).unwrap();
+    assert_eq!(reader.json_key(), "mitomap");
+    let j = json_at(&reader, "chrM", 8993, "T", "G").expect("chrM:8993 annotated");
+    let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+    assert_eq!(v["disease"], "Leigh Disease", "{j}");
+    assert_eq!(v["status"], "Reported", "{j}");
+    // MitoMap is keyed on the mitochondrion; every spelling must reach it.
+    for alias in ["chrM", "M", "MT", "chrMT"] {
+        assert!(
+            json_at(&reader, alias, 3243, "A", "G").is_some(),
+            "mito spelling {alias} should resolve"
+        );
+    }
+}
+
+const CUSTOM_VCF: &str = "\
+##fileformat=VCFv4.2
+##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"score\">
+##INFO=<ID=LABEL,Number=1,Type=String,Description=\"label\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t100\t.\tA\tG\t.\t.\tSCORE=1.5;LABEL=alpha
+chr1\t300\t.\tGATTACA\tG\t.\t.\tSCORE=0.25;LABEL=beta
+chr2\t50\t.\tC\tT\t.\t.\tSCORE=9;LABEL=gamma
+";
+
+/// Build the same custom VCF both ways and compare. Not routed through
+/// `assert_v1_v2_parity` because custom sources need `--name` threaded in.
+#[test]
+fn custom_vcf_v1_v2_output_parity() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.vcf");
+    fs::write(&input, CUSTOM_VCF).unwrap();
+    let v1_base = dir.path().join("v1");
+    let v2_base = dir.path().join("v2");
+
+    for (base, format) in [(&v1_base, "osa"), (&v2_base, "osa2")] {
+        run_sa_build_format(
+            format,
+            "custom_vcf",
+            input.to_str().unwrap(),
+            base.to_str().unwrap(),
+            "GRCh38",
+            Some("myset"),
+            &[],
+            false,
+        )
+        .unwrap();
+    }
+
+    let v1 = SaReader::open(&v1_base.with_extension("osa")).unwrap();
+    let v2 = Osa2Reader::open(&v2_base.with_extension("osa2")).unwrap();
+    assert_eq!(v1.json_key(), "myset");
+    assert_eq!(v2.json_key(), "myset", "the user's --name must survive into v2");
+    assert_eq!(v1.name(), v2.name());
+
+    for &(chrom, pos, r, a) in &[
+        ("chr1", 100u64, "A", "G"),
+        ("chr1", 300, "GATTACA", "G"), // long variant
+        ("chr2", 50, "C", "T"),
+    ] {
+        let j1 = match v1.annotate_position(chrom, pos, r, a).unwrap() {
+            Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => j,
+            other => panic!("v1 missing {chrom}:{pos} {r}>{a}: {other:?}"),
+        };
+        let j2 = match v2.annotate_position(chrom, pos, r, a).unwrap() {
+            Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => j,
+            other => panic!("v2 missing {chrom}:{pos} {r}>{a}: {other:?}"),
+        };
+        // Whole-record blob encoding, so this is byte-for-byte, not just
+        // numerically equivalent.
+        assert_eq!(j1, j2, "custom_vcf {chrom}:{pos} {r}>{a} must be byte-identical");
+    }
+
+    // Explicit INFO-field selection also survives the v2 path.
+    let sel_base = dir.path().join("sel");
+    run_sa_build_format(
+        "osa2",
+        "custom_vcf",
+        input.to_str().unwrap(),
+        sel_base.to_str().unwrap(),
+        "GRCh38",
+        Some("selected"),
+        &["SCORE".to_string()],
+        false,
+    )
+    .unwrap();
+    let sel = Osa2Reader::open(&sel_base.with_extension("osa2")).unwrap();
+    let j = match sel.annotate_position("chr1", 100, "A", "G").unwrap() {
+        Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => j,
+        other => panic!("selected build missing chr1:100: {other:?}"),
+    };
+    assert!(j.contains("SCORE"), "requested INFO field missing: {j}");
+    assert!(!j.contains("LABEL"), "unrequested INFO field leaked: {j}");
+}
+
+#[test]
+fn custom_vcf_osa2_sorts_unsorted_input() {
+    // `parse_custom_vcf` preserves file order, and the v2 streaming writer
+    // rejects a reopened chunk outright — so a user VCF that is not coordinate
+    // sorted has to be sorted by the builder, not passed straight through.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("unsorted.vcf");
+    fs::write(
+        &input,
+        // chr1:100 and chr1:200 share chunk 0; the chr1:9000000 row between them
+        // sits in chunk 8, so streaming this file as-is would *reopen* chunk 0
+        // and the writer would bail. chr2 first, to unsort the chromosomes too.
+        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         chr2\t500\t.\tA\tG\t.\t.\tSCORE=3\n\
+         chr1\t100\t.\tA\tG\t.\t.\tSCORE=2\n\
+         chr1\t9000000\t.\tA\tG\t.\t.\tSCORE=1\n\
+         chr1\t200\t.\tA\tG\t.\t.\tSCORE=4\n",
+    )
+    .unwrap();
+    let out = dir.path().join("out");
+    run_sa_build_format(
+        "osa2",
+        "custom_vcf",
+        input.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "GRCh38",
+        Some("unsorted"),
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let reader = Osa2Reader::open(&out.with_extension("osa2")).unwrap();
+    for (chrom, pos) in [("chr1", 100u64), ("chr1", 200), ("chr1", 9_000_000), ("chr2", 500)] {
+        assert!(
+            reader.annotate_position(chrom, pos, "A", "G").unwrap().is_some(),
+            "{chrom}:{pos} should be present despite unsorted input"
+        );
+    }
+}
+
+/// `--format auto` on `source`, returning `(built_osa, built_osa2, built_osi)`.
+fn auto_build_extensions(dir: &std::path::Path, source: &str, input_name: &str, body: &str)
+    -> (bool, bool, bool)
+{
+    let input = dir.join(input_name);
+    fs::write(&input, body).unwrap();
+    let out = dir.join(format!("out_{source}"));
+    run_sa_build_format(
+        "auto",
+        source,
+        input.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+    (
+        out.with_extension("osa").exists(),
+        out.with_extension("osa2").exists(),
+        out.with_extension("osi").exists(),
+    )
+}
+
+#[test]
+fn format_auto_picks_v2_for_every_variant_level_source() {
     let dir = tempfile::tempdir().unwrap();
 
-    // gnomAD supports v2 → auto must produce .osa2 (and not .osa).
-    let gnomad_in = dir.path().join("gnomad.vcf");
-    fs::write(&gnomad_in, GNOMAD_VCF).unwrap();
-    let gnomad_out = dir.path().join("gnomad");
-    run_sa_build_format(
-        "auto",
-        "gnomad",
-        gnomad_in.to_str().unwrap(),
-        gnomad_out.to_str().unwrap(),
-        "GRCh38",
-        None,
-        &[],
-        false,
-    )
-    .unwrap();
-    assert!(
-        gnomad_out.with_extension("osa2").exists(),
-        "auto+gnomad should build .osa2"
-    );
-    assert!(
-        !gnomad_out.with_extension("osa").exists(),
-        "auto+gnomad should not build .osa"
-    );
+    // gnomAD is the reference case: auto builds .osa2 and not .osa.
+    let (osa, osa2, _) = auto_build_extensions(dir.path(), "gnomad", "gnomad.vcf", GNOMAD_VCF);
+    assert!(osa2, "auto+gnomad should build .osa2");
+    assert!(!osa, "auto+gnomad should not build .osa");
 
-    // MitoMap has no v2 encoder → auto must fall back to v1 .osa.
-    let mito_in = dir.path().join("mitomap.vcf");
-    fs::write(
-        &mito_in,
-        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
-         chrMT\t100\t.\tA\tG\t.\t.\tDisease=Test;DiseaseStatus=Confirmed\n",
-    )
-    .unwrap();
-    let mito_out = dir.path().join("mitomap");
-    run_sa_build_format(
-        "auto",
+    // MitoMap and custom_vcf were the last two variant-level sources that auto
+    // fell back to v1 for. They now build v2 too, so an all-defaults --sa-dir is
+    // entirely .osa2.
+    let (osa, osa2, _) = auto_build_extensions(
+        dir.path(),
         "mitomap",
-        mito_in.to_str().unwrap(),
-        mito_out.to_str().unwrap(),
+        "mitomap.tsv",
+        "Position\tRef\tAlt\tDisease\tStatus\n3243\tA\tG\tMELAS\tConfirmed\n",
+    );
+    assert!(osa2, "auto+mitomap should build .osa2");
+    assert!(!osa, "auto+mitomap should not build .osa");
+
+    let (osa, osa2, _) = auto_build_extensions(
+        dir.path(),
+        "custom_vcf",
+        "custom.vcf",
+        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         chr1\t100\t.\tA\tG\t.\t.\tSCORE=1.5\n",
+    );
+    assert!(osa2, "auto+custom_vcf should build .osa2");
+    assert!(!osa, "auto+custom_vcf should not build .osa");
+
+    // custom_bed is interval-keyed, so it still builds .osi — v2 has no
+    // interval container. This is a structural exception, not a gap.
+    let (osa, osa2, osi) =
+        auto_build_extensions(dir.path(), "custom_bed", "regions.bed", "chr1\t100\t200\tfoo\n");
+    assert!(osi, "auto+custom_bed should build .osi");
+    assert!(!osa && !osa2, "auto+custom_bed should build neither .osa nor .osa2");
+}
+
+#[test]
+fn format_osa_remains_the_explicit_v1_escape_hatch() {
+    // Every variant-level source now defaults to v2, so `--format osa` is the
+    // only way to reproduce a v1 build. It must still work.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("gnomad.vcf");
+    fs::write(&input, GNOMAD_VCF).unwrap();
+    let out = dir.path().join("v1_forced");
+    run_sa_build_format(
+        "osa",
+        "gnomad",
+        input.to_str().unwrap(),
+        out.to_str().unwrap(),
         "GRCh38",
         None,
         &[],
         false,
     )
     .unwrap();
+    assert!(out.with_extension("osa").exists(), "--format osa should build .osa");
+    assert!(out.with_extension("osa.idx").exists(), "--format osa should build .osa.idx");
     assert!(
-        mito_out.with_extension("osa").exists(),
-        "auto+mitomap should build .osa"
+        !out.with_extension("osa2").exists(),
+        "--format osa must not build .osa2"
     );
-    assert!(
-        !mito_out.with_extension("osa2").exists(),
-        "auto+mitomap should not build .osa2"
-    );
+    // And it is readable through the v1 reader.
+    let reader = SaReader::open(&out.with_extension("osa")).unwrap();
+    assert_eq!(reader.json_key(), "gnomad");
+    assert!(reader.annotate_position("chr1", 100, "A", "G").unwrap().is_some());
 }

--- a/crates/fastvep-cli/tests/sa_convert.rs
+++ b/crates/fastvep-cli/tests/sa_convert.rs
@@ -1,0 +1,263 @@
+//! Integration tests for `fastvep sa-convert`: transcoding an existing v1
+//! `.osa` database into v2 `.osa2` without going back to the upstream source.
+//!
+//! The contract being pinned is that a converted database answers every query
+//! exactly as the `.osa` did — same records, same JSON bytes, same identity and
+//! matching semantics — because that is the only reason to trust the conversion
+//! over a rebuild.
+
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_cli::pipeline::{run_sa_build, run_sa_convert};
+use fastvep_sa::reader::SaReader;
+use fastvep_sa::reader_v2::Osa2Reader;
+use std::fs;
+
+fn json_of(v: Option<AnnotationValue>) -> Option<String> {
+    match v {
+        Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => Some(j),
+        Some(AnnotationValue::Interval(v)) => Some(format!("[{}]", v.join(","))),
+        None => None,
+    }
+}
+
+/// Build `source` to v1, convert it, and return the (v1, v2) reader pair.
+fn build_and_convert(
+    dir: &std::path::Path,
+    source: &str,
+    body: &str,
+    input_name: &str,
+) -> (SaReader, Osa2Reader) {
+    let input = dir.join(input_name);
+    fs::write(&input, body).unwrap();
+    let base = dir.join(format!("db_{source}"));
+    run_sa_build(
+        source,
+        input.to_str().unwrap(),
+        base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let osa = base.with_extension("osa");
+    assert!(osa.exists(), "v1 build should have produced {}", osa.display());
+    run_sa_convert(osa.to_str().unwrap(), base.to_str().unwrap(), false).unwrap();
+
+    let osa2 = base.with_extension("osa2");
+    assert!(osa2.exists(), "conversion should have produced {}", osa2.display());
+    (SaReader::open(&osa).unwrap(), Osa2Reader::open(&osa2).unwrap())
+}
+
+const CLINVAR_VCF: &str = "\
+##fileformat=VCFv4.2
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t100\t12345\tA\tG\t.\t.\tCLNSIG=Pathogenic;CLNREVSTAT=criteria_provided;GENEINFO=BRCA1:672
+chr1\t300\t12346\tGATTACA\tG\t.\t.\tCLNSIG=Likely_benign;GENEINFO=BRCA1:672
+chr2\t50\t12347\tC\tT\t.\t.\tCLNSIG=Uncertain_significance;GENEINFO=TP53:7157
+chr2\t9000000\t12348\tT\tA\t.\t.\tCLNSIG=Benign;GENEINFO=TP53:7157
+";
+
+#[test]
+fn converted_database_answers_every_query_identically() {
+    let dir = tempfile::tempdir().unwrap();
+    let (v1, v2) = build_and_convert(dir.path(), "clinvar", CLINVAR_VCF, "clinvar.vcf");
+
+    // Identity and matching semantics carry over verbatim — an annotate run
+    // against the converted file must produce the same column, keyed the same
+    // way, with the same allele-matching behaviour.
+    assert_eq!(v1.json_key(), v2.json_key());
+    assert_eq!(v1.name(), v2.name());
+    assert_eq!(v1.metadata().assembly, v2.metadata().assembly);
+    assert_eq!(v1.metadata().version, v2.metadata().version);
+    assert_eq!(v1.metadata().description, v2.metadata().description);
+    assert_eq!(v1.metadata().match_by_allele, v2.metadata().match_by_allele);
+    assert_eq!(v1.metadata().is_array, v2.metadata().is_array);
+    assert_eq!(v1.metadata().is_positional, v2.metadata().is_positional);
+
+    for &(chrom, pos, r, a) in &[
+        ("chr1", 100u64, "A", "G"),
+        ("chr1", 300, "GATTACA", "G"), // long variant (kmer16 path)
+        ("chr2", 50, "C", "T"),
+        ("chr2", 9_000_000, "T", "A"), // a far-away chunk on a second contig
+    ] {
+        let j1 = json_of(v1.annotate_position(chrom, pos, r, a).unwrap())
+            .unwrap_or_else(|| panic!("v1 missing {chrom}:{pos} {r}>{a}"));
+        let j2 = json_of(v2.annotate_position(chrom, pos, r, a).unwrap())
+            .unwrap_or_else(|| panic!("converted db missing {chrom}:{pos} {r}>{a}"));
+        assert_eq!(j1, j2, "{chrom}:{pos} {r}>{a} must be byte-identical");
+    }
+
+    // Misses stay misses: an unknown position, a wrong allele, and an absent
+    // contig must not start matching.
+    for &(chrom, pos, r, a) in &[
+        ("chr1", 999, "A", "G"),
+        ("chr1", 100, "A", "T"),
+        ("chr9", 100, "A", "G"),
+    ] {
+        assert!(
+            json_of(v1.annotate_position(chrom, pos, r, a).unwrap()).is_none(),
+            "v1 should miss {chrom}:{pos} {r}>{a}"
+        );
+        assert!(
+            json_of(v2.annotate_position(chrom, pos, r, a).unwrap()).is_none(),
+            "converted db should miss {chrom}:{pos} {r}>{a}"
+        );
+    }
+}
+
+const PHYLOP_WIG: &str = "\
+fixedStep chrom=chr1 start=100 step=1
+1.5
+2.5
+3.5
+";
+
+#[test]
+fn conversion_preserves_positional_matching() {
+    // A positional source (`is_positional`) matches on coordinate alone. The
+    // flag has to survive so the v2 reader keys on `positional_key` rather than
+    // trying to match the alleles the blobs happen to carry.
+    let dir = tempfile::tempdir().unwrap();
+    let (v1, v2) = build_and_convert(dir.path(), "phylop", PHYLOP_WIG, "phylop.wig");
+
+    assert!(v2.metadata().is_positional, "positional flag must survive conversion");
+    assert!(!v2.metadata().match_by_allele);
+
+    for pos in [100u64, 101, 102] {
+        let j1 = json_of(v1.annotate_position("chr1", pos, "A", "G").unwrap())
+            .unwrap_or_else(|| panic!("v1 missing chr1:{pos}"));
+        let j2 = json_of(v2.annotate_position("chr1", pos, "A", "G").unwrap())
+            .unwrap_or_else(|| panic!("converted db missing chr1:{pos}"));
+        assert_eq!(j1, j2);
+        // Any allele resolves to the same score, in both formats.
+        let other = json_of(v2.annotate_position("chr1", pos, "C", "T").unwrap()).unwrap();
+        assert_eq!(j2, other, "positional lookup must ignore alleles");
+    }
+}
+
+#[test]
+fn conversion_covers_every_record_not_just_the_queried_ones() {
+    // A block-by-block scan is easy to get subtly wrong (skipping a block
+    // boundary, dropping the last block, missing a chromosome). Build enough
+    // records to span several blocks on two contigs and require the converted
+    // database to return all of them.
+    let dir = tempfile::tempdir().unwrap();
+    let mut vcf =
+        String::from("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n");
+    let mut expected: Vec<(String, u64)> = Vec::new();
+    for (chrom, base) in [("chr1", 1_000u64), ("chr2", 5_000)] {
+        for i in 0..4_000u64 {
+            let pos = base + i * 7;
+            vcf.push_str(&format!(
+                "{chrom}\t{pos}\t.\tA\tG\t.\t.\tCLNSIG=Pathogenic;GENEINFO=G{i}:1\n"
+            ));
+            expected.push((chrom.to_string(), pos));
+        }
+    }
+    let (v1, v2) = build_and_convert(dir.path(), "clinvar", &vcf, "big.vcf");
+
+    let mut checked = 0;
+    for (chrom, pos) in &expected {
+        let j1 = json_of(v1.annotate_position(chrom, *pos, "A", "G").unwrap())
+            .unwrap_or_else(|| panic!("v1 missing {chrom}:{pos}"));
+        let j2 = json_of(v2.annotate_position(chrom, *pos, "A", "G").unwrap())
+            .unwrap_or_else(|| panic!("converted db dropped {chrom}:{pos}"));
+        assert_eq!(j1, j2, "{chrom}:{pos}");
+        checked += 1;
+    }
+    assert_eq!(checked, expected.len());
+    assert_eq!(checked, 8_000, "sanity: the fixture should span many blocks");
+}
+
+#[test]
+fn rejects_inputs_that_have_no_v2_form() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Already v2.
+    let osa2 = dir.path().join("already.osa2");
+    fs::write(&osa2, b"whatever").unwrap();
+    let err = run_sa_convert(osa2.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
+        .unwrap_err();
+    assert!(err.to_string().contains("already a v2"), "got: {err}");
+
+    // Interval- and gene-level databases: v2 is a variant-level container, so
+    // there is nothing to convert them into. The error must say so rather than
+    // failing on a parse deep inside.
+    for (ext, expected) in [("osi", "interval-level"), ("oga", "gene-level")] {
+        let path = dir.path().join(format!("db.{ext}"));
+        fs::write(&path, b"whatever").unwrap();
+        let err =
+            run_sa_convert(path.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
+                .unwrap_err();
+        assert!(
+            err.to_string().contains(expected) && err.to_string().contains("variant-level"),
+            "expected a {ext}-specific message, got: {err}"
+        );
+    }
+
+    // Anything else.
+    let other = dir.path().join("notes.txt");
+    fs::write(&other, b"whatever").unwrap();
+    let err = run_sa_convert(other.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
+        .unwrap_err();
+    assert!(err.to_string().contains("expects a v1"), "got: {err}");
+}
+
+#[test]
+fn refuses_to_overwrite_its_own_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.vcf");
+    fs::write(&input, CLINVAR_VCF).unwrap();
+    let base = dir.path().join("db");
+    run_sa_build(
+        "clinvar",
+        input.to_str().unwrap(),
+        base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    // An `.osa2` input was already rejected above; this covers the other way to
+    // collide — asking for an output path that resolves onto the input file.
+    let osa2_in = base.with_extension("osa2");
+    fs::rename(base.with_extension("osa"), &osa2_in).unwrap();
+    let err = run_sa_convert(osa2_in.to_str().unwrap(), base.to_str().unwrap(), false).unwrap_err();
+    assert!(err.to_string().contains("already a v2"), "got: {err}");
+}
+
+#[test]
+fn a_failed_conversion_leaves_no_partial_output() {
+    // Truncated `.osa` (the `.osa.idx` is intact, so `open` succeeds and the
+    // failure lands mid-scan). No `.osa2` may survive.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.vcf");
+    fs::write(&input, CLINVAR_VCF).unwrap();
+    let base = dir.path().join("db");
+    run_sa_build(
+        "clinvar",
+        input.to_str().unwrap(),
+        base.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+
+    let osa = base.with_extension("osa");
+    let truncated: Vec<u8> = fs::read(&osa).unwrap().into_iter().take(16).collect();
+    fs::write(&osa, &truncated).unwrap();
+
+    let out_base = dir.path().join("converted");
+    let result = run_sa_convert(osa.to_str().unwrap(), out_base.to_str().unwrap(), false);
+    assert!(result.is_err(), "a truncated .osa must not convert successfully");
+    assert!(
+        !out_base.with_extension("osa2").exists(),
+        "no partial .osa2 may be left behind"
+    );
+}

--- a/crates/fastvep-core/src/chrom.rs
+++ b/crates/fastvep-core/src/chrom.rs
@@ -56,6 +56,45 @@ pub fn chrom_aliases(chrom: &str) -> Vec<String> {
     out
 }
 
+/// Invert [`chrom_aliases`] over a known set of contig names: every accepted
+/// spelling mapped to the canonical name actually present in `canonical`.
+///
+/// [`chrom_aliases`] is the right shape for a one-off resolution but the wrong
+/// shape for a hot loop - it allocates a `Vec` of two or three `String`s per
+/// call, and every SA reader used to call it once per queried variant per
+/// source. Building this map once, when a database is opened, turns the
+/// per-query cost into a single hash lookup that borrows the canonical name and
+/// allocates nothing.
+///
+/// Identity wins on collision: if `canonical` contains both `chr1` and `1`
+/// (which no well-formed database does, but a hand-assembled one might), each
+/// maps to itself rather than aliasing onto the other. Beyond that, the first
+/// canonical name to claim an alias keeps it, so the result is deterministic
+/// only if `canonical` is iterated deterministically - pass a sorted or
+/// insertion-ordered sequence when that matters.
+pub fn chrom_alias_map<I, S>(canonical: I) -> HashMap<String, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let names: Vec<String> = canonical
+        .into_iter()
+        .map(|s| s.as_ref().to_string())
+        .collect();
+    let mut map: HashMap<String, String> = HashMap::with_capacity(names.len() * 3);
+    // Identities first so a real contig name can never be shadowed by another
+    // contig's alias.
+    for name in &names {
+        map.insert(name.clone(), name.clone());
+    }
+    for name in &names {
+        for alias in chrom_aliases(name) {
+            map.entry(alias).or_insert_with(|| name.clone());
+        }
+    }
+    map
+}
+
 /// Heuristic: does this name look like an NCBI RefSeq molecule accession
 /// (`NC_000017.11`, `NW_…`, `NT_…`, `NG_…`)?
 ///
@@ -286,6 +325,51 @@ mod chrom_alias_tests {
         assert_eq!(aliases.len(), 2, "unexpected aliases: {:?}", aliases);
         assert_eq!(aliases[0], "HLA-A*01:01");
         assert_eq!(aliases[1], "chrHLA-A*01:01");
+    }
+
+    #[test]
+    fn alias_map_resolves_every_alias_to_the_canonical_name() {
+        use super::chrom_alias_map;
+
+        let map = chrom_alias_map(["chr1", "chr2", "chrM"]);
+        for (query, want) in [
+            ("chr1", "chr1"),
+            ("1", "chr1"),
+            ("chr2", "chr2"),
+            ("2", "chr2"),
+            ("chrM", "chrM"),
+            ("M", "chrM"),
+            ("MT", "chrM"),
+            ("chrMT", "chrM"),
+        ] {
+            assert_eq!(map.get(query).map(String::as_str), Some(want), "query {query}");
+        }
+        // An absent contig resolves to nothing, so callers miss cleanly rather
+        // than probing the database with a name it does not contain.
+        assert!(!map.contains_key("chr3"));
+        assert!(!map.contains_key("3"));
+    }
+
+    #[test]
+    fn alias_map_agrees_with_chrom_aliases_for_bare_keyed_databases() {
+        use super::chrom_alias_map;
+
+        // The historical SA writer canonicalized to the bare form; a `chr1`
+        // query must still resolve (issue #37).
+        let map = chrom_alias_map(["1", "X", "MT"]);
+        assert_eq!(map.get("chr1").map(String::as_str), Some("1"));
+        assert_eq!(map.get("chrX").map(String::as_str), Some("X"));
+        assert_eq!(map.get("chrM").map(String::as_str), Some("MT"));
+        assert_eq!(map.get("M").map(String::as_str), Some("MT"));
+    }
+
+    #[test]
+    fn alias_map_identity_wins_when_both_spellings_are_present() {
+        use super::chrom_alias_map;
+
+        let map = chrom_alias_map(["chr1", "1"]);
+        assert_eq!(map.get("chr1").map(String::as_str), Some("chr1"));
+        assert_eq!(map.get("1").map(String::as_str), Some("1"));
     }
 
     #[test]

--- a/crates/fastvep-core/src/lib.rs
+++ b/crates/fastvep-core/src/lib.rs
@@ -5,7 +5,8 @@ mod position;
 
 pub use annotation_types::{GeneAnnotation, SupplementaryAnnotation};
 pub use chrom::{
-    chrom_aliases, looks_like_refseq_accession, refseq_primary_accessions, ChromSynonyms,
+    chrom_alias_map, chrom_aliases, looks_like_refseq_accession, refseq_primary_accessions,
+    ChromSynonyms,
 };
 pub use consequence::{Consequence, Impact};
 pub use position::{Allele, GenomicPosition, Strand, VariantType};

--- a/crates/fastvep-sa/src/chunk.rs
+++ b/crates/fastvep-sa/src/chunk.rs
@@ -4,7 +4,7 @@
 //! Chunks are loaded on demand from .osa2 ZIP archives.
 
 use crate::fields::{Field, FieldType};
-use crate::kmer16::LongVariant;
+use crate::kmer16::{LongVariant, OtherVariant};
 
 /// A loaded genomic chunk (~1MB region) with sorted variant keys and values.
 pub struct Chunk {
@@ -12,6 +12,11 @@ pub struct Chunk {
     pub var32s: Vec<u32>,
     /// Long variants (ref+alt > 4 bases) sorted for binary search.
     pub longs: Vec<LongVariant>,
+    /// Variants whose alleles are not 2-bit packable (contain `N`/IUPAC), kept
+    /// verbatim and sorted for binary search. Almost always empty; real ClinVar
+    /// puts ~0.015% of its records here. Absent from `.osa2` files written
+    /// before this bucket existed, which simply leaves it empty.
+    pub others: Vec<OtherVariant>,
     /// Parallel value arrays, one per non-JsonBlob field in field-config order:
     /// `values[non_jsonblob_position][variant_idx]`. JsonBlob fields do not
     /// contribute a column here (their payloads live in `json_blobs`), so this
@@ -26,19 +31,26 @@ pub struct Chunk {
 impl Chunk {
     /// Create an empty chunk.
     pub fn empty() -> Self {
-        Self { var32s: Vec::new(), longs: Vec::new(), values: Vec::new(), json_blobs: None }
+        Self {
+            var32s: Vec::new(),
+            longs: Vec::new(),
+            others: Vec::new(),
+            values: Vec::new(),
+            json_blobs: None,
+        }
     }
 
-    /// Number of variants in this chunk (short + long).
+    /// Number of variants in this chunk (short + long + non-ACGT).
     pub fn len(&self) -> usize {
-        self.var32s.len() + self.longs.len()
+        self.var32s.len() + self.longs.len() + self.others.len()
     }
 
-    /// A chunk is empty only when it holds neither short nor long variants.
-    /// Long-only chunks (all indels) must not be treated as empty, or every
-    /// lookup against them would miss.
+    /// A chunk is empty only when it holds no variants of any kind. Long-only
+    /// chunks (all indels) must not be treated as empty, or every lookup
+    /// against them would miss — and the same goes for a chunk that happens to
+    /// hold only non-ACGT-allele variants.
     pub fn is_empty(&self) -> bool {
-        self.var32s.is_empty() && self.longs.is_empty()
+        self.var32s.is_empty() && self.longs.is_empty() && self.others.is_empty()
     }
 
     /// Look up a variant by Var32 key. Returns the index into value arrays.
@@ -49,9 +61,8 @@ impl Chunk {
 
     /// Look up a long variant. Returns the index into value arrays.
     ///
-    /// Returns `None` if either allele contains a non-ACGT base: such a
-    /// variant could not have been written into the index without being
-    /// silently corrupted, so we report a miss rather than guessing.
+    /// Returns `None` if either allele contains a non-ACGT base — such a variant
+    /// is filed in `others`, not here; see [`find_other`](Self::find_other).
     pub fn find_long(&self, position: u32, ref_allele: &[u8], alt_allele: &[u8]) -> Option<usize> {
         let sequence = crate::kmer16::encode_var(ref_allele, alt_allele)?;
         let query = LongVariant {
@@ -60,6 +71,28 @@ impl Chunk {
             sequence,
         };
         self.longs.binary_search(&query).ok().map(|i| self.longs[i].idx as usize)
+    }
+
+    /// Look up a variant whose alleles are not 2-bit packable. Returns the index
+    /// into the value arrays.
+    ///
+    /// `others` is empty for every source without `N`/IUPAC alleles and for any
+    /// `.osa2` written before the bucket existed, so this is a length check in
+    /// the overwhelmingly common case.
+    pub fn find_other(&self, position: u32, ref_allele: &[u8], alt_allele: &[u8]) -> Option<usize> {
+        if self.others.is_empty() {
+            return None;
+        }
+        let query = OtherVariant {
+            position,
+            idx: 0,
+            ref_allele: ref_allele.to_vec(),
+            alt_allele: alt_allele.to_vec(),
+        };
+        self.others
+            .binary_search(&query)
+            .ok()
+            .map(|i| self.others[i].idx as usize)
     }
 
     /// Reconstruct a JSON string from parallel value arrays at the given index.

--- a/crates/fastvep-sa/src/custom.rs
+++ b/crates/fastvep-sa/src/custom.rs
@@ -4,9 +4,34 @@
 //! that get indexed and queried at annotation time.
 
 use crate::common::AnnotationRecord;
+use crate::writer_v2::Osa2Metadata;
 use anyhow::{Context, Result};
 use std::collections::{BTreeMap, HashMap};
 use std::io::BufRead;
+
+/// `.osa2` metadata for a user-supplied VCF, keyed by the display/JSON `name`
+/// the user chose.
+///
+/// Custom VCFs carry whatever INFO keys the file happens to have - a
+/// heterogeneous, per-file schema - so there is no fixed column layout to encode
+/// and the record is stored as a whole-record JSON blob (see
+/// [`crate::writer_v2::raw_json_blob_fields`]). v2 still pays off: it zstd's a
+/// whole chunk's records together, exploiting the redundancy between adjacent
+/// records that v1's per-block scheme cannot.
+pub fn custom_vcf_osa2_metadata(name: &str, assembly: &str) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: name.into(),
+        version: "user-supplied".into(),
+        assembly: assembly.into(),
+        json_key: name.into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: format!("Custom VCF annotations for {assembly}"),
+    }
+}
 
 /// Parse a custom VCF annotation file.
 ///

--- a/crates/fastvep-sa/src/index.rs
+++ b/crates/fastvep-sa/src/index.rs
@@ -3,8 +3,9 @@
 //! The index maps (chromosome, position) -> file offset so the reader can
 //! seek directly to the relevant compressed block.
 
-use crate::common::{chrom_aliases, MAX_INDEX_PAYLOAD, OSA_MAGIC, SCHEMA_VERSION};
+use crate::common::{MAX_INDEX_PAYLOAD, OSA_MAGIC, SCHEMA_VERSION};
 use anyhow::Result;
+use fastvep_core::chrom_alias_map;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -42,6 +43,17 @@ pub struct SaIndex {
     pub header: IndexHeader,
     /// Chromosome name -> list of block references, sorted by start_pos.
     pub chromosomes: HashMap<String, Vec<BlockRef>>,
+    /// Every accepted spelling of every chromosome in the index → its key in
+    /// `chromosomes` (issue #37). Derived state, not part of the on-disk format:
+    /// `#[serde(skip)]` keeps the `.osa.idx` bytes unchanged, and
+    /// [`rebuild_chrom_lookup`](Self::rebuild_chrom_lookup) fills it in after a
+    /// load or a mutation.
+    ///
+    /// Exists so `blocks_for_chrom` is one hash lookup on the query path. It
+    /// used to call `chrom_aliases`, which allocates a `Vec<String>`, once per
+    /// queried variant per source.
+    #[serde(skip)]
+    chrom_lookup: HashMap<String, String>,
 }
 
 impl SaIndex {
@@ -50,27 +62,44 @@ impl SaIndex {
         Self {
             header,
             chromosomes: HashMap::new(),
+            chrom_lookup: HashMap::new(),
         }
     }
 
     /// Add a block reference for a chromosome.
+    ///
+    /// Registers the chromosome's aliases as it goes, so an index built purely
+    /// through `add_block` (the writer's path, and several tests') resolves
+    /// queries without needing a separate finalize step.
     pub fn add_block(&mut self, chrom: &str, block_ref: BlockRef) {
+        if !self.chromosomes.contains_key(chrom) {
+            for (alias, canonical) in chrom_alias_map([chrom]) {
+                self.chrom_lookup.entry(alias).or_insert(canonical);
+            }
+        }
         self.chromosomes
             .entry(chrom.to_string())
             .or_default()
             .push(block_ref);
     }
 
+    /// Recompute the alias → on-disk-key map from `chromosomes`. Run after
+    /// loading an index or mutating `chromosomes` directly.
+    fn rebuild_chrom_lookup(&mut self) {
+        self.chrom_lookup = chrom_alias_map(self.chromosomes.keys());
+    }
+
     /// Resolve a chromosome name to the on-disk key, tolerating `chr*` vs
     /// bare naming and mitochondrial aliases. Returns `None` if no alias is
     /// present in the index.
-    fn blocks_for_chrom(&self, chrom: &str) -> Option<&Vec<BlockRef>> {
-        for alias in chrom_aliases(chrom) {
-            if let Some(blocks) = self.chromosomes.get(&alias) {
-                return Some(blocks);
-            }
-        }
-        None
+    ///
+    /// Public so the reader's `preload` resolves chromosomes through exactly the
+    /// same path as `find_blocks`; they used to have two copies of the alias
+    /// logic, and a preload that resolved differently from the query silently
+    /// warmed nothing (issue #37).
+    pub fn blocks_for_chrom(&self, chrom: &str) -> Option<&Vec<BlockRef>> {
+        let key = self.chrom_lookup.get(chrom)?;
+        self.chromosomes.get(key)
     }
 
     /// Find the block(s) that may contain the given position on a chromosome.
@@ -170,7 +199,10 @@ impl SaIndex {
         let mut data = vec![0u8; len];
         reader.read_exact(&mut data)?;
 
-        let index: SaIndex = bincode::deserialize(&data)?;
+        let mut index: SaIndex = bincode::deserialize(&data)?;
+        // `chrom_lookup` is `#[serde(skip)]`, so it arrives empty regardless of
+        // what the file held. Build it before the index is queried.
+        index.rebuild_chrom_lookup();
         Ok(index)
     }
 }
@@ -224,6 +256,93 @@ mod tests {
         assert_eq!(loaded.chromosomes.len(), 2);
         assert_eq!(loaded.chromosomes["chr1"].len(), 2);
         assert_eq!(loaded.chromosomes["chr2"].len(), 1);
+        // The derived alias map is rebuilt on load, so aliases resolve
+        // immediately without any finalize step.
+        assert!(loaded.blocks_for_chrom("1").is_some());
+        assert!(loaded.blocks_for_chrom("chr1").is_some());
+        assert!(loaded.blocks_for_chrom("chr9").is_none());
+    }
+
+    fn test_header() -> IndexHeader {
+        IndexHeader {
+            schema_version: SCHEMA_VERSION,
+            json_key: "test".into(),
+            name: "Test".into(),
+            version: "1.0".into(),
+            description: "Test".into(),
+            assembly: "GRCh38".into(),
+            match_by_allele: true,
+            is_array: false,
+            is_positional: false,
+        }
+    }
+
+    #[test]
+    fn idx_files_written_before_chrom_lookup_existed_still_load() {
+        // `chrom_lookup` is `#[serde(skip)]`, so an `.osa.idx` is still encoded
+        // as exactly (header, chromosomes). Build that payload from a standalone
+        // tuple — the old two-field layout — and require `read_from` to accept
+        // it and to derive the alias map itself.
+        let mut chromosomes: HashMap<String, Vec<BlockRef>> = HashMap::new();
+        chromosomes.insert(
+            "1".into(),
+            vec![BlockRef { start_pos: 100, end_pos: 500, file_offset: 0, compressed_len: 16 }],
+        );
+        let legacy = (test_header(), chromosomes);
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(OSA_MAGIC);
+        buf.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
+        let payload = bincode::serialize(&legacy).unwrap();
+        buf.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        buf.extend_from_slice(&payload);
+
+        let loaded = SaIndex::read_from(&mut std::io::Cursor::new(buf)).unwrap();
+        assert_eq!(loaded.chromosomes["1"].len(), 1);
+        // The historical writer canonicalized to the bare form; a chr-prefixed
+        // query must still resolve (issue #37).
+        assert_eq!(loaded.find_blocks("chr1", 200).len(), 1);
+        assert_eq!(loaded.find_blocks("1", 200).len(), 1);
+    }
+
+    #[test]
+    fn write_to_output_is_unchanged_by_the_derived_field() {
+        // Guards the on-disk format: the bytes `write_to` emits must equal
+        // magic + version + len + bincode((header, chromosomes)).
+        let mut index = SaIndex::new(test_header());
+        index.add_block(
+            "chr1",
+            BlockRef { start_pos: 1, end_pos: 9, file_offset: 0, compressed_len: 4 },
+        );
+
+        let mut actual = Vec::new();
+        index.write_to(&mut actual).unwrap();
+
+        let legacy = (index.header.clone(), index.chromosomes.clone());
+        let payload = bincode::serialize(&legacy).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(OSA_MAGIC);
+        expected.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
+        expected.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        expected.extend_from_slice(&payload);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn add_block_registers_aliases_for_every_spelling() {
+        let mut index = SaIndex::new(test_header());
+        index.add_block(
+            "chrM",
+            BlockRef { start_pos: 1, end_pos: 100, file_offset: 0, compressed_len: 4 },
+        );
+        for alias in ["chrM", "M", "MT", "chrMT"] {
+            assert!(
+                index.blocks_for_chrom(alias).is_some(),
+                "mito spelling {alias} should resolve"
+            );
+        }
+        assert!(index.blocks_for_chrom("chr1").is_none());
     }
 
     #[test]

--- a/crates/fastvep-sa/src/interval.rs
+++ b/crates/fastvep-sa/src/interval.rs
@@ -6,6 +6,7 @@
 use crate::common::{IntervalRecord, MAX_INDEX_PAYLOAD, OSI_MAGIC, SCHEMA_VERSION};
 use anyhow::Result;
 use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, SaMetadata};
+use fastvep_core::chrom_alias_map;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -27,6 +28,29 @@ pub struct IntervalIndex {
     pub header: IntervalHeader,
     /// Chromosome -> sorted list of intervals.
     pub intervals: HashMap<String, Vec<StoredInterval>>,
+    /// Per-chromosome prefix maxima of `end`: `end_maxima[chrom][i] ==
+    /// max(intervals[chrom][0..=i].end)`. Because it is monotonically
+    /// non-decreasing it can be binary-searched to find the first interval
+    /// that could possibly reach a query, which is what turns
+    /// [`find_overlapping`](Self::find_overlapping) from a scan-from-index-0
+    /// into two binary searches plus a bounded scan.
+    ///
+    /// Derived state, not part of the on-disk format: `#[serde(skip)]` keeps
+    /// the `.osi` bytes byte-identical to files written before this field
+    /// existed, and it is rebuilt by [`sort`](Self::sort) and
+    /// [`read_from`](Self::read_from).
+    #[serde(skip)]
+    end_maxima: HashMap<String, Vec<u32>>,
+    /// Every accepted spelling of every chromosome in the index → its key in
+    /// `intervals` (issue #37). Same derived-state contract as `end_maxima`:
+    /// `#[serde(skip)]`, rebuilt by [`sort`](Self::sort) and
+    /// [`read_from`](Self::read_from).
+    ///
+    /// Replaces a per-query `chrom_aliases` call - which allocates a
+    /// `Vec<String>` and probed the map once per alias - with a single
+    /// allocation-free lookup.
+    #[serde(skip)]
+    chrom_lookup: HashMap<String, String>,
 }
 
 /// A stored interval with its annotation.
@@ -43,11 +67,24 @@ impl IntervalIndex {
         Self {
             header,
             intervals: HashMap::new(),
+            end_maxima: HashMap::new(),
+            chrom_lookup: HashMap::new(),
         }
     }
 
     /// Add an interval record.
+    ///
+    /// Invalidates the derived `end_maxima` for that chromosome; call
+    /// [`sort`](Self::sort) once all records are added to rebuild it (and to
+    /// establish the start-order invariant `find_overlapping` needs). The alias
+    /// map is extended eagerly instead, so a query works even before `sort`.
     pub fn add(&mut self, record: IntervalRecord) {
+        self.end_maxima.remove(&record.chrom);
+        if !self.intervals.contains_key(&record.chrom) {
+            for (alias, canonical) in chrom_alias_map([&record.chrom]) {
+                self.chrom_lookup.entry(alias).or_insert(canonical);
+            }
+        }
         self.intervals
             .entry(record.chrom)
             .or_default()
@@ -59,26 +96,122 @@ impl IntervalIndex {
     }
 
     /// Sort all intervals by start position (call after adding all records).
+    ///
+    /// Also rebuilds the derived `end_maxima` and `chrom_lookup` structures
+    /// [`find_overlapping`](Self::find_overlapping) relies on.
     pub fn sort(&mut self) {
         for intervals in self.intervals.values_mut() {
             intervals.sort_by_key(|i| i.start);
         }
+        self.rebuild_derived();
+    }
+
+    /// Recompute every derived lookup structure from `intervals`.
+    fn rebuild_derived(&mut self) {
+        self.rebuild_end_maxima();
+        self.chrom_lookup = chrom_alias_map(self.intervals.keys());
+    }
+
+    /// Resolve a query chromosome name to its key in `intervals`, tolerating
+    /// `chr*` vs bare naming and mitochondrial aliases. `None` means the index
+    /// has no contig by any accepted spelling of that name.
+    pub fn resolve_chrom(&self, chrom: &str) -> Option<&str> {
+        self.chrom_lookup.get(chrom).map(String::as_str)
+    }
+
+    /// Recompute the per-chromosome prefix maxima of `end` from `intervals`.
+    /// Must run after any mutation of `intervals`, and only once they are
+    /// sorted by `start`.
+    fn rebuild_end_maxima(&mut self) {
+        self.end_maxima.clear();
+        self.end_maxima.reserve(self.intervals.len());
+        for (chrom, intervals) in &self.intervals {
+            let mut maxima = Vec::with_capacity(intervals.len());
+            let mut running = 0u32;
+            for iv in intervals {
+                running = running.max(iv.end);
+                maxima.push(running);
+            }
+            self.end_maxima.insert(chrom.clone(), maxima);
+        }
+    }
+
+    /// The half-open `[lo, hi)` slice of `intervals[chrom]` that can contain an
+    /// overlap of `[query_start, query_end]`. See
+    /// [`find_overlapping`](Self::find_overlapping) for the reasoning; split out
+    /// so the window width itself is testable rather than only its output.
+    ///
+    /// Resolves `chrom` itself rather than requiring a pre-resolved name, so it
+    /// is correct in isolation; resolution is idempotent for a canonical name,
+    /// so the caller re-resolving costs one hash lookup.
+    fn candidate_window(&self, chrom: &str, query_start: u32, query_end: u32) -> (usize, usize) {
+        let Some(chrom) = self.resolve_chrom(chrom) else {
+            return (0, 0);
+        };
+        let intervals = match self.intervals.get(chrom) {
+            Some(i) => i,
+            None => return (0, 0),
+        };
+
+        // One past the last interval that begins at or before the query end.
+        let hi = intervals.partition_point(|iv| iv.start <= query_end);
+
+        // First interval that can reach back to `query_start`. Falls back to 0
+        // when the derived maxima are absent or stale (an `IntervalIndex`
+        // mutated via `add` without a following `sort`), which only costs the
+        // old scan width and never changes the answer.
+        let lo = match self.end_maxima.get(chrom) {
+            Some(maxima) if maxima.len() == intervals.len() => {
+                maxima.partition_point(|&max_end| max_end < query_start)
+            }
+            _ => 0,
+        };
+
+        (lo.min(hi), hi)
     }
 
     /// Find all intervals overlapping [query_start, query_end].
+    ///
+    /// Two binary searches bound the scan. A point query used to walk every
+    /// interval on the chromosome starting at or before it, so cost grew with
+    /// how far into the chromosome the query landed rather than with how many
+    /// intervals actually overlap it.
+    ///
+    /// Measured on 620,754 real chr22 coordinates as 2 kb intervals, querying
+    /// 15,437 real chr22 variants spread across the chromosome: 70.6 µs →
+    /// 48.6 µs per query (1.45×). The gain is modest there because those
+    /// intervals overlap heavily — ~25 contain any given point, so the window is
+    /// legitimately wide and cloning those hits dominates. It grows with
+    /// sparsity: `candidate_window`'s test builds a non-overlapping database and
+    /// the window shrinks from the whole prefix to ≤4 intervals.
+    ///
+    /// * `hi` — one past the last interval with `start <= query_end`, found by
+    ///   `partition_point` over the start-sorted list.
+    /// * `lo` — the first interval that could reach `query_start`, found by
+    ///   `partition_point` over the monotone `end_maxima`. Every interval
+    ///   before `lo` ends strictly before `query_start`, so none can overlap.
+    ///
+    /// Only `[lo, hi)` is examined, and the per-interval `end >= query_start`
+    /// filter inside that window is unchanged — so results are identical to a
+    /// full scan, in the same (start-sorted) order.
+    ///
+    /// `chrom` may be given in any accepted spelling; it is resolved against the
+    /// index's own contig set via [`resolve_chrom`](Self::resolve_chrom).
     pub fn find_overlapping(&self, chrom: &str, query_start: u32, query_end: u32) -> Vec<OverlapResult> {
+        let Some(chrom) = self.resolve_chrom(chrom) else {
+            return Vec::new();
+        };
         let intervals = match self.intervals.get(chrom) {
             Some(i) => i,
             None => return Vec::new(),
         };
+        let (lo, hi) = self.candidate_window(chrom, query_start, query_end);
 
-        // Binary search for first interval with start <= query_end
-        // (since intervals are sorted by start, we need those where start <= query_end)
         let mut results = Vec::new();
-        for interval in intervals {
-            if interval.start > query_end {
-                break; // Past the query range
-            }
+        if lo >= hi {
+            return results;
+        }
+        for interval in &intervals[lo..hi] {
             if interval.end >= query_start {
                 // Compute reciprocal overlap
                 let overlap_start = interval.start.max(query_start);
@@ -154,6 +287,10 @@ impl IntervalIndex {
                 index.header.name
             );
         }
+        // The derived fields are `#[serde(skip)]`, so they arrive empty
+        // regardless of what the file contained. Build them now, after the sort
+        // above, so the very first query already gets the binary-searched path.
+        index.rebuild_derived();
         Ok(index)
     }
 }
@@ -171,11 +308,12 @@ impl OsiReader {
     pub fn open(path: &Path) -> Result<Self> {
         let mut file = std::fs::File::open(path)?;
         let mut index = IntervalIndex::read_from(&mut file)?;
-        // `find_overlapping` does a linear scan from the start of the
-        // chromosome's interval vector, so the sort invariant is
-        // load-bearing — `IntervalIndex::read_from` already sorts on read
-        // as a safety net (see its docs), but if any caller mutates after
-        // load they're responsible for re-sorting.
+        // `find_overlapping` binary-searches both the start-sorted interval
+        // list and the derived `end_maxima`, so the sort invariant is
+        // load-bearing. `IntervalIndex::read_from` already sorts on read as a
+        // safety net (see its docs); this second `sort()` is cheap on
+        // already-sorted input and keeps the invariant explicit at the one
+        // place the annotate pipeline enters from.
         index.sort();
         let metadata = SaMetadata {
             name: index.header.name.clone(),
@@ -217,30 +355,21 @@ impl AnnotationProvider for OsiReader {
         _ref_allele: &str,
         _alt_allele: &str,
     ) -> Result<Option<AnnotationValue>> {
-        // Point-query semantics: report every interval that contains
-        // `pos`. We probe every standard alias for the chromosome so a
-        // BED stored as `chrM` matches a VCF query of `MT` (and vice
+        // Point-query semantics: report every interval that contains `pos`.
+        // `find_overlapping` resolves the chromosome through the index's alias
+        // map, so a BED stored as `chrM` matches a VCF query of `MT` (and vice
         // versa), matching the behaviour of `SaReader`.
         let pos32: u32 = match u32::try_from(pos) {
             Ok(p) => p,
             Err(_) => return Ok(None),
         };
-        let mut json_hits: Vec<String> = Vec::new();
-        for alias in crate::common::chrom_aliases(chrom) {
-            let hits = self.index.find_overlapping(&alias, pos32, pos32);
-            if !hits.is_empty() {
-                json_hits.extend(hits.into_iter().map(|h| h.json));
-                // A `.osi` only stores each chromosome under one canonical
-                // name, so the first alias that matches is the right one;
-                // stop here to avoid double-counting if a (corrupted) file
-                // somehow had two names for one contig.
-                break;
-            }
-        }
-        if json_hits.is_empty() {
+        let hits = self.index.find_overlapping(chrom, pos32, pos32);
+        if hits.is_empty() {
             return Ok(None);
         }
-        Ok(Some(AnnotationValue::Interval(json_hits)))
+        Ok(Some(AnnotationValue::Interval(
+            hits.into_iter().map(|h| h.json).collect(),
+        )))
     }
 }
 
@@ -423,6 +552,235 @@ mod tests {
         // Position outside any interval → None.
         let val = reader.annotate_position("chr1", 50, "", "").unwrap();
         assert!(val.is_none());
+    }
+
+    /// Reference implementation: the pre-optimization full scan. Any
+    /// divergence between this and `find_overlapping` is a correctness bug.
+    fn brute_force(
+        intervals: &[StoredInterval],
+        query_start: u32,
+        query_end: u32,
+    ) -> Vec<String> {
+        intervals
+            .iter()
+            .filter(|iv| iv.start <= query_end && iv.end >= query_start)
+            .map(|iv| iv.json.clone())
+            .collect()
+    }
+
+    /// Deterministic xorshift so the differential test is reproducible without
+    /// pulling in a `rand` dependency.
+    fn next_rand(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+
+    fn test_header() -> IntervalHeader {
+        IntervalHeader {
+            schema_version: SCHEMA_VERSION,
+            json_key: "t".into(),
+            name: "T".into(),
+            version: "1.0".into(),
+            assembly: "GRCh38".into(),
+        }
+    }
+
+    #[test]
+    fn find_overlapping_matches_full_scan_on_randomized_intervals() {
+        // Covers the shapes the binary-searched window has to survive:
+        // duplicate starts, fully nested intervals, one very long interval
+        // that reaches far past everything after it, and zero-length spans.
+        let mut state = 0x243F_6A88_85A3_08D3u64;
+        let mut index = IntervalIndex::new(test_header());
+        for i in 0..600u32 {
+            let start = (next_rand(&mut state) % 10_000) as u32;
+            let len = match i % 7 {
+                0 => 0,                                      // point interval
+                1 => 5_000 + (next_rand(&mut state) % 4_000) as u32, // long reacher
+                _ => (next_rand(&mut state) % 50) as u32,
+            };
+            index.add(IntervalRecord {
+                chrom: "chr1".into(),
+                start,
+                end: start.saturating_add(len),
+                json: format!("{{\"id\":{}}}", i),
+            });
+        }
+        index.sort();
+        let intervals = index.intervals["chr1"].clone();
+
+        for q in 0..12_000u32 {
+            // Point queries — the hot path from `annotate_position`.
+            let got: Vec<String> = index
+                .find_overlapping("chr1", q, q)
+                .into_iter()
+                .map(|h| h.json)
+                .collect();
+            let want = brute_force(&intervals, q, q);
+            assert_eq!(got, want, "point query at {} diverged", q);
+        }
+
+        // Range queries, including ones that start past every interval.
+        for _ in 0..2_000 {
+            let a = (next_rand(&mut state) % 14_000) as u32;
+            let b = a + (next_rand(&mut state) % 3_000) as u32;
+            let got: Vec<String> = index
+                .find_overlapping("chr1", a, b)
+                .into_iter()
+                .map(|h| h.json)
+                .collect();
+            assert_eq!(got, brute_force(&intervals, a, b), "range {}..{} diverged", a, b);
+        }
+    }
+
+    #[test]
+    fn candidate_window_does_not_scan_from_index_zero() {
+        // The regression this guards: a point query near the end of a
+        // chromosome used to walk every interval starting at or before it, so
+        // cost grew with position rather than with overlap count. With the
+        // `end_maxima` bound the window stays proportional to local density.
+        let mut index = IntervalIndex::new(test_header());
+        for i in 0..100_000u32 {
+            let start = i * 10;
+            index.add(IntervalRecord {
+                chrom: "chr1".into(),
+                start,
+                end: start + 9,
+                json: format!("{{\"id\":{}}}", i),
+            });
+        }
+        index.sort();
+
+        let (lo, hi) = index.candidate_window("chr1", 999_000, 999_000);
+        assert!(
+            hi - lo <= 4,
+            "expected a tiny candidate window for a point query, got {}..{} ({} intervals)",
+            lo,
+            hi,
+            hi - lo
+        );
+        assert!(lo > 99_000, "lower bound should skip the whole prefix, got {}", lo);
+
+        // And it still finds the right interval.
+        let hits = index.find_overlapping("chr1", 999_000, 999_000);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].json.contains("99900"));
+    }
+
+    #[test]
+    fn candidate_window_falls_back_to_full_scan_when_maxima_are_stale() {
+        // `add` after `sort` deliberately drops that chromosome's maxima. The
+        // window must widen to the whole prefix rather than silently trusting
+        // a stale array and missing overlaps.
+        let mut index = IntervalIndex::new(test_header());
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 10, end: 20, json: "{\"id\":\"a\"}".into() });
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 30, end: 40, json: "{\"id\":\"b\"}".into() });
+        index.sort();
+        assert_eq!(index.candidate_window("chr1", 35, 35).0, 1, "maxima should bound a fresh index");
+
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 50, end: 60, json: "{\"id\":\"c\"}".into() });
+        assert_eq!(
+            index.candidate_window("chr1", 35, 35).0,
+            0,
+            "a mutated index must fall back to scanning from 0"
+        );
+        // Correctness is preserved either way.
+        let hits = index.find_overlapping("chr1", 35, 35);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].json.contains("\"b\""));
+    }
+
+    #[test]
+    fn osi_files_written_before_end_maxima_existed_still_load() {
+        // `end_maxima` is `#[serde(skip)]`, so an `.osi` is still encoded as
+        // exactly (header, intervals). Build that payload from a standalone
+        // tuple — i.e. the old two-field layout — and require `read_from` to
+        // accept it and to populate the maxima itself.
+        let mut intervals: HashMap<String, Vec<StoredInterval>> = HashMap::new();
+        intervals.insert(
+            "chr1".into(),
+            vec![
+                StoredInterval { start: 100, end: 200, json: "{\"id\":\"a\"}".into() },
+                StoredInterval { start: 150, end: 400, json: "{\"id\":\"b\"}".into() },
+            ],
+        );
+        let legacy = (test_header(), intervals);
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(OSI_MAGIC);
+        buf.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
+        let payload = bincode::serialize(&legacy).unwrap();
+        buf.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        buf.extend_from_slice(&payload);
+
+        let loaded = IntervalIndex::read_from(&mut std::io::Cursor::new(buf)).unwrap();
+        assert_eq!(loaded.intervals["chr1"].len(), 2);
+        assert_eq!(loaded.end_maxima["chr1"], vec![200, 400]);
+        // Both derived fields are rebuilt, so the bounded path and the alias
+        // resolution are live immediately after load.
+        assert_eq!(loaded.resolve_chrom("1"), Some("chr1"));
+        assert_eq!(loaded.candidate_window("chr1", 350, 350), (1, 2));
+        assert_eq!(loaded.find_overlapping("chr1", 350, 350).len(), 1);
+        assert_eq!(loaded.find_overlapping("1", 350, 350).len(), 1);
+    }
+
+    #[test]
+    fn find_overlapping_accepts_any_chromosome_spelling() {
+        // The alias map replaced a per-query `chrom_aliases` call; the accepted
+        // spellings must be exactly the same set as before.
+        let mut index = IntervalIndex::new(test_header());
+        index.add(IntervalRecord { chrom: "chrM".into(), start: 100, end: 200, json: "{}".into() });
+        index.add(IntervalRecord { chrom: "1".into(), start: 10, end: 20, json: "{}".into() });
+        index.sort();
+
+        for alias in ["chrM", "M", "MT", "chrMT"] {
+            assert_eq!(
+                index.find_overlapping(alias, 150, 150).len(),
+                1,
+                "mito spelling {alias} should resolve"
+            );
+        }
+        // Bare-keyed contig reached from the chr-prefixed spelling and back.
+        assert_eq!(index.find_overlapping("1", 15, 15).len(), 1);
+        assert_eq!(index.find_overlapping("chr1", 15, 15).len(), 1);
+        // A contig the index does not hold resolves to nothing.
+        assert!(index.find_overlapping("chr9", 15, 15).is_empty());
+        assert_eq!(index.resolve_chrom("chr9"), None);
+    }
+
+    #[test]
+    fn add_registers_aliases_before_sort() {
+        // `add` extends the alias map eagerly, so an index that was populated
+        // but never sorted still resolves spellings (it falls back to the wide
+        // scan window, which `candidate_window`'s own test covers).
+        let mut index = IntervalIndex::new(test_header());
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 10, end: 20, json: "{}".into() });
+        assert_eq!(index.resolve_chrom("1"), Some("chr1"));
+        assert_eq!(index.find_overlapping("1", 15, 15).len(), 1);
+    }
+
+    #[test]
+    fn write_to_output_is_unchanged_by_the_derived_field() {
+        // Guards the on-disk format explicitly: the bytes `write_to` emits must
+        // equal magic + version + len + bincode((header, intervals)).
+        let mut index = IntervalIndex::new(test_header());
+        index.add(IntervalRecord { chrom: "chr1".into(), start: 5, end: 9, json: "{}".into() });
+        index.sort();
+
+        let mut actual = Vec::new();
+        index.write_to(&mut actual).unwrap();
+
+        let legacy = (index.header.clone(), index.intervals.clone());
+        let payload = bincode::serialize(&legacy).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(OSI_MAGIC);
+        expected.extend_from_slice(&SCHEMA_VERSION.to_le_bytes());
+        expected.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        expected.extend_from_slice(&payload);
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/fastvep-sa/src/kmer16.rs
+++ b/crates/fastvep-sa/src/kmer16.rs
@@ -39,6 +39,70 @@ impl Ord for LongVariant {
     }
 }
 
+/// A variant whose alleles cannot be 2-bit packed at all, because they contain
+/// a byte outside {A,C,G,T} — `N` runs and IUPAC ambiguity codes, which real
+/// ClinVar carries on ~0.015% of records.
+///
+/// Neither Var32 nor [`LongVariant`] can represent these: both encodings are
+/// 2 bits per base by construction. Rather than dropping them (which is what
+/// the writer used to do, with a `log::warn!` that no CLI logger was installed
+/// to show), a chunk keeps them in a third, small bucket that stores the allele
+/// bytes verbatim and is binary-searched on `(position, ref, alt)`.
+///
+/// Ordering is `(position, ref_allele, alt_allele)` so the writer's sort and the
+/// reader's `binary_search` agree; `idx` is excluded from comparison for the
+/// same reason it is in `LongVariant` — the query side does not know it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OtherVariant {
+    /// Genomic position (full, not within-chunk).
+    pub position: u32,
+    /// Index into the parallel value arrays for this chunk.
+    pub idx: u32,
+    /// REF allele bytes, verbatim.
+    pub ref_allele: Vec<u8>,
+    /// ALT allele bytes, verbatim.
+    pub alt_allele: Vec<u8>,
+}
+
+impl PartialEq for OtherVariant {
+    fn eq(&self, other: &Self) -> bool {
+        self.position == other.position
+            && self.ref_allele == other.ref_allele
+            && self.alt_allele == other.alt_allele
+    }
+}
+
+impl Eq for OtherVariant {}
+
+impl PartialOrd for OtherVariant {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OtherVariant {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.position
+            .cmp(&other.position)
+            .then_with(|| self.ref_allele.cmp(&other.ref_allele))
+            .then_with(|| self.alt_allele.cmp(&other.alt_allele))
+    }
+}
+
+/// Whether both alleles are 2-bit packable, i.e. contain only `ACGTacgt`.
+///
+/// The single predicate both the writer and the reader use to decide whether a
+/// variant belongs in the Var32/kmer16 index or in the verbatim
+/// [`OtherVariant`] bucket. Keeping it in one place is what stops the two sides
+/// from disagreeing about where a variant was filed.
+#[inline]
+pub fn is_acgt_only(ref_allele: &[u8], alt_allele: &[u8]) -> bool {
+    ref_allele
+        .iter()
+        .chain(alt_allele.iter())
+        .all(|b| base_to_bits(*b).is_some())
+}
+
 /// DNA base to 2-bit encoding. Returns `None` for non-ACGT bytes so callers
 /// can surface the problem instead of silently encoding `N`/IUPAC as 'T'.
 #[inline]

--- a/crates/fastvep-sa/src/reader.rs
+++ b/crates/fastvep-sa/src/reader.rs
@@ -6,7 +6,7 @@
 //! same block.
 
 use crate::block::{BlockEntry, SaBlock};
-use crate::common::{chrom_aliases, OSA_MAGIC};
+use crate::common::OSA_MAGIC;
 use crate::index::{BlockRef, SaIndex};
 use anyhow::Result;
 use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, SaMetadata};
@@ -211,6 +211,37 @@ impl SaReader {
         self.decompress_count.load(Ordering::Relaxed)
     }
 
+    /// Stream every record in the database, in `(chromosome, position)` order.
+    ///
+    /// Chromosomes are visited in sorted name order and each chromosome's blocks
+    /// in index order, so the output is deterministic and already satisfies the
+    /// ordering contract of the v2 `Osa2StreamWriter` - which is what
+    /// `sa-convert` needs to transcode a `.osa` into a `.osa2` without loading
+    /// either side into memory.
+    ///
+    /// Memory is bounded by one decompressed block at a time. Blocks do pass
+    /// through the shared block cache, so a full scan evicts whatever else was
+    /// warm in it; that is the right trade for a one-shot conversion and
+    /// irrelevant to the annotate path, which never calls this.
+    pub fn iter_records(&self) -> SaRecordIter<'_> {
+        let mut chroms: Vec<&String> = self.index.chromosomes.keys().collect();
+        chroms.sort();
+        SaRecordIter {
+            reader: self,
+            chroms,
+            chrom_pos: 0,
+            block_pos: 0,
+            buffered: Vec::new().into_iter(),
+            buffered_chrom: None,
+        }
+    }
+
+    /// The header view of this database, for a consumer that needs to reproduce
+    /// its identity (name, keys, matching semantics) in another format.
+    pub fn header(&self) -> &crate::index::IndexHeader {
+        &self.index.header
+    }
+
     /// The block cache this reader writes to: its private one if configured,
     /// otherwise the process-wide shared cache.
     fn cache(&self) -> &Mutex<BlockCache> {
@@ -339,6 +370,60 @@ impl SaReader {
     }
 }
 
+/// Iterator over every `(chromosome, record)` in a `.osa`, in
+/// `(chromosome, position)` order. Created by [`SaReader::iter_records`].
+pub struct SaRecordIter<'a> {
+    reader: &'a SaReader,
+    /// Chromosome keys in sorted order.
+    chroms: Vec<&'a String>,
+    chrom_pos: usize,
+    /// Index into the current chromosome's block list.
+    block_pos: usize,
+    /// Entries of the block currently being drained.
+    buffered: std::vec::IntoIter<BlockEntry>,
+    /// Which chromosome `buffered` belongs to.
+    buffered_chrom: Option<&'a str>,
+}
+
+impl<'a> Iterator for SaRecordIter<'a> {
+    type Item = Result<(&'a str, BlockEntry)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(entry) = self.buffered.next() {
+                // `buffered_chrom` is always set alongside `buffered`.
+                return Some(Ok((self.buffered_chrom?, entry)));
+            }
+
+            let chrom = *self.chroms.get(self.chrom_pos)?;
+            let blocks = match self.reader.index.chromosomes.get(chrom) {
+                Some(b) => b,
+                None => {
+                    self.chrom_pos += 1;
+                    self.block_pos = 0;
+                    continue;
+                }
+            };
+            let Some(block_ref) = blocks.get(self.block_pos) else {
+                self.chrom_pos += 1;
+                self.block_pos = 0;
+                continue;
+            };
+            self.block_pos += 1;
+
+            match self.reader.get_block(block_ref) {
+                // `get_block` hands back a shared `Arc`, so take a copy of the
+                // entries to drain. One block at a time keeps this bounded.
+                Ok(entries) => {
+                    self.buffered = entries.as_ref().clone().into_iter();
+                    self.buffered_chrom = Some(chrom.as_str());
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
 impl AnnotationProvider for SaReader {
     fn name(&self) -> &str {
         &self.metadata.name
@@ -385,14 +470,10 @@ impl AnnotationProvider for SaReader {
             return Ok(());
         }
 
-        // Honor the same chr*/bare/mitochondrial aliases as `find_blocks`
-        // so a preload on `chr1` against an index built with `1` (or vice
-        // versa) still primes the cache instead of silently no-op'ing.
-        let blocks = chrom_aliases(chrom)
-            .iter()
-            .find_map(|alias| self.index.chromosomes.get(alias))
-            .map(|v| v.as_slice());
-        let blocks = match blocks {
+        // Resolve through the index's own alias map, exactly as `find_blocks`
+        // does, so a preload on `chr1` against an index built with `1` (or vice
+        // versa) primes the same cache slots the queries will look in.
+        let blocks = match self.index.blocks_for_chrom(chrom).map(|v| v.as_slice()) {
             Some(b) => b,
             None => {
                 // A chromosome the caller asked about that is not in the

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -21,13 +21,13 @@
 //! first read of each entry, when the page is about to be touched anyway.
 
 use crate::chunk::{delta_decode, Chunk};
-use crate::common::chrom_aliases;
 use crate::fields::{Field, FieldType};
-use crate::kmer16::LongVariant;
+use crate::kmer16::{LongVariant, OtherVariant};
 use crate::var32;
 use crate::writer_v2::{read_u32_array, Osa2Metadata};
 use anyhow::{Context, Result};
 use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, SaMetadata};
+use fastvep_core::chrom_alias_map;
 use flate2::read::DeflateDecoder;
 use lru::LruCache;
 use memmap2::Mmap;
@@ -67,6 +67,15 @@ type ChunkKey = (u64, u64);
 fn chunk_bytes(c: &Chunk) -> usize {
     let v32 = c.var32s.len() * std::mem::size_of::<u32>();
     let longs = c.longs.len() * std::mem::size_of::<LongVariant>();
+    // The non-ACGT bucket carries its allele bytes on the heap, so account for
+    // those too rather than just the struct slots.
+    let others: usize = c
+        .others
+        .iter()
+        .map(|o| {
+            std::mem::size_of::<OtherVariant>() + o.ref_allele.len() + o.alt_allele.len()
+        })
+        .sum();
     let vals: usize = c
         .values
         .iter()
@@ -78,6 +87,7 @@ fn chunk_bytes(c: &Chunk) -> usize {
             .sum()
     });
     v32.saturating_add(longs)
+        .saturating_add(others)
         .saturating_add(vals)
         .saturating_add(blobs)
 }
@@ -183,12 +193,16 @@ pub struct Osa2Reader {
     fields: Vec<Field>,
     /// Categorical string lookup tables per field.
     string_tables: Vec<Vec<String>>,
-    /// On-disk chromosome name → small dense index. Serves two roles:
-    /// `resolve_chrom` uses the keys to canonicalize a query name before any
-    /// cache key is built (issue #37), and the index is folded into the chunk
-    /// cache key so that `chr1`'s chunk 0 and `chr2`'s chunk 0 (same numeric
+    /// On-disk chromosome name → small dense index, folded into the chunk cache
+    /// key so that `chr1`'s chunk 0 and `chr2`'s chunk 0 (same numeric
     /// `chunk_id`) never collide in the shared cache.
     chrom_index: HashMap<String, u32>,
+    /// Every accepted spelling of every chromosome in the archive → the
+    /// canonical on-disk name (issue #37). Built once at open so `resolve_chrom`
+    /// is one hash lookup with no allocation; it previously called
+    /// `chrom_aliases`, which allocates a `Vec<String>`, on every query of every
+    /// variant.
+    chrom_lookup: HashMap<String, String>,
 }
 
 impl Osa2Reader {
@@ -294,6 +308,10 @@ impl Osa2Reader {
             is_positional: metadata.is_positional,
         };
 
+        // Invert the alias rules over the archive's contig set once, so the
+        // per-query path is a single allocation-free hash lookup.
+        let chrom_lookup = chrom_alias_map(chrom_index.keys());
+
         Ok(Self {
             mmap,
             entries,
@@ -306,6 +324,7 @@ impl Osa2Reader {
             fields,
             string_tables,
             chrom_index,
+            chrom_lookup,
         })
     }
 
@@ -338,16 +357,16 @@ impl Osa2Reader {
     }
 
     /// Resolve a query chromosome name (`chr1`, `1`, `chrM`, `MT`, …) to the
-    /// canonical on-disk name present in the archive. Returns the input
-    /// unchanged when no alias matches — callers then naturally miss.
-    fn resolve_chrom(&self, chrom: &str) -> String {
-        if self.chrom_index.contains_key(chrom) {
-            return chrom.to_string();
-        }
-        chrom_aliases(chrom)
-            .into_iter()
-            .find(|alias| self.chrom_index.contains_key(alias))
-            .unwrap_or_else(|| chrom.to_string())
+    /// canonical on-disk name present in the archive, or `None` when the archive
+    /// has no contig by any accepted spelling of that name.
+    ///
+    /// Borrows the canonical name out of `chrom_lookup`, so a query costs one
+    /// hash lookup and no allocation. Callers must treat `None` as a miss rather
+    /// than probing with the raw input: a name the archive does not contain can
+    /// only ever produce an empty chunk, and looking it up anyway would pollute
+    /// the shared chunk cache with a key that never hits.
+    fn resolve_chrom(&self, chrom: &str) -> Option<&str> {
+        self.chrom_lookup.get(chrom).map(String::as_str)
     }
 
     /// Read and decompress one ZIP entry straight from the mmap, with no lock.
@@ -390,7 +409,25 @@ impl Osa2Reader {
             None => Vec::new(),
         };
 
+        // Variants whose alleles are not 2-bit packable (`N`/IUPAC). Absent from
+        // archives written before this bucket existed, and from every chunk that
+        // has none — so the common case is a missing-entry check.
+        let others: Vec<OtherVariant> = match self.read_entry(&format!("{}other.enc", prefix))? {
+            Some(buf) => bincode::deserialize(&buf).map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to deserialize non-ACGT variant block for chunk {}/{}: {}",
+                    chrom,
+                    chunk_id,
+                    e
+                )
+            })?,
+            None => Vec::new(),
+        };
+
         // Parallel value arrays (one per non-JsonBlob field, in field order).
+        // A synthesized all-missing column must span every value slot the chunk
+        // has — short, long, and non-ACGT — not just the short ones.
+        let row_count = var32s.len() + longs.len() + others.len();
         let mut values = Vec::new();
         for field in &self.fields {
             if field.ftype == FieldType::JsonBlob {
@@ -398,7 +435,7 @@ impl Osa2Reader {
             }
             match self.read_entry(&format!("{}{}.bin", prefix, field.alias))? {
                 Some(buf) => values.push(read_u32_array(&buf)?),
-                None => values.push(vec![field.missing_value; var32s.len()]),
+                None => values.push(vec![field.missing_value; row_count]),
             }
         }
 
@@ -425,6 +462,7 @@ impl Osa2Reader {
         Ok(Chunk {
             var32s,
             longs,
+            others,
             values,
             json_blobs,
         })
@@ -472,9 +510,11 @@ impl Osa2Reader {
         ref_allele: &[u8],
         alt_allele: &[u8],
     ) -> Result<Option<String>> {
-        let chrom = self.resolve_chrom(chrom);
+        let Some(chrom) = self.resolve_chrom(chrom) else {
+            return Ok(None);
+        };
         let chunk_id = pos >> self.metadata.chunk_bits;
-        let chunk = self.get_chunk(&chrom, chunk_id)?;
+        let chunk = self.get_chunk(chrom, chunk_id)?;
 
         if chunk.is_empty() {
             return Ok(None);
@@ -487,6 +527,9 @@ impl Osa2Reader {
         let idx = if self.metadata.is_positional {
             // Positional sources match by coordinate alone.
             chunk.find_short(var32::positional_key(within_pos))
+        } else if !crate::kmer16::is_acgt_only(ref_allele, alt_allele) {
+            // Mirrors the writer's bucketing decision, via the same predicate.
+            chunk.find_other(pos, ref_allele, alt_allele)
         } else if var32::is_long(ref_allele.len(), alt_allele.len()) {
             chunk.find_long(pos, ref_allele, alt_allele)
         } else {
@@ -613,8 +656,11 @@ impl AnnotationProvider for Osa2Reader {
             return Ok(());
         }
         // Canonicalize once so preloaded chunks share cache keys with the
-        // `annotate_position` calls that follow.
-        let chrom = self.resolve_chrom(chrom);
+        // `annotate_position` calls that follow. A chromosome the archive does
+        // not carry has nothing to warm.
+        let Some(chrom) = self.resolve_chrom(chrom) else {
+            return Ok(());
+        };
 
         let mut chunk_ids: Vec<u32> = Vec::with_capacity(positions.len());
         for &p in positions {
@@ -627,7 +673,7 @@ impl AnnotationProvider for Osa2Reader {
         chunk_ids.dedup();
 
         for cid in chunk_ids {
-            self.get_chunk(&chrom, cid)?;
+            self.get_chunk(chrom, cid)?;
         }
         Ok(())
     }

--- a/crates/fastvep-sa/src/sources/mitomap.rs
+++ b/crates/fastvep-sa/src/sources/mitomap.rs
@@ -1,9 +1,35 @@
 //! MitoMap mitochondrial variant parser.
 
 use crate::common::{escape_json, AnnotationRecord};
+use crate::writer_v2::Osa2Metadata;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
+
+/// Standard MitoMap `.osa2` metadata. The payload is free-text disease and
+/// review-status strings, so it is stored as a whole-record JSON blob per
+/// variant (see [`crate::writer_v2::raw_json_blob_fields`]) rather than split
+/// into numeric columns.
+///
+/// MitoMap is a few thousand records, so v2 buys no measurable speed or space
+/// here. It is wired up so that a `--sa-dir` can be entirely v2: with every
+/// variant-level source building to `.osa2`, an operator never has to reason
+/// about which of their sources landed in which format, and the v1 reader is
+/// needed only to read databases built before the migration.
+pub fn mitomap_osa2_metadata(assembly: &str) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "MitoMap".into(),
+        version: "latest".into(),
+        assembly: assembly.into(),
+        json_key: "mitomap".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: format!("MitoMap mitochondrial variants for {assembly}"),
+    }
+}
 
 /// Parse a MitoMap variants TSV (pos, ref, alt, disease, status).
 pub fn parse_mitomap<R: BufRead>(

--- a/crates/fastvep-sa/src/sources/spliceai.rs
+++ b/crates/fastvep-sa/src/sources/spliceai.rs
@@ -1,13 +1,185 @@
-//! SpliceAI VCF parser for building .osa annotation files.
+//! SpliceAI VCF parser for building .osa (v1) and .osa2 (v2) annotation files.
 //!
 //! SpliceAI provides splice site effect predictions with delta scores
 //! for acceptor/donor gain/loss and their positions.
+//!
+//! SpliceAI is the densest supplementary source fastVEP ships against - the
+//! precomputed whole-genome SNV release is billions of records - and its payload
+//! is eight numbers plus a gene symbol. That makes it the best fit of any source
+//! for the v2 `.osa2` layout: eight parallel u32 columns plus one categorical
+//! index column against a gene string table, instead of a ~120-byte JSON object
+//! repeated per record. So SpliceAI builds natively into v2 (see
+//! [`iter_spliceai_osa2`]) rather than going through the whole-record JSON blob
+//! bridge.
+//!
+//! As with AlphaMissense, the v1 `.osa` path builds each record's JSON through
+//! the very same [`Field`]/[`format_value`] code the v2 reader reconstructs
+//! with, so the two formats emit byte-identical annotations.
 
 use crate::common::AnnotationRecord;
+use crate::fields::{format_value, Field, FieldType};
+use crate::writer_v2::{Osa2Metadata, Osa2Record};
 use anyhow::{Context, Result};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::io::BufRead;
+use std::rc::Rc;
+
+/// Field index of the gene symbol within [`spliceai_osa2_fields`]. The gene is
+/// the only categorical field, so this is the index its string table is filed
+/// under.
+pub const GENE_FIELD: usize = 8;
+
+/// Upper bound on distinct gene symbols admitted into the categorical string
+/// table. Real SpliceAI releases carry a few tens of thousands of symbols; a
+/// table running into the millions means the `gene` column of the input is not
+/// a gene symbol at all, and silently accumulating it would grow unbounded in
+/// memory during a multi-hour genome-scale build.
+const MAX_GENE_TABLE: usize = 1_000_000;
+
+/// Canonical SpliceAI `.osa2` field schema.
+///
+/// Field order is the JSON key order both formats emit. It is deliberately
+/// alphabetical by alias (`dpAg`..`dsDl`, then `gene`) because that is the order
+/// the historical v1 builder produced - it built the object with `serde_json`,
+/// whose default `Map` is a `BTreeMap` - so routing v1 through `format_value`
+/// changes only the *numeric formatting* of the payload, not its key order.
+///
+/// * delta scores (`DS_*`) are floats in `[0, 1]`; the released files carry two
+///   decimals, so a 1e6 multiplier is comfortably lossless.
+/// * delta positions (`DP_*`) are signed offsets in bases, hence zigzag
+///   integers.
+pub fn spliceai_osa2_fields() -> Vec<Field> {
+    let dp = |field: &str, alias: &str, what: &str| Field {
+        field: field.into(),
+        alias: alias.into(),
+        ftype: FieldType::Integer,
+        multiplier: 1,
+        zigzag: true,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: format!("SpliceAI delta position, {what}"),
+    };
+    let ds = |field: &str, alias: &str, what: &str| Field {
+        field: field.into(),
+        alias: alias.into(),
+        ftype: FieldType::Float,
+        multiplier: 1_000_000,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: format!("SpliceAI delta score, {what}"),
+    };
+    vec![
+        dp("DP_AG", "dpAg", "acceptor gain"),
+        dp("DP_AL", "dpAl", "acceptor loss"),
+        dp("DP_DG", "dpDg", "donor gain"),
+        dp("DP_DL", "dpDl", "donor loss"),
+        ds("DS_AG", "dsAg", "acceptor gain"),
+        ds("DS_AL", "dsAl", "acceptor loss"),
+        ds("DS_DG", "dsDg", "donor gain"),
+        ds("DS_DL", "dsDl", "donor loss"),
+        Field {
+            field: "SYMBOL".into(),
+            alias: "gene".into(),
+            ftype: FieldType::Categorical,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Gene symbol the prediction is relative to".into(),
+        },
+    ]
+}
+
+/// Standard SpliceAI `.osa2` metadata (`json_key = "spliceAI"`, allele-matched,
+/// non-positional) - the same view the v1 `.osa` header carries.
+pub fn spliceai_osa2_metadata(assembly: &str) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "SpliceAI".into(),
+        version: "latest".into(),
+        assembly: assembly.into(),
+        json_key: "spliceAI".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: format!("SpliceAI splice site predictions for {assembly}"),
+    }
+}
+
+/// Accumulates the distinct gene symbols seen while a SpliceAI input streams
+/// past, assigning each a stable u32 index for the `gene` column.
+///
+/// The `.osa2` categorical string table is global to the archive, but the
+/// symbols are only discovered as records go by, so the table cannot be known
+/// up front the way AlphaMissense's fixed three-class table can. A cheap shared
+/// handle lets the record iterator intern as it goes while the build driver
+/// keeps a clone to hand the finished table to the writer just before the
+/// archive is finalized. Single-threaded by construction: the v2 build loop
+/// pushes records on one thread.
+#[derive(Clone, Default)]
+pub struct GeneInterner(Rc<RefCell<GeneTable>>);
+
+#[derive(Default)]
+struct GeneTable {
+    index: HashMap<String, u32>,
+    order: Vec<String>,
+}
+
+impl GeneInterner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Index for `gene`, assigning a fresh one on first sight.
+    ///
+    /// Errors past [`MAX_GENE_TABLE`] distinct symbols rather than growing
+    /// without bound - see that constant for why.
+    pub fn intern(&self, gene: &str) -> Result<u32> {
+        let mut table = self.0.borrow_mut();
+        if let Some(&idx) = table.index.get(gene) {
+            return Ok(idx);
+        }
+        if table.order.len() >= MAX_GENE_TABLE {
+            anyhow::bail!(
+                "SpliceAI gene column has more than {} distinct values (at '{}'); \
+                 this does not look like a SpliceAI VCF",
+                MAX_GENE_TABLE,
+                gene
+            );
+        }
+        let idx = table.order.len() as u32;
+        table.order.push(gene.to_string());
+        table.index.insert(gene.to_string(), idx);
+        Ok(idx)
+    }
+
+    /// The string table in index order, ready for `set_string_table`.
+    pub fn table(&self) -> Vec<String> {
+        self.0.borrow().order.clone()
+    }
+
+    /// The `(field_idx, table)` pairing the v2 writer takes.
+    pub fn string_tables(&self) -> Vec<(usize, Vec<String>)> {
+        vec![(GENE_FIELD, self.table())]
+    }
+}
+
+/// One parsed `SpliceAI=` entry: the variant key plus the nine stored values.
+struct SpliceAiRow {
+    chrom_idx: u16,
+    position: u32,
+    ref_allele: String,
+    alt_allele: String,
+    gene: String,
+    /// `[DP_AG, DP_AL, DP_DG, DP_DL]`, in field-config order.
+    dp: [i32; 4],
+    /// `[DS_AG, DS_AL, DS_DG, DS_DL]`, in field-config order.
+    ds: [f64; 4],
+}
 
 /// Parse a SpliceAI VCF and produce sorted AnnotationRecords.
 ///
@@ -31,25 +203,167 @@ pub fn iter_spliceai_vcf<'a, R: BufRead>(
     chrom_to_idx: &'a HashMap<String, u16>,
 ) -> SpliceAiRecordIter<'a, R> {
     SpliceAiRecordIter {
-        lines: reader.lines(),
-        chrom_to_idx,
-        pending: VecDeque::new(),
+        rows: SpliceAiRowIter::new(reader, chrom_to_idx),
+        fields: spliceai_osa2_fields(),
     }
 }
 
 pub struct SpliceAiRecordIter<'a, R: BufRead> {
-    lines: std::io::Lines<R>,
-    chrom_to_idx: &'a HashMap<String, u16>,
-    pending: VecDeque<AnnotationRecord>,
+    rows: SpliceAiRowIter<'a, R>,
+    fields: Vec<Field>,
 }
 
 impl<R: BufRead> Iterator for SpliceAiRecordIter<'_, R> {
     type Item = Result<AnnotationRecord>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let row = match self.rows.next()? {
+            Ok(row) => row,
+            Err(e) => return Some(Err(e)),
+        };
+        let json = row_json(&row, &self.fields);
+        Some(Ok(AnnotationRecord {
+            chrom_idx: row.chrom_idx,
+            position: row.position,
+            ref_allele: row.ref_allele,
+            alt_allele: row.alt_allele,
+            json,
+        }))
+    }
+}
+
+/// Stream a coordinate-sorted SpliceAI VCF directly as v2 `Osa2Record`s:
+/// eight numeric columns plus a `gene` index interned into `genes`.
+///
+/// Every parsed entry is emitted, including the several a variant in overlapping
+/// genes produces for one (position, ref, alt) key. Collapsing those to the
+/// first - which is the only one either reader can return - is the writer's job
+/// (see `writer_v2::write_chunk_entries`), so that every source gets the same
+/// treatment rather than each parser reimplementing it.
+pub fn iter_spliceai_osa2<'a, R: BufRead>(
+    reader: R,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    chrom_list: &'a [String],
+    genes: GeneInterner,
+) -> SpliceAiOsa2Iter<'a, R> {
+    SpliceAiOsa2Iter {
+        rows: SpliceAiRowIter::new(reader, chrom_to_idx),
+        chrom_list,
+        fields: spliceai_osa2_fields(),
+        genes,
+    }
+}
+
+pub struct SpliceAiOsa2Iter<'a, R: BufRead> {
+    rows: SpliceAiRowIter<'a, R>,
+    chrom_list: &'a [String],
+    fields: Vec<Field>,
+    genes: GeneInterner,
+}
+
+impl<R: BufRead> Iterator for SpliceAiOsa2Iter<'_, R> {
+    type Item = Result<Osa2Record>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row = match self.rows.next()? {
+            Ok(row) => row,
+            Err(e) => return Some(Err(e)),
+        };
+        let chrom = match self.chrom_list.get(row.chrom_idx as usize) {
+            Some(c) => c.clone(),
+            None => {
+                return Some(Err(anyhow::anyhow!(
+                    "chrom_idx {} out of range",
+                    row.chrom_idx
+                )))
+            }
+        };
+        let gene_idx = match self.genes.intern(&row.gene) {
+            Ok(idx) => idx,
+            Err(e) => return Some(Err(e)),
+        };
+        let values = encode_values(&row, &self.fields, gene_idx);
+        Some(Ok(Osa2Record {
+            chrom,
+            position: row.position,
+            ref_allele: row.ref_allele.into_bytes(),
+            alt_allele: row.alt_allele.into_bytes(),
+            values,
+            json_blob: None,
+        }))
+    }
+}
+
+/// Encode one row into the parallel u32 value vector, in field-config order.
+fn encode_values(row: &SpliceAiRow, fields: &[Field], gene_idx: u32) -> Vec<u32> {
+    let mut values = Vec::with_capacity(fields.len());
+    for (i, dp) in row.dp.iter().enumerate() {
+        values.push(fields[i].encode_int(*dp as i64));
+    }
+    for (i, ds) in row.ds.iter().enumerate() {
+        values.push(fields[4 + i].encode_float(*ds));
+    }
+    values.push(gene_idx);
+    debug_assert_eq!(values.len(), fields.len());
+    values
+}
+
+/// Build the flat-object JSON for one row through the same `Field` encode →
+/// `format_value` path the v2 reader reconstructs with, so v1 `.osa` and v2
+/// `.osa2` emit byte-identical annotations. Fields are emitted in config order
+/// and a missing value is omitted, matching `Chunk::reconstruct_json`.
+fn row_json(row: &SpliceAiRow, fields: &[Field]) -> String {
+    // The gene's stored index is 0 against a one-entry table: the v2 archive
+    // uses a global table, but the rendered value depends only on the string it
+    // resolves to, so a local table gives the identical output here.
+    let gene_table = [row.gene.clone()];
+    let values = encode_values(row, fields, 0);
+
+    let mut parts: Vec<String> = Vec::with_capacity(fields.len());
+    for (i, field) in fields.iter().enumerate() {
+        let stored = values[i];
+        if stored == field.missing_value {
+            continue;
+        }
+        let strings = if field.ftype == FieldType::Categorical {
+            Some(&gene_table[..])
+        } else {
+            None
+        };
+        let rendered = format_value(field, stored, strings);
+        if rendered != "null" {
+            parts.push(format!("\"{}\":{}", field.alias, rendered));
+        }
+    }
+    format!("{{{}}}", parts.join(","))
+}
+
+/// The shared front end: turns VCF lines into [`SpliceAiRow`]s. Both the v1 and
+/// v2 iterators wrap this so the two formats can never drift on parsing,
+/// chromosome normalization, or which records are skipped.
+struct SpliceAiRowIter<'a, R: BufRead> {
+    lines: std::io::Lines<R>,
+    chrom_to_idx: &'a HashMap<String, u16>,
+    pending: VecDeque<SpliceAiRow>,
+}
+
+impl<'a, R: BufRead> SpliceAiRowIter<'a, R> {
+    fn new(reader: R, chrom_to_idx: &'a HashMap<String, u16>) -> Self {
+        Self {
+            lines: reader.lines(),
+            chrom_to_idx,
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+impl<R: BufRead> Iterator for SpliceAiRowIter<'_, R> {
+    type Item = Result<SpliceAiRow>;
+
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(record) = self.pending.pop_front() {
-                return Some(Ok(record));
+            if let Some(row) = self.pending.pop_front() {
+                return Some(Ok(row));
             }
 
             let line = match self.lines.next()? {
@@ -76,16 +390,14 @@ impl<R: BufRead> Iterator for SpliceAiRecordIter<'_, R> {
                 Err(_) => continue,
             };
 
-            let ref_allele = fields[3].to_string();
+            let ref_allele = fields[3];
             let info = fields[7];
 
             for pair in info.split(';') {
                 if let Some(val) = pair.strip_prefix("SpliceAI=") {
                     for entry in val.split(',') {
-                        if let Some(record) =
-                            parse_spliceai_entry(chrom_idx, pos, &ref_allele, entry)
-                        {
-                            self.pending.push_back(record);
+                        if let Some(row) = parse_spliceai_entry(chrom_idx, pos, ref_allele, entry) {
+                            self.pending.push_back(row);
                         }
                     }
                 }
@@ -99,42 +411,30 @@ fn parse_spliceai_entry(
     position: u32,
     ref_allele: &str,
     entry: &str,
-) -> Option<AnnotationRecord> {
+) -> Option<SpliceAiRow> {
     let parts: Vec<&str> = entry.split('|').collect();
     if parts.len() < 10 {
         return None;
     }
 
-    let alt_allele = parts[0].to_string();
-    let gene = parts[1];
-    let ds_ag: f64 = parts[2].parse().ok()?;
-    let ds_al: f64 = parts[3].parse().ok()?;
-    let ds_dg: f64 = parts[4].parse().ok()?;
-    let ds_dl: f64 = parts[5].parse().ok()?;
-    let dp_ag: i32 = parts[6].parse().ok()?;
-    let dp_al: i32 = parts[7].parse().ok()?;
-    let dp_dg: i32 = parts[8].parse().ok()?;
-    let dp_dl: i32 = parts[9].parse().ok()?;
-
-    let json = serde_json::json!({
-        "gene": gene,
-        "dsAg": ds_ag,
-        "dsAl": ds_al,
-        "dsDg": ds_dg,
-        "dsDl": ds_dl,
-        "dpAg": dp_ag,
-        "dpAl": dp_al,
-        "dpDg": dp_dg,
-        "dpDl": dp_dl,
-    })
-    .to_string();
-
-    Some(AnnotationRecord {
+    Some(SpliceAiRow {
         chrom_idx,
         position,
         ref_allele: ref_allele.to_string(),
-        alt_allele,
-        json,
+        alt_allele: parts[0].to_string(),
+        gene: parts[1].to_string(),
+        ds: [
+            parts[2].parse().ok()?,
+            parts[3].parse().ok()?,
+            parts[4].parse().ok()?,
+            parts[5].parse().ok()?,
+        ],
+        dp: [
+            parts[6].parse().ok()?,
+            parts[7].parse().ok()?,
+            parts[8].parse().ok()?,
+            parts[9].parse().ok()?,
+        ],
     })
 }
 
@@ -150,51 +450,55 @@ fn normalize_chrom(chrom: &str) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_spliceai_vcf() {
-        let vcf = "\
+    const SAMPLE: &str = "\
 ##fileformat=VCFv4.0
 ##INFO=<ID=SpliceAI,Number=.,Type=String>
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
 1\t25000\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|0.01|0.00|0.85|0.00|5|-28|2|-13
 1\t30000\t.\tC\tT,A\t.\t.\tSpliceAI=T|GENE2|0.00|0.10|0.00|0.92|3|-5|10|-2,A|GENE2|0.50|0.00|0.00|0.00|7|0|0|0
 ";
-        let mut chrom_map = HashMap::new();
-        chrom_map.insert("chr1".into(), 0u16);
 
-        let records = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+    fn chrom_map() -> HashMap<String, u16> {
+        let mut m = HashMap::new();
+        m.insert("chr1".into(), 0u16);
+        m
+    }
+
+    fn chrom_list() -> Vec<String> {
+        vec!["chr1".to_string()]
+    }
+
+    /// Field indices, for readability in the assertions below.
+    const DP_AG: usize = 0;
+    const DS_AG: usize = 4;
+    const DS_DG: usize = 6;
+    const DS_DL: usize = 7;
+
+    #[test]
+    fn test_parse_spliceai_vcf() {
+        let records = parse_spliceai_vcf(SAMPLE.as_bytes(), &chrom_map()).unwrap();
         assert_eq!(records.len(), 3);
 
         assert_eq!(records[0].position, 25000);
         assert_eq!(records[0].alt_allele, "G");
         let first: serde_json::Value = serde_json::from_str(&records[0].json).unwrap();
         assert_eq!(first["gene"], "GENE1");
-        assert_eq!(first["dsDg"], 0.85);
+        assert!((first["dsDg"].as_f64().unwrap() - 0.85).abs() < 1e-9);
 
         assert_eq!(records[1].position, 30000);
         assert_eq!(records[1].alt_allele, "T");
         let second: serde_json::Value = serde_json::from_str(&records[1].json).unwrap();
-        assert_eq!(second["dsDl"], 0.92);
+        assert!((second["dsDl"].as_f64().unwrap() - 0.92).abs() < 1e-9);
 
         assert_eq!(records[2].position, 30000);
         assert_eq!(records[2].alt_allele, "A");
         let third: serde_json::Value = serde_json::from_str(&records[2].json).unwrap();
-        assert_eq!(third["dsAg"], 0.50);
+        assert!((third["dsAg"].as_f64().unwrap() - 0.50).abs() < 1e-9);
     }
 
     #[test]
     fn test_iter_spliceai_vcf_streams_records() {
-        let vcf = "\
-##fileformat=VCFv4.0
-##INFO=<ID=SpliceAI,Number=.,Type=String>
-#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
-1\t25000\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|0.01|0.00|0.85|0.00|5|-28|2|-13
-1\t30000\t.\tC\tT,A\t.\t.\tSpliceAI=T|GENE2|0.00|0.10|0.00|0.92|3|-5|10|-2,A|GENE2|0.50|0.00|0.00|0.00|7|0|0|0
-";
-        let mut chrom_map = HashMap::new();
-        chrom_map.insert("chr1".into(), 0u16);
-
-        let records: Vec<_> = iter_spliceai_vcf(vcf.as_bytes(), &chrom_map)
+        let records: Vec<_> = iter_spliceai_vcf(SAMPLE.as_bytes(), &chrom_map())
             .collect::<Result<Vec<_>>>()
             .unwrap();
 
@@ -211,16 +515,158 @@ mod tests {
     fn test_parse_spliceai_vcf_escapes_gene_for_json() {
         let vcf = "\
 ##fileformat=VCFv4.0
-##INFO=<ID=SpliceAI,Number=.,Type=String>
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
 1\t25000\t.\tA\tG\t.\t.\tSpliceAI=G|GENE\"1|0.01|0.00|0.85|0.00|5|-28|2|-13
 ";
-        let mut chrom_map = HashMap::new();
-        chrom_map.insert("chr1".into(), 0u16);
-
-        let records = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map).unwrap();
+        let records = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map()).unwrap();
         assert_eq!(records.len(), 1);
         let value: serde_json::Value = serde_json::from_str(&records[0].json).unwrap();
         assert_eq!(value["gene"], "GENE\"1");
+    }
+
+    #[test]
+    fn v1_json_keys_stay_in_the_historical_alphabetical_order() {
+        // The pre-v2 builder emitted the object through serde_json, whose
+        // default Map is a BTreeMap, so keys came out alphabetically. Routing
+        // v1 through `format_value` must not reshuffle them.
+        let records = parse_spliceai_vcf(SAMPLE.as_bytes(), &chrom_map()).unwrap();
+        let keys: Vec<&str> = records[0]
+            .json
+            .trim_matches(|c| c == '{' || c == '}')
+            .split(',')
+            .map(|kv| kv.split(':').next().unwrap().trim_matches('"'))
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["dpAg", "dpAl", "dpDg", "dpDl", "dsAg", "dsAl", "dsDg", "dsDl", "gene"]
+        );
+    }
+
+    #[test]
+    fn v2_records_encode_scores_positions_and_gene_index() {
+        let genes = GeneInterner::new();
+        let recs: Vec<_> =
+            iter_spliceai_osa2(SAMPLE.as_bytes(), &chrom_map(), &chrom_list(), genes.clone())
+                .collect::<Result<_>>()
+                .unwrap();
+        assert_eq!(recs.len(), 3);
+
+        let fields = spliceai_osa2_fields();
+        assert_eq!(recs[0].chrom, "chr1");
+        assert_eq!(recs[0].position, 25000);
+        assert_eq!(recs[0].values[DS_DG], fields[DS_DG].encode_float(0.85));
+        assert_eq!(recs[0].values[DP_AG], fields[DP_AG].encode_int(5));
+        // Negative delta positions survive via zigzag.
+        assert_eq!(fields[1].decode_int(recs[0].values[1]), -28);
+
+        assert_eq!(recs[1].values[DS_DL], fields[DS_DL].encode_float(0.92));
+        assert_eq!(recs[2].values[DS_AG], fields[DS_AG].encode_float(0.50));
+
+        // Two distinct symbols across the sample, interned in first-seen order.
+        assert_eq!(genes.table(), vec!["GENE1".to_string(), "GENE2".to_string()]);
+        assert_eq!(recs[0].values[GENE_FIELD], 0);
+        assert_eq!(recs[1].values[GENE_FIELD], 1);
+        assert_eq!(recs[2].values[GENE_FIELD], 1);
+        assert_eq!(genes.string_tables(), vec![(GENE_FIELD, genes.table())]);
+    }
+
+    #[test]
+    fn v1_and_v2_reconstruct_identical_json() {
+        // The whole point of routing both formats through Field/format_value:
+        // a record's v1 JSON must equal what the v2 reader rebuilds from the
+        // encoded columns and the global gene table.
+        let genes = GeneInterner::new();
+        let v1 = parse_spliceai_vcf(SAMPLE.as_bytes(), &chrom_map()).unwrap();
+        let v2: Vec<_> =
+            iter_spliceai_osa2(SAMPLE.as_bytes(), &chrom_map(), &chrom_list(), genes.clone())
+                .collect::<Result<_>>()
+                .unwrap();
+        let fields = spliceai_osa2_fields();
+        let table = genes.table();
+
+        assert_eq!(v1.len(), v2.len());
+        for (r1, r2) in v1.iter().zip(v2.iter()) {
+            let mut parts = Vec::new();
+            for (i, field) in fields.iter().enumerate() {
+                let stored = r2.values[i];
+                if stored == field.missing_value {
+                    continue;
+                }
+                let strings = if field.ftype == FieldType::Categorical {
+                    Some(&table[..])
+                } else {
+                    None
+                };
+                let rendered = format_value(field, stored, strings);
+                if rendered != "null" {
+                    parts.push(format!("\"{}\":{}", field.alias, rendered));
+                }
+            }
+            assert_eq!(r1.json, format!("{{{}}}", parts.join(",")));
+        }
+    }
+
+    #[test]
+    fn multi_gene_entries_are_all_emitted_in_input_order() {
+        // A variant in two overlapping genes yields two entries for one
+        // (position, ref, alt) key. Both iterators emit both, in input order —
+        // collapsing to the first is the writer's job, and it relies on that
+        // order to know which one "first" is.
+        let vcf = "\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t500\t.\tA\tG\t.\t.\tSpliceAI=G|FIRST|0.10|0.00|0.00|0.00|1|0|0|0,G|SECOND|0.90|0.00|0.00|0.00|2|0|0|0
+1\t500\t.\tA\tT\t.\t.\tSpliceAI=T|THIRD|0.30|0.00|0.00|0.00|3|0|0|0
+";
+        let v1 = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map()).unwrap();
+        assert_eq!(v1.len(), 3);
+
+        let genes = GeneInterner::new();
+        let v2: Vec<_> =
+            iter_spliceai_osa2(vcf.as_bytes(), &chrom_map(), &chrom_list(), genes.clone())
+                .collect::<Result<_>>()
+                .unwrap();
+        assert_eq!(v2.len(), 3, "the iterator must not drop the second gene");
+
+        let fields = spliceai_osa2_fields();
+        let gene_of = |r: &Osa2Record| genes.table()[r.values[GENE_FIELD] as usize].clone();
+        assert_eq!(gene_of(&v2[0]), "FIRST");
+        assert_eq!(v2[0].values[DS_AG], fields[DS_AG].encode_float(0.10));
+        assert_eq!(gene_of(&v2[1]), "SECOND");
+        assert_eq!(v2[1].values[DS_AG], fields[DS_AG].encode_float(0.90));
+        assert_eq!(gene_of(&v2[2]), "THIRD");
+        assert_eq!(v2[2].alt_allele, b"T");
+    }
+
+    #[test]
+    fn gene_interner_assigns_stable_indices_and_dedups() {
+        let genes = GeneInterner::new();
+        assert_eq!(genes.intern("A").unwrap(), 0);
+        assert_eq!(genes.intern("B").unwrap(), 1);
+        assert_eq!(genes.intern("A").unwrap(), 0);
+        assert_eq!(genes.table(), vec!["A".to_string(), "B".to_string()]);
+        // Clones share the same table.
+        let other = genes.clone();
+        assert_eq!(other.intern("C").unwrap(), 2);
+        assert_eq!(genes.table().len(), 3);
+    }
+
+    #[test]
+    fn malformed_entries_are_skipped_by_both_formats() {
+        // Too few pipe-separated parts, and an unparseable score.
+        let vcf = "\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t100\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|0.01
+1\t200\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|abc|0.00|0.00|0.00|1|2|3|4
+1\t300\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|0.01|0.00|0.00|0.00|1|2|3|4
+";
+        let v1 = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map()).unwrap();
+        let v2: Vec<_> =
+            iter_spliceai_osa2(vcf.as_bytes(), &chrom_map(), &chrom_list(), GeneInterner::new())
+                .collect::<Result<_>>()
+                .unwrap();
+        assert_eq!(v1.len(), 1);
+        assert_eq!(v2.len(), 1);
+        assert_eq!(v1[0].position, 300);
+        assert_eq!(v2[0].position, 300);
     }
 }

--- a/crates/fastvep-sa/src/writer_v2.rs
+++ b/crates/fastvep-sa/src/writer_v2.rs
@@ -6,7 +6,7 @@
 use crate::chunk::delta_encode;
 use crate::common::AnnotationRecord;
 use crate::fields::{Field, FieldType};
-use crate::kmer16::{self, LongVariant};
+use crate::kmer16::{self, LongVariant, OtherVariant};
 use crate::var32;
 use anyhow::{Context, Result};
 use std::io::{Seek, Write};
@@ -158,14 +158,20 @@ fn write_string_tables<W: Write + Seek>(
 /// into the archive.
 ///
 /// The value/JSON-blob columns are laid out as
-/// `[short variants in Var32-sorted order] ++ [long variants in sorted order]`,
-/// and each `LongVariant.idx` is set to the slot that variant occupies in that
-/// combined layout. This keeps a single value slot per variant that both the
-/// short (`binary_search` position) and long (`LongVariant.idx`) lookup paths
-/// resolve to consistently. An earlier revision set `idx` to the record's
+/// `[short variants in Var32-sorted order] ++ [long variants in sorted order] ++
+/// [non-ACGT variants in sorted order]`, and each `LongVariant.idx` /
+/// `OtherVariant.idx` is set to the slot that variant occupies in that combined
+/// layout. This keeps a single value slot per variant that all three lookup
+/// paths resolve to consistently. An earlier revision set `idx` to the record's
 /// input-order position and only stored short variants in the value columns,
 /// so any chunk mixing short and long variants returned the wrong values for
 /// its indels (and long-only chunks were unreadable).
+///
+/// The third bucket exists because both Var32 and kmer16 are 2 bits per base and
+/// therefore cannot represent `N` or IUPAC codes. Such records used to be
+/// dropped here with a `log::warn!` that the CLI installs no logger to display —
+/// silent data loss on 668 of 4,438,232 real ClinVar records. They are now
+/// stored with their allele bytes verbatim.
 fn write_chunk_entries<W: Write + Seek>(
     zip: &mut zip::ZipWriter<W>,
     options: zip::write::SimpleFileOptions,
@@ -183,6 +189,7 @@ fn write_chunk_entries<W: Write + Seek>(
     // in the combined short-then-long order.
     let mut short_entries: Vec<(u32, usize)> = Vec::new(); // (var32_key, local_idx)
     let mut long_entries: Vec<(LongVariant, usize)> = Vec::new(); // (variant, local_idx)
+    let mut other_entries: Vec<(OtherVariant, usize)> = Vec::new(); // non-ACGT alleles
 
     for (local_idx, record) in chunk_records.iter().enumerate() {
         let within_chunk_pos = record.position & chunk_mask;
@@ -191,56 +198,95 @@ fn write_chunk_entries<W: Write + Seek>(
             // Positional sources match by coordinate alone; key on position
             // only (alleles are empty) and never take the long-variant path.
             short_entries.push((var32::positional_key(within_chunk_pos), local_idx));
-        } else if var32::is_long(record.ref_allele.len(), record.alt_allele.len()) {
-            // Skip variants whose alleles contain non-ACGT bases. Earlier
-            // revisions silently encoded them as runs of 'T', producing index
-            // entries that could never be retrieved with their original allele
-            // string.
-            let Some(sequence) = kmer16::encode_var(&record.ref_allele, &record.alt_allele) else {
-                log::warn!(
-                    "Skipping long variant at {}:{} with non-ACGT allele (ref={:?} alt={:?})",
-                    chrom,
-                    record.position,
-                    String::from_utf8_lossy(&record.ref_allele),
-                    String::from_utf8_lossy(&record.alt_allele),
-                );
-                continue;
-            };
-            long_entries.push((
-                LongVariant { position: record.position, idx: 0, sequence },
+        } else if !kmer16::is_acgt_only(&record.ref_allele, &record.alt_allele) {
+            // `N`/IUPAC alleles: neither 2-bit encoding can represent them, so
+            // they go in the verbatim bucket instead of being dropped.
+            other_entries.push((
+                OtherVariant {
+                    position: record.position,
+                    idx: 0,
+                    ref_allele: record.ref_allele.clone(),
+                    alt_allele: record.alt_allele.clone(),
+                },
                 local_idx,
             ));
+        } else if var32::is_long(record.ref_allele.len(), record.alt_allele.len()) {
+            // ACGT-only by the branch above, so this cannot fail; treat a
+            // failure as the non-ACGT case rather than dropping the record.
+            match kmer16::encode_var(&record.ref_allele, &record.alt_allele) {
+                Some(sequence) => long_entries.push((
+                    LongVariant { position: record.position, idx: 0, sequence },
+                    local_idx,
+                )),
+                None => other_entries.push((
+                    OtherVariant {
+                        position: record.position,
+                        idx: 0,
+                        ref_allele: record.ref_allele.clone(),
+                        alt_allele: record.alt_allele.clone(),
+                    },
+                    local_idx,
+                )),
+            }
         } else if let Some(key) =
             var32::encode(within_chunk_pos, &record.ref_allele, &record.alt_allele)
         {
             short_entries.push((key, local_idx));
         } else {
-            // Short variant that fails Var32 encoding only when it contains a
-            // non-ACGT base; same skip-with-warning policy.
-            log::warn!(
-                "Skipping short variant at {}:{} with non-ACGT allele (ref={:?} alt={:?})",
-                chrom,
-                record.position,
-                String::from_utf8_lossy(&record.ref_allele),
-                String::from_utf8_lossy(&record.alt_allele),
-            );
+            // Same reasoning as the long case: unreachable given the ACGT check,
+            // and filed rather than dropped if it ever is reached.
+            other_entries.push((
+                OtherVariant {
+                    position: record.position,
+                    idx: 0,
+                    ref_allele: record.ref_allele.clone(),
+                    alt_allele: record.alt_allele.clone(),
+                },
+                local_idx,
+            ));
         }
     }
 
-    short_entries.sort_by_key(|(key, _)| *key);
-    long_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    // Sort by (key, input position), then drop all but the first record of each
+    // duplicate-key run.
+    //
+    // **Why dedup (real-data bug):** several sources carry more than one record
+    // for the same (position, ref, alt) — REVEL has 111,270 such keys on chr22
+    // alone (6.4% of its records), one per transcript/protein change, and
+    // SpliceAI has one per overlapping gene. The v1 reader resolves a position
+    // by scanning forward from its first entry, so it always returns the
+    // *first* such record. A v2 chunk index is a sorted key array resolved by
+    // `binary_search`, which on a run of equal keys returns an arbitrary member
+    // — so v2 could return a different record than v1 for the same query, which
+    // is exactly what a real chr22 annotate run showed on REVEL scores.
+    //
+    // Keeping the first match reproduces v1's observable behaviour exactly and
+    // shrinks the archive, since the dropped records were unreachable through
+    // either reader's API. Sorting by `local_idx` within a key run makes "first"
+    // mean input order, and `dedup_by` keeps the first element of each run.
+    short_entries.sort_by_key(|(key, local_idx)| (*key, *local_idx));
+    short_entries.dedup_by(|a, b| a.0 == b.0);
+    long_entries.sort_by(|(a, ai), (b, bi)| a.cmp(b).then(ai.cmp(bi)));
+    long_entries.dedup_by(|a, b| a.0 == b.0);
+    other_entries.sort_by(|(a, ai), (b, bi)| a.cmp(b).then(ai.cmp(bi)));
+    other_entries.dedup_by(|a, b| a.0 == b.0);
 
     // Value slot layout: short variants first (parallel to the sorted var32
     // key array, so `binary_search` positions map directly), then long
-    // variants. Assign each long variant its slot index.
+    // variants, then the non-ACGT ones. Assign each of the latter two its slot.
     let short_count = short_entries.len();
     for (rank, (lv, _)) in long_entries.iter_mut().enumerate() {
         lv.idx = (short_count + rank) as u32;
+    }
+    let long_count = long_entries.len();
+    for (rank, (ov, _)) in other_entries.iter_mut().enumerate() {
+        ov.idx = (short_count + long_count + rank) as u32;
     }
     let value_order: Vec<usize> = short_entries
         .iter()
         .map(|(_, li)| *li)
         .chain(long_entries.iter().map(|(_, li)| *li))
+        .chain(other_entries.iter().map(|(_, li)| *li))
         .collect();
 
     let var32s: Vec<u32> = short_entries.iter().map(|(k, _)| *k).collect();
@@ -254,6 +300,16 @@ fn write_chunk_entries<W: Write + Seek>(
         let longs: Vec<&LongVariant> = long_entries.iter().map(|(lv, _)| lv).collect();
         zip.start_file(format!("{}too-long.enc", prefix), options)?;
         let data = bincode::serialize(&longs)?;
+        zip.write_all(&data)?;
+    }
+
+    // Only emitted when the chunk actually holds a non-ACGT allele, so archives
+    // for ordinary sources are byte-for-byte what they were before this bucket
+    // existed, and a reader that predates it simply never sees the entry.
+    if !other_entries.is_empty() {
+        let others: Vec<&OtherVariant> = other_entries.iter().map(|(ov, _)| ov).collect();
+        zip.start_file(format!("{}other.enc", prefix), options)?;
+        let data = bincode::serialize(&others)?;
         zip.write_all(&data)?;
     }
 

--- a/crates/fastvep-sa/tests/issue_37_v2_cache_coherence.rs
+++ b/crates/fastvep-sa/tests/issue_37_v2_cache_coherence.rs
@@ -54,7 +54,7 @@ fn v2_reader_resolves_chr_query_against_bare_keyed_archive() {
             position: 10_000 + i * 100,
             ref_allele: b"A".to_vec(),
             alt_allele: b"G".to_vec(),
-            values: vec![i as u32 + 1],
+            values: vec![i + 1],
             json_blob: None,
         })
         .collect();
@@ -94,7 +94,7 @@ fn v2_reader_preload_chr_warms_cache_for_bare_query() {
             position: 10_000 + i * 100,
             ref_allele: b"A".to_vec(),
             alt_allele: b"G".to_vec(),
-            values: vec![i as u32 + 1],
+            values: vec![i + 1],
             json_blob: None,
         })
         .collect();
@@ -108,12 +108,82 @@ fn v2_reader_preload_chr_warms_cache_for_bare_query() {
     // Warm the cache via the chr*-prefixed style.
     reader.preload("chr1", &[10_500u64]).unwrap();
 
-    // Now query with the bare form. If the cache key is not
-    // canonicalized, this would re-decode the chunk — which is the
-    // expensive path the preload is supposed to amortize. The
-    // visible-from-test signal is simply that the bare query still
-    // returns the right annotation; the cache-key coherence is a
-    // structural invariant kept by `resolve_chrom`.
+    // Now query with the bare form. If the cache key is not canonicalized this
+    // re-decodes the chunk, which is exactly the expensive path the preload is
+    // supposed to amortize. `chunk_load_count` makes that observable: the
+    // preload is the only chunk build, and every later query - in either
+    // spelling - must be served from the cache it warmed.
+    let after_preload = reader.chunk_load_count();
+    assert_eq!(after_preload, 1, "preload should build exactly one chunk");
+
     let hit = reader.annotate_position("1", 10_500, "A", "G").unwrap();
     assert!(hit.is_some());
+    for chrom in ["1", "chr1"] {
+        for pos in [10_000u64, 10_500, 11_500] {
+            reader.annotate_position(chrom, pos, "A", "G").unwrap();
+        }
+    }
+    assert_eq!(
+        reader.chunk_load_count(),
+        after_preload,
+        "queries after preload must hit the warmed chunk, not rebuild it"
+    );
+}
+
+#[test]
+fn v2_reader_misses_absent_chromosomes_without_touching_the_chunk_cache() {
+    // `resolve_chrom` used to fall back to the raw query name when no alias
+    // matched, so a query for a contig the archive does not carry still built a
+    // cache key and went looking for a chunk. Returning a miss up front keeps
+    // the shared cache free of keys that can never hit — which matters on a
+    // per-chromosome `--sa-dir`, where every shard is asked about every contig.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("v2_absent.osa2");
+
+    let fields = one_int_field();
+    let records: Vec<Osa2Record> = (0..8)
+        .map(|i| Osa2Record {
+            chrom: "chr1".into(),
+            position: 10_000 + i * 100,
+            ref_allele: b"A".to_vec(),
+            alt_allele: b"G".to_vec(),
+            values: vec![i + 1],
+            json_blob: None,
+        })
+        .collect();
+    let writer = Osa2Writer::new(metadata(), fields);
+    writer
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+
+    let reader = Osa2Reader::open(&path).unwrap();
+
+    // Contigs the shard does not carry: a real one, an alias of a real one that
+    // is still absent, and a nonsense name.
+    for chrom in ["chr2", "2", "chrM", "MT", "not_a_contig", ""] {
+        assert!(
+            reader
+                .annotate_position(chrom, 10_000, "A", "G")
+                .unwrap()
+                .is_none(),
+            "query on absent contig '{chrom}' should miss"
+        );
+        reader.preload(chrom, &[10_000u64]).unwrap();
+    }
+    assert_eq!(
+        reader.chunk_load_count(),
+        0,
+        "absent contigs must not build or key any chunk"
+    );
+
+    // The contig that IS present still works, in either spelling.
+    assert!(reader
+        .annotate_position("chr1", 10_000, "A", "G")
+        .unwrap()
+        .is_some());
+    assert!(reader
+        .annotate_position("1", 10_000, "A", "G")
+        .unwrap()
+        .is_some());
+    assert_eq!(reader.chunk_load_count(), 1);
 }

--- a/crates/fastvep-sa/tests/query_path_allocations.rs
+++ b/crates/fastvep-sa/tests/query_path_allocations.rs
@@ -1,0 +1,216 @@
+//! Pins the allocation behaviour of the SA query path.
+//!
+//! Chromosome resolution used to call `chrom_aliases`, which builds a
+//! `Vec<String>` (two or three heap allocations) on every query. With N
+//! providers in a `--sa-dir` and millions of variants that is tens of millions
+//! of allocations to resolve a name that is constant per (reader, chromosome).
+//! Both readers now invert the alias rules once at open into a map, so a query
+//! resolves its chromosome with one hash lookup and no allocation.
+//!
+//! This file installs a counting global allocator, so it deliberately holds
+//! exactly ONE test: `cargo test` runs the tests in a binary concurrently, and a
+//! second test allocating on another thread would be counted here.
+
+use fastvep_cache::annotation::AnnotationProvider;
+use fastvep_sa::common::AnnotationRecord;
+use fastvep_sa::index::IndexHeader;
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::interval::{IntervalHeader, IntervalIndex};
+use fastvep_sa::reader::SaReader;
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer::SaWriter;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2Writer};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Allocations performed while running `f`.
+fn allocations_during<F: FnOnce()>(f: F) -> usize {
+    let before = ALLOCS.load(Ordering::Relaxed);
+    f();
+    ALLOCS.load(Ordering::Relaxed) - before
+}
+
+fn v2_metadata() -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "Test".into(),
+        version: "1".into(),
+        assembly: "GRCh38".into(),
+        json_key: "test".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: "test".into(),
+    }
+}
+
+fn one_int_field() -> Vec<Field> {
+    vec![Field {
+        field: "AC".into(),
+        alias: "ac".into(),
+        ftype: FieldType::Integer,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+fn v1_header() -> IndexHeader {
+    IndexHeader {
+        schema_version: fastvep_sa::common::SCHEMA_VERSION,
+        json_key: "test".into(),
+        name: "Test".into(),
+        version: "1".into(),
+        description: "test".into(),
+        assembly: "GRCh38".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+    }
+}
+
+#[test]
+fn resolving_a_chromosome_allocates_nothing_on_any_reader() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // ---- v2 `.osa2` ----
+    let v2_path = dir.path().join("t.osa2");
+    let records: Vec<Osa2Record> = (0..64)
+        .map(|i| Osa2Record {
+            chrom: "chr1".into(),
+            position: 10_000 + i * 10,
+            ref_allele: b"A".to_vec(),
+            alt_allele: b"G".to_vec(),
+            values: vec![i + 1],
+            json_blob: None,
+        })
+        .collect();
+    Osa2Writer::new(v2_metadata(), one_int_field())
+        .write_all(std::fs::File::create(&v2_path).unwrap(), &records)
+        .unwrap();
+    let v2 = Osa2Reader::open(&v2_path).unwrap();
+
+    // ---- v1 `.osa` ----
+    let v1_base = dir.path().join("t");
+    let v1_records: Vec<AnnotationRecord> = (0..64u32)
+        .map(|i| AnnotationRecord {
+            chrom_idx: 0,
+            position: 10_000 + i * 10,
+            ref_allele: "A".into(),
+            alt_allele: "G".into(),
+            json: "{\"ac\":1}".into(),
+        })
+        .collect();
+    let mut writer = SaWriter::new(v1_header());
+    writer
+        .write_to_files(&v1_base, v1_records.into_iter(), &["chr1".to_string()])
+        .unwrap();
+    let v1 = SaReader::open(&v1_base.with_extension("osa")).unwrap();
+
+    // ---- `.osi` ----
+    let mut osi = IntervalIndex::new(IntervalHeader {
+        schema_version: fastvep_sa::common::SCHEMA_VERSION,
+        json_key: "iv".into(),
+        name: "IV".into(),
+        version: "1".into(),
+        assembly: "GRCh38".into(),
+    });
+    for i in 0..64u32 {
+        osi.add(fastvep_sa::common::IntervalRecord {
+            chrom: "chr1".into(),
+            start: 10_000 + i * 10,
+            end: 10_005 + i * 10,
+            json: "{}".into(),
+        });
+    }
+    osi.sort();
+    let osi_path = dir.path().join("t.osi");
+    osi.write_to(&mut std::fs::File::create(&osi_path).unwrap())
+        .unwrap();
+    let osi = fastvep_sa::interval::OsiReader::open(&osi_path).unwrap();
+
+    let readers: [(&str, &dyn AnnotationProvider); 3] =
+        [("osa2", &v2), ("osa", &v1), ("osi", &osi)];
+
+    // Warm every cache and every lazily-resolved offset first, so the measured
+    // window covers only steady-state lookups.
+    for (_, r) in &readers {
+        for _ in 0..3 {
+            r.annotate_position("chr1", 10_000, "A", "G").unwrap();
+            r.annotate_position("chr2", 10_000, "A", "G").unwrap();
+        }
+    }
+
+    for (name, reader) in &readers {
+        // A query for a contig the database does not carry resolves to a miss
+        // and returns. That is pure chromosome resolution with nothing else in
+        // the way, so it must allocate exactly nothing.
+        let allocs = allocations_during(|| {
+            for _ in 0..1_000 {
+                assert!(reader
+                    .annotate_position("chr2", 10_000, "A", "G")
+                    .unwrap()
+                    .is_none());
+            }
+        });
+        assert_eq!(
+            allocs, 0,
+            "{name}: 1000 absent-contig queries allocated {allocs} times; \
+             chromosome resolution must be allocation-free"
+        );
+
+        // The same, via an alias of an absent contig — the path that used to
+        // build the alias Vec before discovering the miss.
+        let allocs = allocations_during(|| {
+            for _ in 0..1_000 {
+                assert!(reader.annotate_position("2", 10_000, "A", "G").unwrap().is_none());
+            }
+        });
+        assert_eq!(allocs, 0, "{name}: aliased absent-contig queries allocated {allocs} times");
+
+        // A hit necessarily allocates (it returns an owned JSON String), but
+        // resolving via an alias must cost the same as the canonical spelling.
+        let canonical = allocations_during(|| {
+            for _ in 0..1_000 {
+                assert!(reader
+                    .annotate_position("chr1", 10_000, "A", "G")
+                    .unwrap()
+                    .is_some());
+            }
+        });
+        let aliased = allocations_during(|| {
+            for _ in 0..1_000 {
+                assert!(reader.annotate_position("1", 10_000, "A", "G").unwrap().is_some());
+            }
+        });
+        assert_eq!(
+            canonical, aliased,
+            "{name}: alias resolution cost {aliased} allocations vs {canonical} for the \
+             canonical name; resolving a spelling must be free"
+        );
+    }
+}

--- a/crates/fastvep-sa/tests/v2_duplicate_keys.rs
+++ b/crates/fastvep-sa/tests/v2_duplicate_keys.rs
@@ -1,0 +1,260 @@
+//! Regression tests: when several records share one `(position, ref, alt)` key,
+//! `.osa2` must resolve to the same one the `.osa` reader does — the first.
+//!
+//! Found by annotating 15,437 real ClinVar chr22 variants through a real `.osa`
+//! directory and the same databases converted to `.osa2`: the REVEL column
+//! disagreed (`0.324` vs `0.349`, `0.009` vs `0.042`, …). Real REVEL carries
+//! **111,270 duplicate keys on chr22 alone — 6.4% of its 1,776,286 records** —
+//! one per transcript/protein change, and SpliceAI carries one per overlapping
+//! gene.
+//!
+//! The v1 reader resolves a position by scanning forward from its first entry,
+//! so it always returns the first matching record. A v2 chunk index is a sorted
+//! key array resolved by `binary_search`, which on a run of equal keys returns an
+//! *arbitrary* member. The writer now keeps only the first record of each
+//! duplicate run, which both reproduces v1 exactly and drops records that were
+//! unreachable through either reader.
+
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2StreamWriter, Osa2Writer};
+use std::io::BufWriter;
+
+fn metadata(is_positional: bool) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "Test".into(),
+        version: "1".into(),
+        assembly: "GRCh38".into(),
+        json_key: "test".into(),
+        match_by_allele: !is_positional,
+        is_array: false,
+        is_positional,
+        chunk_bits: 20,
+        description: "test".into(),
+    }
+}
+
+fn blob_fields() -> Vec<Field> {
+    fastvep_sa::writer_v2::raw_json_blob_fields()
+}
+
+fn one_int_field() -> Vec<Field> {
+    vec![Field {
+        field: "AC".into(),
+        alias: "ac".into(),
+        ftype: FieldType::Integer,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+fn json_of(v: Option<AnnotationValue>) -> Option<String> {
+    match v {
+        Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => Some(j),
+        Some(AnnotationValue::Interval(v)) => Some(format!("[{}]", v.join(","))),
+        None => None,
+    }
+}
+
+fn blob(chrom: &str, position: u32, r: &str, a: &str, payload: &str) -> Osa2Record {
+    Osa2Record {
+        chrom: chrom.into(),
+        position,
+        ref_allele: r.as_bytes().to_vec(),
+        alt_allele: a.as_bytes().to_vec(),
+        values: Vec::new(),
+        json_blob: Some(format!("{{\"id\":\"{payload}\"}}")),
+    }
+}
+
+/// Records in **input order**, with duplicate keys across all three index
+/// buckets: short (Var32), long (kmer16), and non-ACGT (verbatim).
+fn duplicated() -> Vec<Osa2Record> {
+    vec![
+        // Short key, three records. Only "first" may ever be returned.
+        blob("chr1", 100, "A", "G", "first"),
+        blob("chr1", 100, "A", "G", "second"),
+        blob("chr1", 100, "A", "G", "third"),
+        // A distinct allele at the same position is not a duplicate.
+        blob("chr1", 100, "A", "T", "other-allele"),
+        // Long key (ref+alt > 4 bases), duplicated.
+        blob("chr1", 200, "GATTACA", "G", "long-first"),
+        blob("chr1", 200, "GATTACA", "G", "long-second"),
+        // Non-ACGT key, duplicated.
+        blob("chr1", 300, "A", "N", "n-first"),
+        blob("chr1", 300, "A", "N", "n-second"),
+        // A different chunk entirely, also duplicated.
+        blob("chr1", 5_000_000, "C", "T", "far-first"),
+        blob("chr1", 5_000_000, "C", "T", "far-second"),
+        // And a different chromosome, so the dedup cannot be keyed globally.
+        blob("chr2", 100, "A", "G", "chr2-first"),
+        blob("chr2", 100, "A", "G", "chr2-second"),
+    ]
+}
+
+fn assert_first_wins(reader: &Osa2Reader) {
+    for (chrom, pos, r, a, want) in [
+        ("chr1", 100u64, "A", "G", "first"),
+        ("chr1", 100, "A", "T", "other-allele"),
+        ("chr1", 200, "GATTACA", "G", "long-first"),
+        ("chr1", 300, "A", "N", "n-first"),
+        ("chr1", 5_000_000, "C", "T", "far-first"),
+        ("chr2", 100, "A", "G", "chr2-first"),
+    ] {
+        let json = json_of(reader.annotate_position(chrom, pos, r, a).unwrap())
+            .unwrap_or_else(|| panic!("{chrom}:{pos} {r}>{a} missing"));
+        assert_eq!(
+            json,
+            format!("{{\"id\":\"{want}\"}}"),
+            "{chrom}:{pos} {r}>{a} must resolve to the first record written"
+        );
+    }
+}
+
+#[test]
+fn buffered_writer_keeps_the_first_of_each_duplicate_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    Osa2Writer::new(metadata(false), blob_fields())
+        .write_all(std::fs::File::create(&path).unwrap(), &duplicated())
+        .unwrap();
+    assert_first_wins(&Osa2Reader::open(&path).unwrap());
+}
+
+#[test]
+fn streaming_writer_keeps_the_first_of_each_duplicate_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    let f = std::fs::File::create(&path).unwrap();
+    let mut w = Osa2StreamWriter::new(BufWriter::new(f), &metadata(false), blob_fields()).unwrap();
+    for r in duplicated() {
+        w.push(r).unwrap();
+    }
+    w.finish().unwrap();
+    assert_first_wins(&Osa2Reader::open(&path).unwrap());
+}
+
+#[test]
+fn deduping_keeps_value_columns_aligned() {
+    // Dropping records shifts every later value slot, so the columns and the
+    // index have to be rebuilt together. Give each record a distinct value and
+    // check the survivors resolve to their own.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+
+    // (position, ref, alt, value) in input order; value 0 marks the first of a run.
+    let specs: Vec<(u32, &str, &str, u32)> = vec![
+        (100, "A", "G", 10),
+        (100, "A", "G", 11), // dropped
+        (100, "A", "T", 20),
+        (200, "GATTACA", "G", 30),
+        (200, "GATTACA", "G", 31), // dropped
+        (300, "A", "N", 40),
+        (300, "A", "N", 41), // dropped
+        (400, "C", "T", 50),
+    ];
+    let records: Vec<Osa2Record> = specs
+        .iter()
+        .map(|(pos, r, a, v)| Osa2Record {
+            chrom: "chr1".into(),
+            position: *pos,
+            ref_allele: r.as_bytes().to_vec(),
+            alt_allele: a.as_bytes().to_vec(),
+            values: vec![*v],
+            json_blob: None,
+        })
+        .collect();
+    Osa2Writer::new(metadata(false), one_int_field())
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+
+    let reader = Osa2Reader::open(&path).unwrap();
+    for (pos, r, a, want) in [
+        (100u32, "A", "G", 10),
+        (100, "A", "T", 20),
+        (200, "GATTACA", "G", 30),
+        (300, "A", "N", 40),
+        (400, "C", "T", 50),
+    ] {
+        let json = json_of(reader.annotate_position("chr1", pos as u64, r, a).unwrap())
+            .unwrap_or_else(|| panic!("chr1:{pos} {r}>{a} missing"));
+        assert_eq!(
+            json,
+            format!("{{\"ac\":{want}}}"),
+            "chr1:{pos} {r}>{a} resolved to a shifted value slot"
+        );
+    }
+}
+
+#[test]
+fn positional_sources_also_keep_the_first_record_per_position() {
+    // A positional source keys on coordinate alone, so two records at the same
+    // position are duplicates regardless of their alleles — same rule applies.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    let records = vec![
+        blob("chr1", 100, "", "", "pos-first"),
+        blob("chr1", 100, "", "", "pos-second"),
+        blob("chr1", 101, "", "", "next-position"),
+    ];
+    Osa2Writer::new(metadata(true), blob_fields())
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+
+    let reader = Osa2Reader::open(&path).unwrap();
+    assert_eq!(
+        json_of(reader.annotate_position("chr1", 100, "A", "G").unwrap()).unwrap(),
+        "{\"id\":\"pos-first\"}"
+    );
+    assert_eq!(
+        json_of(reader.annotate_position("chr1", 101, "A", "G").unwrap()).unwrap(),
+        "{\"id\":\"next-position\"}"
+    );
+}
+
+#[test]
+fn dedup_shrinks_the_archive() {
+    // The dropped records were unreachable through either reader's API, so
+    // removing them is pure savings — worth pinning so a future change that
+    // reintroduces them is noticed.
+    let dir = tempfile::tempdir().unwrap();
+    let with_dupes = dir.path().join("dupes.osa2");
+    let without = dir.path().join("unique.osa2");
+
+    let mut many: Vec<Osa2Record> = Vec::new();
+    let mut unique: Vec<Osa2Record> = Vec::new();
+    for i in 0..5_000u32 {
+        let pos = 1_000 + i * 7;
+        // Five records per key, as REVEL has per transcript.
+        for k in 0..5 {
+            many.push(blob("chr1", pos, "A", "G", &format!("rec-{i}-{k}")));
+        }
+        unique.push(blob("chr1", pos, "A", "G", &format!("rec-{i}-0")));
+    }
+    Osa2Writer::new(metadata(false), blob_fields())
+        .write_all(std::fs::File::create(&with_dupes).unwrap(), &many)
+        .unwrap();
+    Osa2Writer::new(metadata(false), blob_fields())
+        .write_all(std::fs::File::create(&without).unwrap(), &unique)
+        .unwrap();
+
+    let a = std::fs::metadata(&with_dupes).unwrap().len();
+    let b = std::fs::metadata(&without).unwrap().len();
+    assert_eq!(
+        a, b,
+        "an archive built from 5x-duplicated records must match one built from \
+         the unique records alone: {a} vs {b}"
+    );
+
+    // And it still answers correctly.
+    let reader = Osa2Reader::open(&with_dupes).unwrap();
+    assert_eq!(
+        json_of(reader.annotate_position("chr1", 1_000, "A", "G").unwrap()).unwrap(),
+        "{\"id\":\"rec-0-0\"}"
+    );
+}

--- a/crates/fastvep-sa/tests/v2_non_acgt_alleles.rs
+++ b/crates/fastvep-sa/tests/v2_non_acgt_alleles.rs
@@ -1,0 +1,271 @@
+//! Regression tests: `.osa2` must not drop variants whose alleles contain
+//! bytes outside `ACGT`.
+//!
+//! Found by running the full real ClinVar release (4,438,232 records) through
+//! both formats and querying every v1 record against the v2 database: **668
+//! records were retrievable from the `.osa` and missing from the `.osa2`.**
+//! Their alleles all carry `N` runs (ClinVar's `Microsatellite` and long
+//! `Insertion` entries), and both v2 key encodings — Var32 and kmer16 — are two
+//! bits per base, so neither can represent them. The writer dropped them with a
+//! `log::warn!` that the CLI installs no logger to display, making it silent
+//! data loss on a source that already built to v2 by default.
+//!
+//! Such variants now go in a third per-chunk bucket that stores the allele bytes
+//! verbatim and is binary-searched on `(position, ref, alt)`.
+
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2StreamWriter, Osa2Writer};
+use std::io::BufWriter;
+
+fn metadata() -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "Test".into(),
+        version: "1".into(),
+        assembly: "GRCh38".into(),
+        json_key: "test".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits: 20,
+        description: "test".into(),
+    }
+}
+
+fn blob_fields() -> Vec<Field> {
+    fastvep_sa::writer_v2::raw_json_blob_fields()
+}
+
+fn one_int_field() -> Vec<Field> {
+    vec![Field {
+        field: "AC".into(),
+        alias: "ac".into(),
+        ftype: FieldType::Integer,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+fn json_of(v: Option<AnnotationValue>) -> Option<String> {
+    match v {
+        Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => Some(j),
+        Some(AnnotationValue::Interval(v)) => Some(format!("[{}]", v.join(","))),
+        None => None,
+    }
+}
+
+/// The allele shapes that used to be dropped, alongside ordinary ones that must
+/// keep working. Ordering here is deliberately not sorted, and positions are
+/// spread so short/long/non-ACGT variants share chunks.
+fn mixed_records() -> Vec<(u32, &'static str, &'static str, &'static str)> {
+    vec![
+        // (position, ref, alt, payload)
+        (100, "A", "G", "snv-short"),
+        // Short but non-ACGT: fails Var32 encoding.
+        (100, "A", "N", "short-alt-N"),
+        (101, "N", "A", "short-ref-N"),
+        // IUPAC ambiguity codes, not just N.
+        (102, "A", "R", "iupac-R"),
+        (103, "Y", "A", "iupac-Y"),
+        // Long (ref+alt > 4) and non-ACGT: fails kmer16 encoding. This is the
+        // exact shape of the real ClinVar Microsatellite entries.
+        (
+            200,
+            "C",
+            "CAAAAGAACCATTTNNNNNNNNNNAAAAAAAAAA",
+            "long-alt-with-N-run",
+        ),
+        (201, "GATTACANNNN", "G", "long-ref-with-N-run"),
+        // Ordinary long variant in the same neighbourhood.
+        (202, "GATTACA", "G", "long-acgt"),
+        // Lowercase must still be treated as ACGT, not shunted to the bucket.
+        (300, "a", "g", "lowercase-snv"),
+        (301, "gattaca", "g", "lowercase-long"),
+        // A far chunk holding ONLY a non-ACGT variant.
+        (5_000_000, "A", "N", "lonely-N-in-its-own-chunk"),
+    ]
+}
+
+fn blob_records() -> Vec<Osa2Record> {
+    mixed_records()
+        .into_iter()
+        .map(|(pos, r, a, payload)| Osa2Record {
+            chrom: "chr1".into(),
+            position: pos,
+            ref_allele: r.as_bytes().to_vec(),
+            alt_allele: a.as_bytes().to_vec(),
+            values: Vec::new(),
+            json_blob: Some(format!("{{\"id\":\"{payload}\"}}")),
+        })
+        .collect()
+}
+
+/// Assert every record written is retrievable with its own alleles, carrying its
+/// own payload — i.e. no drops and no cross-wired value slots.
+fn assert_all_retrievable(reader: &Osa2Reader) {
+    for (pos, r, a, payload) in mixed_records() {
+        let json = json_of(reader.annotate_position("chr1", pos as u64, r, a).unwrap())
+            .unwrap_or_else(|| panic!("chr1:{pos} {r}>{a} ({payload}) was dropped"));
+        assert!(
+            json.contains(payload),
+            "chr1:{pos} {r}>{a} returned the wrong record's payload: {json}"
+        );
+    }
+}
+
+#[test]
+fn buffered_writer_keeps_non_acgt_alleles() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    let mut records = blob_records();
+    records.sort_by_key(|r| r.position);
+
+    Osa2Writer::new(metadata(), blob_fields())
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+
+    assert_all_retrievable(&Osa2Reader::open(&path).unwrap());
+}
+
+#[test]
+fn streaming_writer_keeps_non_acgt_alleles() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    let mut records = blob_records();
+    records.sort_by_key(|r| r.position);
+
+    let f = std::fs::File::create(&path).unwrap();
+    let mut w = Osa2StreamWriter::new(BufWriter::new(f), &metadata(), blob_fields()).unwrap();
+    for r in records {
+        w.push(r).unwrap();
+    }
+    w.finish().unwrap();
+
+    assert_all_retrievable(&Osa2Reader::open(&path).unwrap());
+}
+
+#[test]
+fn non_acgt_alleles_resolve_to_their_own_numeric_columns() {
+    // The bucket's `idx` must point at the right slot in the parallel value
+    // arrays, which is exactly what the original long-variant `idx` bug got
+    // wrong. Give each record a distinct value and check every one.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+
+    let specs = mixed_records();
+    let mut records: Vec<Osa2Record> = specs
+        .iter()
+        .enumerate()
+        .map(|(i, (pos, r, a, _))| Osa2Record {
+            chrom: "chr1".into(),
+            position: *pos,
+            ref_allele: r.as_bytes().to_vec(),
+            alt_allele: a.as_bytes().to_vec(),
+            values: vec![i as u32 + 1],
+            json_blob: None,
+        })
+        .collect();
+    records.sort_by_key(|r| r.position);
+
+    Osa2Writer::new(metadata(), one_int_field())
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+
+    let reader = Osa2Reader::open(&path).unwrap();
+    for (i, (pos, r, a, label)) in specs.iter().enumerate() {
+        let json = json_of(reader.annotate_position("chr1", *pos as u64, r, a).unwrap())
+            .unwrap_or_else(|| panic!("chr1:{pos} {r}>{a} ({label}) was dropped"));
+        assert_eq!(
+            json,
+            format!("{{\"ac\":{}}}", i + 1),
+            "chr1:{pos} {r}>{a} ({label}) resolved to the wrong value slot"
+        );
+    }
+}
+
+#[test]
+fn a_wrong_non_acgt_allele_still_misses() {
+    // The bucket must match exactly, not merely by position — otherwise
+    // recovering these records would trade data loss for false positives.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.osa2");
+    let mut records = blob_records();
+    records.sort_by_key(|r| r.position);
+    Osa2Writer::new(metadata(), blob_fields())
+        .write_all(std::fs::File::create(&path).unwrap(), &records)
+        .unwrap();
+    let reader = Osa2Reader::open(&path).unwrap();
+
+    // Right position, different non-ACGT allele.
+    assert!(json_of(reader.annotate_position("chr1", 100, "A", "NN").unwrap()).is_none());
+    assert!(json_of(reader.annotate_position("chr1", 100, "N", "N").unwrap()).is_none());
+    // Right allele shape, wrong position.
+    assert!(json_of(reader.annotate_position("chr1", 999, "A", "N").unwrap()).is_none());
+    // A non-ACGT query against a position holding only ACGT records.
+    assert!(json_of(reader.annotate_position("chr1", 202, "GATTACN", "G").unwrap()).is_none());
+    // And the ACGT record at a position that also holds a non-ACGT one is
+    // unaffected by the bucket's presence.
+    assert!(json_of(reader.annotate_position("chr1", 100, "A", "G").unwrap()).is_some());
+}
+
+#[test]
+fn archives_without_non_acgt_alleles_carry_no_extra_entry() {
+    // The `other.enc` sub-entry is only emitted when a chunk actually needs it,
+    // so ordinary sources produce the same archive they did before the bucket
+    // existed — and a reader that predates it never encounters the entry.
+    let dir = tempfile::tempdir().unwrap();
+    let clean = dir.path().join("clean.osa2");
+    let dirty = dir.path().join("dirty.osa2");
+
+    let acgt_only: Vec<Osa2Record> = [(100u32, "A", "G"), (200, "GATTACA", "G")]
+        .iter()
+        .map(|(pos, r, a)| Osa2Record {
+            chrom: "chr1".into(),
+            position: *pos,
+            ref_allele: r.as_bytes().to_vec(),
+            alt_allele: a.as_bytes().to_vec(),
+            values: Vec::new(),
+            json_blob: Some("{\"id\":\"x\"}".into()),
+        })
+        .collect();
+    Osa2Writer::new(metadata(), blob_fields())
+        .write_all(std::fs::File::create(&clean).unwrap(), &acgt_only)
+        .unwrap();
+
+    let mut with_n = acgt_only.clone();
+    with_n.push(Osa2Record {
+        chrom: "chr1".into(),
+        position: 300,
+        ref_allele: b"A".to_vec(),
+        alt_allele: b"N".to_vec(),
+        values: Vec::new(),
+        json_blob: Some("{\"id\":\"n\"}".into()),
+    });
+    Osa2Writer::new(metadata(), blob_fields())
+        .write_all(std::fs::File::create(&dirty).unwrap(), &with_n)
+        .unwrap();
+
+    let entry_names = |p: &std::path::Path| -> Vec<String> {
+        let f = std::fs::File::open(p).unwrap();
+        let mut zip = zip::ZipArchive::new(f).unwrap();
+        (0..zip.len())
+            .map(|i| zip.by_index(i).unwrap().name().to_string())
+            .collect()
+    };
+
+    let clean_entries = entry_names(&clean);
+    assert!(
+        !clean_entries.iter().any(|n| n.ends_with("other.enc")),
+        "an ACGT-only archive must not carry other.enc: {clean_entries:?}"
+    );
+    let dirty_entries = entry_names(&dirty);
+    assert!(
+        dirty_entries.iter().any(|n| n.ends_with("other.enc")),
+        "an archive with an N allele must carry other.enc: {dirty_entries:?}"
+    );
+}

--- a/docs/SUPPLEMENTARY_ANNOTATIONS.md
+++ b/docs/SUPPLEMENTARY_ANNOTATIONS.md
@@ -56,8 +56,8 @@ source scope:
 
 | Extension | Scope        | Producers                                             | Loaded by `--sa-dir`? |
 |-----------|--------------|-------------------------------------------------------|-----------------------|
-| `.osa`    | Allele-level | All allele-level sources above                        | Yes (`SaReader`)      |
-| `.osa2`   | Allele-level | Optional v2 encoding (echtvar-style, chunked ZIP)     | Yes (`Osa2Reader`)    |
+| `.osa2`   | Allele-level | Every allele-level source (the `--format auto` default) | Yes (`Osa2Reader`)  |
+| `.osa`    | Allele-level | Any allele-level source, via explicit `--format osa`  | Yes (`SaReader`)      |
 | `.osi`    | Interval     | `custom_bed` (and any future structural-variant DB)   | Yes (`OsiReader`)     |
 | `.oga`    | Gene         | `omim`, `gnomad_genes`, `clinvar_protein`             | Yes (`GeneIndex`)     |
 
@@ -72,18 +72,21 @@ skipped.
 
 Allele-level sources can build to either the v1 `.osa` or v2 `.osa2`
 container. **You normally don't have to choose:** `sa-build --format` defaults
-to `auto`, which builds v2 for the sources that support it and v1 for the rest.
+to `auto`, and every allele-level source now has a v2 encoder, so `auto` builds
+`.osa2` for all of them.
 The annotate side loads either transparently from `--sa-dir`, so downstream
 usage is identical.
 
 Rule of thumb:
 
-- **`auto` (default)** — recommended. Gives the best format per source with no
-  decision required.
-- **`osa` (force v1)** — use for a faster one-time build, or when a downstream
-  tool specifically expects the `.osa`/`.osa.idx` file pair.
-- **`osa2` (force v2)** — use to build v2 for a source that supports it even if
-  the default ever changes; errors out for sources with no v2 encoder.
+- **`auto` (default)** — recommended. Builds `.osa2` for every allele-level
+  source; the gene- and interval-level sources have no v2 form and build
+  `.oga`/`.osi` as always.
+- **`osa` (force v1)** — the escape hatch. Use for a faster one-time build, or
+  when a downstream tool specifically expects the `.osa`/`.osa.idx` file pair.
+- **`osa2` (force v2)** — same as `auto` for allele-level sources; errors out
+  for the gene- and interval-level sources rather than silently building
+  something else.
 
 Why v2 is the higher-quality default where available: at genome scale it is
 **smaller on disk** (≈0.67× for numeric payloads, as low as ≈0.30× for the
@@ -92,21 +95,123 @@ real VCF produces (≈3.8–4.5× at 10M records). The trade-off is a one-time
 build that is ≈4× slower; v2 is also not a size win for very small inputs,
 where its fixed per-chunk overhead dominates. Output is byte-identical between
 the two formats for the blob-backed sources (dbSNP, COSMIC, ClinVar, REVEL,
-PrimateAI, dbNSFP, and the positional scores) and for AlphaMissense. For the
+PrimateAI, dbNSFP, MitoMap, `custom_vcf`, and the positional scores) and for
+AlphaMissense and SpliceAI. For the
 frequency sources (gnomAD, 1000G, TOPMed) the integer counts are exact and
 frequencies match to a fixed 5e-7 resolution — identical in practice except
 for the very rarest gnomAD v4 singletons, whose AF falls below that floor.
 
+AlphaMissense and SpliceAI reach that byte-identity by having their **v1**
+builder render each record through the same field-encode/format code the v2
+reader reconstructs with.
+For SpliceAI that changed the v1 `.osa` payload's number formatting: delta
+scores now render in the shared scientific-notation form (`8.500000e-1` rather
+than `0.85`).
+The JSON keys and their order are unchanged, and every consumer parses these
+with a JSON parser, so nothing downstream is affected — but a `.osa` built
+before this change will differ textually from one built after.
+The delta positions (`dpAg`…`dpDl`) are unaffected and still render as plain
+signed integers.
+
 Every allele-level and positional source has a v2 encoder: `gnomad`, `onekg`
-(`1000g`), `topmed`, `alphamissense`, `dbsnp`, `cosmic`, `clinvar`, `revel`,
-`primateai`, `dbnsfp`, and the positional per-base scores `phylop`, `gerp`,
-`dann`. Only gene-level (`.oga`) sources and `custom_*` inputs build v1
-`.osa`/`.osi`/`.oga` regardless of `--format`.
+(`1000g`), `topmed`, `alphamissense`, `spliceai`, `dbsnp`, `cosmic`, `clinvar`,
+`revel`, `primateai`, `dbnsfp`, `mitomap`, `custom_vcf`, and the positional
+per-base scores `phylop`, `gerp`, `dann`.
+The only sources that ignore `--format` are the ones v2 structurally cannot
+represent: gene-keyed sources (`omim`, `gnomad_genes`, `clinvar_protein`) build
+`.oga`, and interval-keyed `custom_bed` builds `.osi`.
+
+Two encodings sit behind `.osa2`.
+**Column-oriented** sources (`gnomad`, `onekg`/`1000g`, `topmed`,
+`alphamissense`, `spliceai`) decompose each record into parallel u32 value
+columns, plus a categorical string table where one applies (AlphaMissense's
+three-level class, SpliceAI's gene symbol).
+The rest store one **whole-record JSON blob** per variant, because their
+payloads are high-cardinality ID strings or nested arrays that the numeric
+layout cannot represent; they still gain from v2's chunk-level zstd, which
+compresses a whole chunk's records together.
 
 Positional scores get an especially large v2 win: their per-base coordinates
 delta-encode to almost nothing and the score column compresses well, so a
 dense per-base database is roughly **0.23× the size** of the v1 `.osa`
 (measured via `bench_shapes` on realistic-entropy synthetic scores).
+
+Measured on real releases, whole-database, with every record queried through both
+readers and compared:
+
+| Source | Records | v1 (`.osa` + `.idx`) | v2 (`.osa2`) | Ratio |
+|--------|---------|----------------------|--------------|-------|
+| ClinVar (full release) | 4,438,232 | 50.5 MB | 40.9 MB | 0.81× |
+| SpliceAI (chr22) | 827,827 | 4.8 MB | 2.7 MB | 0.56× |
+| REVEL (chr22) | 1,776,286 | 8.7 MB | 3.8 MB | 0.44× |
+| gnomAD (chr22) | 852,255 | 15.4 MB | 12.9 MB | 0.84× |
+| PhyloP (chr22) | 852,255 | 3.1 MB | 1.4 MB | 0.45× |
+
+Annotating 308,740 real chr22 variants against all five of those databases at
+once takes **12.7 s from the `.osa` set and 8.5 s from the `.osa2` set (1.50×)**,
+with md5-identical output.
+
+The SpliceAI ratio is data-dependent and can be much better than the 0.56×
+above: that shard comes from gnomAD's summarised SpliceAI fields, where the four
+delta scores are equal per record and all four delta positions are zero, so v1's
+JSON is unusually compressible. On a fixture with independently varying scores,
+positions, and 200 gene symbols the ratio is **0.14×**.
+
+### v1/v2 record fidelity
+
+Two ways v2 used to disagree with v1 about *which records exist* were found by
+running the full real ClinVar release and a real per-chromosome `--sa-dir`
+through both formats and comparing every record. Both are fixed; both are worth
+knowing about if you have `.osa2` files built before this change.
+
+**Alleles containing `N` or IUPAC codes were dropped.** Var32 and kmer16 are both
+two bits per base, so neither can encode them, and the writer skipped such
+records with a `log::warn!` that the CLI installs no logger to display. Real
+ClinVar carries 668 of them among 4,438,232 records (0.015%) — `Microsatellite`
+and long `Insertion` entries. They are now kept in a third per-chunk bucket that
+stores the allele bytes verbatim, costing 0.20% on the ClinVar archive
+(82 KB of 41 MB).
+
+**Duplicate keys resolved arbitrarily.** Several sources hold more than one
+record for the same `(position, ref, alt)`: REVEL has one per transcript or
+protein change (111,270 duplicate keys on chr22 alone, 6.4% of its records),
+SpliceAI one per overlapping gene. The v1 reader scans forward from a position's
+first entry and so always returns the first such record, but a v2 chunk index is
+a sorted key array resolved by `binary_search`, which on a run of equal keys
+returns an arbitrary member — so the two formats could return different records
+for the same query, which showed up as differing REVEL scores in a real chr22
+annotate run. The writer now keeps only the first record of each duplicate run,
+which reproduces v1 exactly and shrinks the archive, since the dropped records
+were unreachable through either reader.
+
+If you have `.osa2` files built before this change, rebuild or `sa-convert` them.
+
+### Converting an existing v1 database (`sa-convert`)
+
+If you already have `.osa` files from before every source defaulted to v2, you
+do not have to re-download and re-parse the upstream release:
+
+```bash
+fastvep sa-convert -i sa_databases/dbsnp.osa          # writes dbsnp.osa2
+fastvep sa-convert -i old/spliceai.osa -o new/spliceai # explicit output base
+```
+
+The conversion preserves the record set and every record's JSON payload byte
+for byte, along with the database's identity and matching semantics (`json_key`,
+name, version, description, assembly, `match_by_allele`, `is_array`,
+`is_positional`), so a converted database answers every query exactly as the
+`.osa` did.
+
+One caveat, which the tool prints: a `.osa` retains no field schema, so a
+conversion can only produce the JSON-blob encoding. For the blob-backed sources
+that is exactly what a native v2 build produces anyway. For the five
+column-oriented sources it is not, so if you still have the upstream release
+prefer `sa-build --format osa2` to get the column layout. Which of the two ends
+up smaller is data-dependent, so compare if size matters.
+
+`sa-convert` refuses `.osi` and `.oga` inputs with an explanation rather than
+failing obscurely: v2 is a variant-level container and has no equivalent form
+for interval- or gene-keyed data.
 
 ## Pipe formats
 


### PR DESCRIPTION
Audit of everything in the SA still on the v1 path or leaving performance on the table. Two of these are **correctness bugs that real-data testing surfaced**, not the items I originally set out to fix.

## Record fidelity: two v2 bugs found on real data

Both were found by building the full real ClinVar release both ways and querying every v1 record against the v2 database, then annotating a real per-chromosome `--sa-dir`.

**1. v2 silently dropped variants whose alleles contain `N` or IUPAC codes.** Var32 and kmer16 are both 2 bits per base, so the writer skipped such records with a `log::warn!` that the CLI installs no logger to display. Real ClinVar carries **668 of them among 4,438,232 records** (0.015%) - `Microsatellite` and long `Insertion` entries. They now go in a third per-chunk bucket storing the allele bytes verbatim, binary-searched on `(position, ref, alt)`. Costs 0.20% on the ClinVar archive (82 KB of 41 MB). The `other.enc` sub-entry is only emitted when a chunk needs it, so ordinary archives are unchanged.

**2. v2 resolved duplicate `(position, ref, alt)` keys arbitrarily.** The v1 reader scans forward from a position's first entry and so always returns the first matching record; a v2 chunk index is a sorted key array resolved by `binary_search`, which on a run of equal keys returns an arbitrary member. Real REVEL has **111,270 duplicate keys on chr22 alone - 6.4% of its 1,776,286 records** (one per transcript/protein change), and a real chr22 annotate run returned different REVEL scores from the two formats (`0.324` vs `0.349`, `0.009` vs `0.042`). The writer now keeps the first record of each run, which reproduces v1 exactly and shrinks the archive since the dropped records were unreachable through either reader.

Both pre-date this branch - ClinVar and REVEL already built to v2 by default - but this PR routes three more sources through v2, so they had to be fixed first. **If you have `.osa2` files built before this, rebuild or `sa-convert` them.**

## Every variant-level source now builds v2

- **SpliceAI** gets a native encoder: eight numeric columns (four zigzag delta positions, four float delta scores) plus a categorical gene index. Needed deferred string-table plumbing, since the gene vocabulary is only known once the input has streamed past. 0.14x-0.56x the v1 size depending on how much the scores vary. This was the worst gap - SpliceAI is the densest source fastVEP ships against and the one whose payload fits the column layout best.
- **`mitomap`** and **`custom_vcf`** build v2 via the whole-record blob bridge. `--format auto` now produces `.osa2` for every allele-level source, and `--format osa` is the explicit escape hatch. Gene-level (`.oga`) and `custom_bed` (`.osi`) have no v2 form - structural, not a gap.
- **New `fastvep sa-convert`** transcodes an existing `.osa` to `.osa2` without re-downloading upstream, preserving the record set, every payload byte for byte, and the database's identity and matching semantics. Prints an honest caveat for the five column-oriented sources, whose column layout a `.osa` cannot recover.

## Performance

- **`.osi` interval lookup** was a linear scan from index 0 despite a comment claiming a binary search. Now bounded by two `partition_point` calls over the start-sorted list and a derived prefix-maxima array. 70.6us -> 48.6us per query on 620,754 real chr22 intervals; on a sparse database the candidate window shrinks from the whole prefix to <=4 intervals.
- **Chromosome resolution is allocation-free** in all three readers: the alias rules are inverted once at open (new `chrom_alias_map`) instead of building a `Vec<String>` per query per provider. Pinned by a counting-global-allocator test; reverting one reader shows exactly 3 allocations per query.
- **Providers are no longer stored behind a per-provider `Mutex`**, which serialized every lookup across concurrent `/annotate` requests even though the trait is `Send + Sync` with `&self` methods (the CLI already worked around it by unwrapping immediately). `has_gnomad` hoisted out of the per-variant loops in both paths.
- **Removed `annotate_batch`**: an unused default-implemented stub whose doc claimed the v2 reader overrode it to "load chunks once and serve multiple queries". Nothing called or overrode it. `preload` is what delivers that, now documented accurately and with a test proving it via `chunk_load_count`.

Derived-state fields added to `SaIndex` and `IntervalIndex` are `#[serde(skip)]`, so `.osa.idx` and `.osi` bytes are unchanged - pinned by tests that build the payload from the old field layout and require it to load.

## Verification

**Real data** (full ClinVar release + real per-chromosome shards from `data/benchmark/sa_db`):

| Source | Records | v1 | v2 | Ratio |
|--------|---------|----|----|-------|
| ClinVar (full) | 4,438,232 | 50.5 MB | 40.9 MB | 0.81x |
| REVEL (chr22) | 1,776,286 | 8.7 MB | 3.8 MB | 0.44x |
| gnomAD (chr22) | 852,255 | 15.4 MB | 12.9 MB | 0.84x |
| SpliceAI (chr22) | 827,827 | 4.8 MB | 2.7 MB | 0.56x |
| PhyloP (chr22) | 852,255 | 3.1 MB | 1.4 MB | 0.45x |

- **8,318,903 keys** across those five databases queried through both readers and compared byte for byte: zero differing, zero missing.
- Annotating **308,740 real chr22 variants** against all five at once: **12.7s from `.osa`, 8.5s from `.osa2` (1.50x)**, md5-identical output from `.osa`, converted `.osa2`, and natively built `.osa2`.
- A v1 ClinVar rebuild is md5-identical to the committed `data/benchmark/sa_db/clinvar.osa`, confirming the untouched v1 sources didn't regress.

**CI gates**: `cargo check --workspace --all-targets` clean (0 warnings), `cargo test --workspace` green - 44 binaries, **706 tests** (up from 662). Zero new clippy warnings (142 vs a 144 baseline). Every new test was mutation-checked by reverting the fix and confirming it fails.

## Behaviour change worth calling out

SpliceAI's **v1** `.osa` payload now renders delta scores in scientific notation (`8.500000e-1` rather than `0.85`), because both formats route through the same encode path - the mechanism AlphaMissense already uses to get byte-identity. Keys and their order are unchanged and every consumer uses a JSON parser (there's a test feeding both builders' output through the ACMG classifier's `SpliceAiData`), but a `.osa` built before this differs textually from one built after.

## Not fixed, noted

`.osi` and `.oga` still load their whole bincode payload into memory at open (O(n), no mmap), and tab output omits interval (`.osi`) columns entirely - both pre-date this branch and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
