### PR TITLE
chore(ci): pin the toolchain so a local check means what it says

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Install the toolchain rather than inheriting whatever the runner image
+      # ships. `rust-toolchain.toml` names the same channel, so a developer's
+      # local `cargo clippy` and this job resolve to one compiler instead of
+      # drifting apart until a lint gap shows up as a surprise red build.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - name: Check every target (libs, bins, tests)
         run: cargo check --workspace --all-targets
       # The workspace is clippy-clean; `-D warnings` keeps it that way. A lint

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,17 @@
+# Pin the toolchain to the channel CI uses, so a local check means what it says.
+#
+# CI runs `cargo clippy -- -D warnings` and gates on it. Before this file, CI
+# took whatever Rust the `ubuntu-latest` image happened to ship and a developer
+# took whatever they last installed, so the two drifted apart silently. That is
+# not hypothetical: a branch passed clippy locally on 1.94 and failed CI on
+# 1.97 over ten lints that only exist in the gap, none of which the author
+# could have seen.
+#
+# `stable` rather than a fixed version on purpose. Pinning an exact release
+# makes the gate reproducible and then stale, and the failure mode is a
+# toolchain bump nobody does until it is a large one. Tracking stable means the
+# lint set moves in small steps, and it moves for CI and for the developer at
+# the same time.
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
CI gates on `cargo clippy --workspace --all-targets -- -D warnings` but installed no toolchain, taking whatever Rust the `ubuntu-latest` image happened to ship. A developer took whatever they last installed. The two drifted silently until the gap showed up as a red build on a branch that had passed locally: 1.94 against CI's 1.97, ten lints that exist only in between, none of them visible to the author.

Two lines of defence, both naming the same channel:

- `rust-toolchain.toml` so a local `cargo clippy` resolves to the compiler CI uses.
- An explicit `dtolnay/rust-toolchain@stable` step in `ci.yml`, so the job declares its toolchain instead of inheriting it from the runner image. `release.yml` already did this; `ci.yml` was the one that did not.

`stable` rather than a fixed version, deliberately. Pinning an exact release makes the gate reproducible and then stale, and the failure mode is a toolchain bump nobody does until it is a large one. Tracking stable moves the lint set in small steps, and moves it for CI and the developer at the same time.

Verified locally on 1.97.1: `cargo check`, `cargo clippy -- -D warnings` and `cargo test --workspace` all pass.