### PR TITLE
style: rustfmt the workspace, in one isolated commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Commits that changed formatting only, and should not be attributed authorship
+# by `git blame`.
+#
+# GitHub honours this file automatically. Locally, opt in once with:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only add a commit here if it changed no behaviour. A commit listed by mistake
+# hides real authorship, which is worse than the noise it was meant to remove.
+
+# style: rustfmt the workspace
+39b0681a1100818e8b54dca747388a3eac143129

--- a/crates/fastvep-annotate/src/hgvs_normalize.rs
+++ b/crates/fastvep-annotate/src/hgvs_normalize.rs
@@ -197,52 +197,46 @@ pub fn three_prime_shift_intronic(
             let mut e = end;
 
             match strand {
-                fastvep_core::Strand::Forward => {
-                    loop {
-                        let next_pos = e + 1;
-                        if next_pos > intron_genomic_end {
-                            break;
-                        }
-                        let next_base = match seq_provider.fetch_sequence(chrom, next_pos, next_pos)
-                        {
-                            Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                            _ => break,
-                        };
-                        let first_base = match seq_provider.fetch_sequence(chrom, s, s) {
-                            Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                            _ => break,
-                        };
-                        if next_base == first_base {
-                            s += 1;
-                            e += 1;
-                        } else {
-                            break;
-                        }
+                fastvep_core::Strand::Forward => loop {
+                    let next_pos = e + 1;
+                    if next_pos > intron_genomic_end {
+                        break;
                     }
-                }
-                fastvep_core::Strand::Reverse => {
-                    loop {
-                        if s == 0 || s - 1 < intron_genomic_start {
-                            break;
-                        }
-                        let prev_pos = s - 1;
-                        let prev_base =
-                            match seq_provider.fetch_sequence(chrom, prev_pos, prev_pos) {
-                                Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                                _ => break,
-                            };
-                        let last_base = match seq_provider.fetch_sequence(chrom, e, e) {
-                            Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                            _ => break,
-                        };
-                        if prev_base == last_base {
-                            s -= 1;
-                            e -= 1;
-                        } else {
-                            break;
-                        }
+                    let next_base = match seq_provider.fetch_sequence(chrom, next_pos, next_pos) {
+                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                        _ => break,
+                    };
+                    let first_base = match seq_provider.fetch_sequence(chrom, s, s) {
+                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                        _ => break,
+                    };
+                    if next_base == first_base {
+                        s += 1;
+                        e += 1;
+                    } else {
+                        break;
                     }
-                }
+                },
+                fastvep_core::Strand::Reverse => loop {
+                    if s == 0 || s - 1 < intron_genomic_start {
+                        break;
+                    }
+                    let prev_pos = s - 1;
+                    let prev_base = match seq_provider.fetch_sequence(chrom, prev_pos, prev_pos) {
+                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                        _ => break,
+                    };
+                    let last_base = match seq_provider.fetch_sequence(chrom, e, e) {
+                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                        _ => break,
+                    };
+                    if prev_base == last_base {
+                        s -= 1;
+                        e -= 1;
+                    } else {
+                        break;
+                    }
+                },
             }
             (s, e)
         }
@@ -250,8 +244,7 @@ pub fn three_prime_shift_intronic(
         (Allele::Deletion, Allele::Sequence(ins_bases)) if !ins_bases.is_empty() => {
             let ins_len = ins_bases.len();
             let mut pos = start;
-            let genomic_ins: Vec<u8> =
-                ins_bases.iter().map(|b| b.to_ascii_uppercase()).collect();
+            let genomic_ins: Vec<u8> = ins_bases.iter().map(|b| b.to_ascii_uppercase()).collect();
 
             match strand {
                 fastvep_core::Strand::Forward => {
@@ -260,11 +253,10 @@ pub fn three_prime_shift_intronic(
                         if pos > intron_genomic_end {
                             break;
                         }
-                        let check_base =
-                            match seq_provider.fetch_sequence(chrom, pos, pos) {
-                                Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                                _ => break,
-                            };
+                        let check_base = match seq_provider.fetch_sequence(chrom, pos, pos) {
+                            Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                            _ => break,
+                        };
                         let idx = (shift_count as usize) % ins_len;
                         if check_base == genomic_ins[idx] {
                             pos += 1;

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -149,16 +149,17 @@ impl AnnotationContext {
         if let Some(ref sp) = seq_provider {
             let built = AtomicUsize::new(0);
             transcripts.par_iter_mut().for_each(|tr| {
-                if tr.is_coding() && tr.spliced_seq.is_none()
+                if tr.is_coding()
+                    && tr.spliced_seq.is_none()
                     && tr
                         .build_sequences(|chrom, start, end| {
                             sp.fetch_sequence(chrom, start, end)
                                 .map_err(|e| e.to_string())
                         })
                         .is_ok()
-                    {
-                        built.fetch_add(1, Ordering::Relaxed);
-                    }
+                {
+                    built.fetch_add(1, Ordering::Relaxed);
+                }
             });
             let built = built.load(Ordering::Relaxed);
             tracing::info!("Built sequences for {} coding transcripts", built);
@@ -269,16 +270,17 @@ impl AnnotationContext {
         if let Some(ref sp) = self.seq_provider {
             let mut built = 0usize;
             for tr in &mut transcripts {
-                if tr.is_coding() && tr.spliced_seq.is_none()
+                if tr.is_coding()
+                    && tr.spliced_seq.is_none()
                     && tr
                         .build_sequences(|chrom, start, end| {
                             sp.fetch_sequence(chrom, start, end)
                                 .map_err(|e| e.to_string())
                         })
                         .is_ok()
-                    {
-                        built += 1;
-                    }
+                {
+                    built += 1;
+                }
             }
             if built > 0 {
                 tracing::info!("Built sequences for {} coding transcripts", built);
@@ -297,11 +299,7 @@ impl AnnotationContext {
     }
 
     /// Annotate VCF text and return JSON results, using `self.acmg_config`.
-    pub fn annotate_vcf_text(
-        &self,
-        vcf_text: &str,
-        pick: bool,
-    ) -> Result<Vec<serde_json::Value>> {
+    pub fn annotate_vcf_text(&self, vcf_text: &str, pick: bool) -> Result<Vec<serde_json::Value>> {
         self.annotate_vcf_text_with_acmg(vcf_text, pick, self.acmg_config.as_ref())
     }
 
@@ -341,10 +339,7 @@ impl AnnotationContext {
         // is resolved once here instead of re-scanning every provider for every
         // variant.
         let has_gnomad = self.seq_provider.is_some()
-            && self
-                .sa_providers
-                .iter()
-                .any(|sa| sa.json_key() == "gnomad");
+            && self.sa_providers.iter().any(|sa| sa.json_key() == "gnomad");
 
         let functional_evidence = self.functional_evidence.as_ref();
 
@@ -360,9 +355,10 @@ impl AnnotationContext {
             if overlapping.is_empty() {
                 annotate_intergenic(vf);
             } else {
-                let ref_seq = self.seq_provider.as_ref().and_then(|sp| {
-                    sp.fetch_sequence(chrom, query_start, query_end).ok()
-                });
+                let ref_seq = self
+                    .seq_provider
+                    .as_ref()
+                    .and_then(|sp| sp.fetch_sequence(chrom, query_start, query_end).ok());
 
                 let result = self.predictor.predict(
                     &vf.position,
@@ -373,8 +369,7 @@ impl AnnotationContext {
                 );
 
                 for tc in &result.transcript_consequences {
-                    let transcript =
-                        overlapping.iter().find(|t| t.stable_id == tc.transcript_id);
+                    let transcript = overlapping.iter().find(|t| t.stable_id == tc.transcript_id);
 
                     let allele_annotations: Vec<AlleleAnnotation> = tc
                         .allele_consequences
@@ -669,11 +664,8 @@ impl AnnotationContext {
                             tsl: transcript.and_then(|t| t.tsl),
                             appris: transcript.and_then(|t| t.appris.clone()),
                             ccds: transcript.and_then(|t| t.ccds.clone()),
-                            gencode_primary: transcript
-                                .map(|t| t.gencode_primary)
-                                .unwrap_or(false),
-                            symbol_source: transcript
-                                .and_then(|t| t.gene.symbol_source.clone()),
+                            gencode_primary: transcript.map(|t| t.gencode_primary).unwrap_or(false),
+                            symbol_source: transcript.and_then(|t| t.gene.symbol_source.clone()),
                             hgnc_id: transcript.and_then(|t| t.gene.hgnc_id.clone()),
                             flags: transcript.map(|t| t.flags.clone()).unwrap_or_default(),
                         });
@@ -693,10 +685,8 @@ impl AnnotationContext {
                 // missing — which otherwise makes PM2 misfire on common
                 // variants. Applied only to the gnomAD lookup; every other
                 // source keeps the query unchanged.
-                let mut allele_results: std::collections::HashMap<
-                    String,
-                    Vec<(String, String)>,
-                > = std::collections::HashMap::new();
+                let mut allele_results: std::collections::HashMap<String, Vec<(String, String)>> =
+                    std::collections::HashMap::new();
                 for tv in &vf.transcript_variations {
                     for aa in &tv.allele_annotations {
                         let alt_str = aa.allele.to_string();
@@ -728,8 +718,7 @@ impl AnnotationContext {
                             } else {
                                 (vf.position.start, ref_str.as_str(), alt_str.as_str())
                             };
-                            if let Ok(Some(ann)) =
-                                sa.annotate_position(chrom, q_pos, q_ref, q_alt)
+                            if let Ok(Some(ann)) = sa.annotate_position(chrom, q_pos, q_ref, q_alt)
                             {
                                 let json_str = match ann {
                                     AnnotationValue::Json(j) => j,
@@ -762,13 +751,11 @@ impl AnnotationContext {
                         if seen_genes.insert(gene_sym.to_string()) {
                             for gp in &self.gene_providers {
                                 if let Ok(Some(json)) = gp.annotate_gene(gene_sym) {
-                                    vf.gene_annotations.push(
-                                        fastvep_core::GeneAnnotation {
-                                            gene_symbol: gene_sym.to_string(),
-                                            json_key: gp.json_key().to_string(),
-                                            json_string: json,
-                                        },
-                                    );
+                                    vf.gene_annotations.push(fastvep_core::GeneAnnotation {
+                                        gene_symbol: gene_sym.to_string(),
+                                        json_key: gp.json_key().to_string(),
+                                        json_string: json,
+                                    });
                                 }
                             }
                         }
@@ -790,43 +777,48 @@ impl AnnotationContext {
 
                 for tv in &mut vf.transcript_variations {
                     let gene_sym = tv.gene_symbol.as_deref().unwrap_or("");
-                    let gene_anns: Vec<&fastvep_core::GeneAnnotation> =
-                        vf.gene_annotations
-                            .iter()
-                            .filter(|ga| ga.gene_symbol == gene_sym)
-                            .collect();
+                    let gene_anns: Vec<&fastvep_core::GeneAnnotation> = vf
+                        .gene_annotations
+                        .iter()
+                        .filter(|ga| ga.gene_symbol == gene_sym)
+                        .collect();
                     for aa in &mut tv.allele_annotations {
                         let alt_idx = vf.alt_alleles.iter().position(|a| *a == aa.allele);
-                        let input =
-                            fastvep_classification::extract_classification_input(
-                                &aa.consequences,
-                                aa.impact,
-                                tv.gene_symbol.as_deref(),
-                                tv.canonical,
-                                aa.amino_acids.as_ref(),
-                                aa.protein_position.map(|(s, _)| s),
-                                aa.hgvsc.as_deref(),
-                                aa.exon,
-                                aa.protein_length,
-                                aa.escapes_nmd,
-                                repeat_db_loaded,
-                                splice_ps1_evidence(aa, &gene_anns, &query_alleles, alt_idx),
-                                alt_idx.and_then(|i| query_alleles.get(i)).map(|(_, pos, r, a)| {
-                                    (vf.position.chromosome.to_string(), *pos, r.clone(), a.clone())
+                        let input = fastvep_classification::extract_classification_input(
+                            &aa.consequences,
+                            aa.impact,
+                            tv.gene_symbol.as_deref(),
+                            tv.canonical,
+                            aa.amino_acids.as_ref(),
+                            aa.protein_position.map(|(s, _)| s),
+                            aa.hgvsc.as_deref(),
+                            aa.exon,
+                            aa.protein_length,
+                            aa.escapes_nmd,
+                            repeat_db_loaded,
+                            splice_ps1_evidence(aa, &gene_anns, &query_alleles, alt_idx),
+                            alt_idx
+                                .and_then(|i| query_alleles.get(i))
+                                .map(|(_, pos, r, a)| {
+                                    (
+                                        vf.position.chromosome.to_string(),
+                                        *pos,
+                                        r.clone(),
+                                        a.clone(),
+                                    )
                                 }),
-                                fastvep_classification::is_pure_insertion(&vf.ref_allele),
-                                alt_idx.and_then(|i| functional_by_alt[i].clone()),
-                                &aa.supplementary,
-                                &gene_anns,
-                                &vf.supplementary_annotations,
-                                trio_genotypes.0.clone(),
-                                trio_genotypes.1.clone(),
-                                trio_genotypes.2.clone(),
-                                vec![], // companion_variants populated in second pass
-                            );
+                            fastvep_classification::is_pure_insertion(&vf.ref_allele),
+                            alt_idx.and_then(|i| functional_by_alt[i].clone()),
+                            &aa.supplementary,
+                            &gene_anns,
+                            &vf.supplementary_annotations,
+                            trio_genotypes.0.clone(),
+                            trio_genotypes.1.clone(),
+                            trio_genotypes.2.clone(),
+                            vec![], // companion_variants populated in second pass
+                        );
                         let result = fastvep_classification::classify(&input, acmg_cfg);
-                        aa.acmg_classification =
-                            serde_json::to_value(&result).ok();
+                        aa.acmg_classification = serde_json::to_value(&result).ok();
                     }
                 }
             }
@@ -847,7 +839,10 @@ impl AnnotationContext {
             }
         }
 
-        Ok(variants.iter().map(|vf| output::format_json(vf, false)).collect())
+        Ok(variants
+            .iter()
+            .map(|vf| output::format_json(vf, false))
+            .collect())
     }
 }
 
@@ -1009,8 +1004,7 @@ fn extract_trio_genotypes(
     let format_str = &vcf_fields.rest[0];
     let sample_strs: Vec<&str> = vcf_fields.rest[1..].iter().map(|s| s.as_str()).collect();
 
-    let samples =
-        fastvep_io::sample::parse_samples(format_str, &sample_strs, sample_names);
+    let samples = fastvep_io::sample::parse_samples(format_str, &sample_strs, sample_names);
 
     let proband_gt = samples
         .iter()
@@ -1046,12 +1040,7 @@ fn sample_data_to_genotype_info(
     let is_phased = gt.is_some_and(|g| g.phased);
 
     // Determine which alt allele index is carried
-    let alt_allele_index = gt.and_then(|g| {
-        g.alleles
-            .iter()
-            .filter_map(|a| *a)
-            .find(|&a| a > 0)
-    });
+    let alt_allele_index = gt.and_then(|g| g.alleles.iter().filter_map(|a| *a).find(|&a| a > 0));
 
     fastvep_classification::GenotypeInfo {
         is_het,
@@ -1115,9 +1104,7 @@ fn enrich_compound_het(
                             c.get("code")
                                 .and_then(|v| v.as_str())
                                 .is_some_and(|code| code == "PP5" || code == "PS4")
-                                && c.get("met")
-                                    .and_then(|v| v.as_bool())
-                                    .unwrap_or(false)
+                                && c.get("met").and_then(|v| v.as_bool()).unwrap_or(false)
                         })
                     });
 
@@ -1278,9 +1265,16 @@ fn enrich_compound_het(
                 aa.escapes_nmd,
                 repeat_db_loaded,
                 splice_ps1_evidence(aa, &gene_anns, &query_alleles, alt_idx),
-                alt_idx.and_then(|i| query_alleles.get(i)).map(|(_, pos, r, a)| {
-                    (vf.position.chromosome.to_string(), *pos, r.clone(), a.clone())
-                }),
+                alt_idx
+                    .and_then(|i| query_alleles.get(i))
+                    .map(|(_, pos, r, a)| {
+                        (
+                            vf.position.chromosome.to_string(),
+                            *pos,
+                            r.clone(),
+                            a.clone(),
+                        )
+                    }),
                 fastvep_classification::is_pure_insertion(&vf.ref_allele),
                 alt_idx.and_then(|i| functional_by_alt[i].clone()),
                 &aa.supplementary,
@@ -1308,9 +1302,7 @@ fn enrich_compound_het(
 /// startup scale linearly with shard count for no reason. Sorting by path also
 /// makes the provider order - and therefore the output column order - depend on
 /// the file names rather than on directory iteration order.
-pub fn load_sa_providers(
-    sa_dir: &Path,
-) -> Result<Vec<Box<dyn AnnotationProvider>>> {
+pub fn load_sa_providers(sa_dir: &Path) -> Result<Vec<Box<dyn AnnotationProvider>>> {
     use fastvep_sa::interval::OsiReader;
     use fastvep_sa::reader::SaReader;
     use fastvep_sa::reader_v2::Osa2Reader;
@@ -1391,9 +1383,7 @@ fn sorted_paths_with_extensions(dir: &Path, exts: &[&str]) -> Result<Vec<std::pa
 /// Load gene-level annotation providers (.oga files) from a directory.
 ///
 /// Same ordering and parallelism contract as [`load_sa_providers`].
-pub fn load_gene_providers(
-    sa_dir: &Path,
-) -> Result<Vec<fastvep_sa::gene::GeneIndex>> {
+pub fn load_gene_providers(sa_dir: &Path) -> Result<Vec<fastvep_sa::gene::GeneIndex>> {
     use rayon::prelude::*;
 
     if !sa_dir.is_dir() {
@@ -1524,9 +1514,7 @@ mod tests {
         // acmg_requested=false) must take precedence over self.acmg_config,
         // since concurrent requests share one AnnotationContext and must not
         // leak each other's ACMG preference.
-        let results = ctx
-            .annotate_vcf_text_with_acmg(vcf, false, None)
-            .unwrap();
+        let results = ctx.annotate_vcf_text_with_acmg(vcf, false, None).unwrap();
         assert_eq!(results.len(), 1);
     }
 

--- a/crates/fastvep-annotate/tests/mitochondrial.rs
+++ b/crates/fastvep-annotate/tests/mitochondrial.rs
@@ -111,7 +111,10 @@ fn mt_tga_reads_as_tryptophan_not_stop() {
     let fasta = ">MT\nATGTGGAAATAA\n";
     let mut transcript = mt_transcript(1, 12, 12);
     build_sequences_from_fasta(&mut transcript, fasta);
-    assert_eq!(transcript.translateable_seq.as_deref(), Some("ATGTGGAAATAA"));
+    assert_eq!(
+        transcript.translateable_seq.as_deref(),
+        Some("ATGTGGAAATAA")
+    );
     // Peptide translation (Transcript::build_sequences) must also use the
     // mitochondrial table: MTAK* would be wrong; the correct read is M W K *.
     assert_eq!(transcript.peptide.as_deref(), Some("MWK*"));
@@ -164,11 +167,11 @@ fn mt_origin_spanning_allele_produces_stop_gained() {
     seq[16565] = b'A'; // pos 16566
     seq[16566] = b'T'; // pos 16567
     seq[16567] = b'G'; // pos 16568
-    // Codon 2 (protein pos 2), genomic 16569, then wraps to 1, 2: "CGA".
+                       // Codon 2 (protein pos 2), genomic 16569, then wraps to 1, 2: "CGA".
     seq[16568] = b'C'; // pos 16569 (last base of the contig)
     seq[0] = b'G'; // pos 1 (wrapped)
     seq[1] = b'A'; // pos 2 (wrapped)
-    // Codon 3 (protein pos 3), wrapped genomic 3, 4, 5: "AAA" (Lys).
+                   // Codon 3 (protein pos 3), wrapped genomic 3, 4, 5: "AAA" (Lys).
     seq[2] = b'A';
     seq[3] = b'A';
     seq[4] = b'A';

--- a/crates/fastvep-annotate/tests/sa_provider_loading.rs
+++ b/crates/fastvep-annotate/tests/sa_provider_loading.rs
@@ -66,10 +66,7 @@ fn providers_are_ordered_by_path() {
     }
 
     let providers = load_sa_providers(dir.path()).unwrap();
-    let keys: Vec<String> = providers
-        .iter()
-        .map(|p| p.json_key().to_string())
-        .collect();
+    let keys: Vec<String> = providers.iter().map(|p| p.json_key().to_string()).collect();
 
     // Sorted by file name, which is lexicographic - chr1 < chr2 < chr21 < chr9.
     assert_eq!(keys, vec!["k1", "k2", "k21", "k9"]);
@@ -87,10 +84,7 @@ fn an_unopenable_source_is_skipped_not_fatal() {
     std::fs::write(dir.path().join("notes.txt"), b"ignore me").unwrap();
 
     let providers = load_sa_providers(dir.path()).unwrap();
-    let keys: Vec<String> = providers
-        .iter()
-        .map(|p| p.json_key().to_string())
-        .collect();
+    let keys: Vec<String> = providers.iter().map(|p| p.json_key().to_string()).collect();
     assert_eq!(keys, vec!["good_a", "good_c"]);
 }
 

--- a/crates/fastvep-cache/src/fasta.rs
+++ b/crates/fastvep-cache/src/fasta.rs
@@ -46,15 +46,15 @@ impl FastaReader {
                 // An empty header would silently produce an unnamed sequence
                 // that downstream lookups can never match; surface it
                 // explicitly so the caller knows the file is malformed.
-                let name = line.strip_prefix('>').unwrap_or(line)
+                let name = line
+                    .strip_prefix('>')
+                    .unwrap_or(line)
                     .split_whitespace()
                     .next()
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string())
                     .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "FASTA contains a `>` line with no sequence identifier"
-                        )
+                        anyhow::anyhow!("FASTA contains a `>` line with no sequence identifier")
                     })?;
                 current_name = Some(name);
                 current_seq.clear();
@@ -138,17 +138,22 @@ impl MmapFastaReader {
         let fai_contents = std::fs::read_to_string(&fai_path)
             .with_context(|| format!("Reading FASTA index: {}", fai_path))?;
         let index = parse_fai(&fai_contents)?;
-        let name_to_idx: HashMap<String, usize> = index.iter()
+        let name_to_idx: HashMap<String, usize> = index
+            .iter()
             .enumerate()
             .map(|(i, e)| (e.name.clone(), i))
             .collect();
 
         let file = std::fs::File::open(fasta_path)
             .with_context(|| format!("Opening FASTA: {}", fasta_path.display()))?;
-        let mmap = unsafe { memmap2::Mmap::map(&file) }
-            .with_context(|| "Memory-mapping FASTA file")?;
+        let mmap =
+            unsafe { memmap2::Mmap::map(&file) }.with_context(|| "Memory-mapping FASTA file")?;
 
-        Ok(Self { mmap, index, name_to_idx })
+        Ok(Self {
+            mmap,
+            index,
+            name_to_idx,
+        })
     }
 
     #[inline]
@@ -173,7 +178,12 @@ impl MmapFastaReader {
         let end_0 = end.min(entry.length).saturating_sub(1);
 
         if start_0 >= entry.length {
-            anyhow::bail!("Start {} exceeds length {} for {}", start, entry.length, chrom);
+            anyhow::bail!(
+                "Start {} exceeds length {} for {}",
+                start,
+                entry.length,
+                chrom
+            );
         }
 
         let bases_needed = (end_0 - start_0 + 1) as usize;

--- a/crates/fastvep-cache/src/gff.rs
+++ b/crates/fastvep-cache/src/gff.rs
@@ -29,9 +29,10 @@ pub fn parse_gff3<R: Read>(reader: R) -> Result<Vec<Transcript>> {
 /// indistinguishable from a single-source one.
 pub fn parse_gff3_with_source<R: Read>(reader: R, source: &str) -> Result<Vec<Transcript>> {
     let buf = BufReader::new(reader);
-    let lines = buf.lines().enumerate().map(|(i, line)| {
-        line.map_err(|e| anyhow::anyhow!("Reading GFF3 line {}: {}", i + 1, e))
-    });
+    let lines = buf
+        .lines()
+        .enumerate()
+        .map(|(i, line)| line.map_err(|e| anyhow::anyhow!("Reading GFF3 line {}: {}", i + 1, e)));
     let mut trs = parse_gff3_lines(lines)?;
     for tr in &mut trs {
         tr.source = Some(source.to_string());
@@ -68,19 +69,20 @@ fn parse_gff3_indexed_inner(
     regions: &[(String, u64, u64)],
 ) -> Result<Vec<Transcript>> {
     use noodles_bgzf as bgzf;
-    use noodles_core::Position;
     use noodles_core::region::Interval;
+    use noodles_core::Position;
     use noodles_csi::binning_index::BinningIndex;
     use noodles_tabix as tabix;
-
 
     let tbi_path = format!("{}.tbi", gff3_gz_path.display());
     let index = tabix::fs::read(&tbi_path)
         .map_err(|e| anyhow::anyhow!("Reading tabix index {}: {}", tbi_path, e))?;
 
-    let header = index.header()
+    let header = index
+        .header()
         .ok_or_else(|| anyhow::anyhow!("Missing tabix header"))?;
-    let ref_names: Vec<String> = header.reference_sequence_names()
+    let ref_names: Vec<String> = header
+        .reference_sequence_names()
         .iter()
         .map(|n| n.to_string())
         .collect();
@@ -90,25 +92,22 @@ fn parse_gff3_indexed_inner(
 
     for (chrom, start, end) in regions {
         // Find reference ID, trying with/without "chr" prefix
-        let ref_id = ref_names.iter().position(|n| n == chrom)
-            .or_else(|| {
-                if chrom.starts_with("chr") {
-                    ref_names.iter().position(|n| n == &chrom[3..])
-                } else {
-                    let with_chr = format!("chr{}", chrom);
-                    ref_names.iter().position(|n| *n == with_chr)
-                }
-            });
+        let ref_id = ref_names.iter().position(|n| n == chrom).or_else(|| {
+            if chrom.starts_with("chr") {
+                ref_names.iter().position(|n| n == &chrom[3..])
+            } else {
+                let with_chr = format!("chr{}", chrom);
+                ref_names.iter().position(|n| *n == with_chr)
+            }
+        });
 
         let ref_id = match ref_id {
             Some(id) => id,
             None => continue,
         };
 
-        let pos_start = Position::try_from((*start).max(1) as usize)
-            .unwrap_or(Position::MIN);
-        let pos_end = Position::try_from(*end as usize)
-            .unwrap_or(Position::MIN);
+        let pos_start = Position::try_from((*start).max(1) as usize).unwrap_or(Position::MIN);
+        let pos_end = Position::try_from(*end as usize).unwrap_or(Position::MIN);
         let query_interval: Interval = (pos_start..=pos_end).into();
 
         let chunks = match index.query(ref_id, query_interval) {
@@ -126,11 +125,15 @@ fn parse_gff3_indexed_inner(
             loop {
                 line.clear();
                 let bytes = reader.read_line(&mut line)?;
-                if bytes == 0 { break; }
+                if bytes == 0 {
+                    break;
+                }
 
                 let trimmed = line.trim();
                 if trimmed.is_empty() || trimmed.starts_with('#') {
-                    if reader.virtual_position() >= chunk.end() { break; }
+                    if reader.virtual_position() >= chunk.end() {
+                        break;
+                    }
                     continue;
                 }
 
@@ -145,7 +148,9 @@ fn parse_gff3_indexed_inner(
                     all_lines.push(trimmed.to_string());
                 }
 
-                if reader.virtual_position() >= chunk.end() { break; }
+                if reader.virtual_position() >= chunk.end() {
+                    break;
+                }
             }
         }
     }
@@ -159,9 +164,7 @@ fn parse_gff3_indexed_inner(
 /// builds Transcript models. Each item is either a raw line or a typed IO
 /// error from the underlying reader; the latter aborts parsing immediately
 /// rather than being silently treated as an empty line.
-fn parse_gff3_lines(
-    lines: impl Iterator<Item = Result<String>>,
-) -> Result<Vec<Transcript>> {
+fn parse_gff3_lines(lines: impl Iterator<Item = Result<String>>) -> Result<Vec<Transcript>> {
     let mut genes: HashMap<String, GffGene> = HashMap::new();
     let mut transcripts: HashMap<String, GffTranscript> = HashMap::new();
     let mut exons: Vec<GffExon> = Vec::new();
@@ -224,10 +227,11 @@ fn parse_gff3_lines(
                     .cloned()
                     .unwrap_or_default();
                 // Strip "gene:" prefix if present (Ensembl GFF3)
-                let gene_id = gene_id.strip_prefix("gene:").unwrap_or(&gene_id).to_string();
-                let symbol = attrs.get("Name")
-                    .or_else(|| attrs.get("gene"))
-                    .cloned();
+                let gene_id = gene_id
+                    .strip_prefix("gene:")
+                    .unwrap_or(&gene_id)
+                    .to_string();
+                let symbol = attrs.get("Name").or_else(|| attrs.get("gene")).cloned();
                 let biotype = attrs
                     .get("biotype")
                     .or_else(|| attrs.get("gene_biotype"))
@@ -254,9 +258,21 @@ fn parse_gff3_lines(
                     },
                 );
             }
-            "mRNA" | "transcript" | "lnc_RNA" | "miRNA" | "snRNA" | "snoRNA" | "rRNA"
-            | "ncRNA" | "tRNA" | "scRNA" | "V_gene_segment" | "D_gene_segment"
-            | "J_gene_segment" | "C_gene_segment" | "NMD_transcript_variant"
+            "mRNA"
+            | "transcript"
+            | "lnc_RNA"
+            | "miRNA"
+            | "snRNA"
+            | "snoRNA"
+            | "rRNA"
+            | "ncRNA"
+            | "tRNA"
+            | "scRNA"
+            | "V_gene_segment"
+            | "D_gene_segment"
+            | "J_gene_segment"
+            | "C_gene_segment"
+            | "NMD_transcript_variant"
             | "pseudogenic_transcript" => {
                 let transcript_id = attrs
                     .get("ID")
@@ -267,10 +283,7 @@ fn parse_gff3_lines(
                     .strip_prefix("transcript:")
                     .unwrap_or(&transcript_id)
                     .to_string();
-                let parent = attrs
-                    .get("Parent")
-                    .cloned()
-                    .unwrap_or_default();
+                let parent = attrs.get("Parent").cloned().unwrap_or_default();
                 let parent = parent.strip_prefix("gene:").unwrap_or(&parent).to_string();
                 let biotype = attrs
                     .get("biotype")
@@ -296,9 +309,9 @@ fn parse_gff3_lines(
                 let ccds = attrs.get("ccdsid").cloned();
 
                 // Parse TSL: "1 (assigned to previous version 2)" → 1
-                let tsl: Option<u8> = attrs.get("transcript_support_level").and_then(|v| {
-                    v.split_whitespace().next().and_then(|n| n.parse().ok())
-                });
+                let tsl: Option<u8> = attrs
+                    .get("transcript_support_level")
+                    .and_then(|v| v.split_whitespace().next().and_then(|n| n.parse().ok()));
 
                 transcripts.insert(
                     transcript_id.clone(),
@@ -332,7 +345,10 @@ fn parse_gff3_lines(
                     .or_else(|| attrs.get("exon_id"))
                     .cloned()
                     .unwrap_or_default();
-                let exon_id = exon_id.strip_prefix("exon:").unwrap_or(&exon_id).to_string();
+                let exon_id = exon_id
+                    .strip_prefix("exon:")
+                    .unwrap_or(&exon_id)
+                    .to_string();
                 let rank: u32 = attrs
                     .get("rank")
                     .or_else(|| attrs.get("exon_number"))
@@ -370,7 +386,8 @@ fn parse_gff3_lines(
                     })
                     .unwrap_or_default();
 
-                let protein_version: Option<u32> = attrs.get("version").and_then(|v| v.parse().ok());
+                let protein_version: Option<u32> =
+                    attrs.get("version").and_then(|v| v.parse().ok());
 
                 cds_features.push(GffCds {
                     parent_transcript: parent,
@@ -442,13 +459,14 @@ fn parse_gff3_lines(
     // Create implicit exons for CDS features under implicit transcripts
     // that have no corresponding exon (bacterial genomes where CDS = exon)
     {
-        let exon_parents: std::collections::HashSet<&str> = exons
-            .iter()
-            .map(|e| e.parent_transcript.as_str())
-            .collect();
+        let exon_parents: std::collections::HashSet<&str> =
+            exons.iter().map(|e| e.parent_transcript.as_str()).collect();
         let implicit_exons: Vec<GffExon> = cds_features
             .iter()
-            .filter(|cds| cds.parent_transcript.ends_with("_t1") && !exon_parents.contains(cds.parent_transcript.as_str()))
+            .filter(|cds| {
+                cds.parent_transcript.ends_with("_t1")
+                    && !exon_parents.contains(cds.parent_transcript.as_str())
+            })
             .map(|cds| GffExon {
                 id: format!("exon_{}_{}_{}", cds.parent_transcript, cds.start, cds.end),
                 parent_transcript: cds.parent_transcript.clone(),
@@ -466,11 +484,17 @@ fn parse_gff3_lines(
     // This replaces the O(T*E) nested scan in the assembly loop.
     let mut exons_by_tx: HashMap<String, Vec<GffExon>> = HashMap::new();
     for exon in exons {
-        exons_by_tx.entry(exon.parent_transcript.clone()).or_default().push(exon);
+        exons_by_tx
+            .entry(exon.parent_transcript.clone())
+            .or_default()
+            .push(exon);
     }
     let mut cds_by_tx: HashMap<String, Vec<GffCds>> = HashMap::new();
     for cds in cds_features {
-        cds_by_tx.entry(cds.parent_transcript.clone()).or_default().push(cds);
+        cds_by_tx
+            .entry(cds.parent_transcript.clone())
+            .or_default()
+            .push(cds);
     }
 
     // Build transcripts
@@ -545,8 +569,16 @@ fn parse_gff3_lines(
         // "missing" bases, effectively shifting cdna_coding_start earlier.
         let first_cds_ensembl_phase: u64 = if !tr_cds.is_empty() {
             let gff_phase = match gff_tr.strand {
-                Strand::Forward => tr_cds.iter().min_by_key(|c| c.start).map(|c| c.phase).unwrap_or(0),
-                Strand::Reverse => tr_cds.iter().max_by_key(|c| c.end).map(|c| c.phase).unwrap_or(0),
+                Strand::Forward => tr_cds
+                    .iter()
+                    .min_by_key(|c| c.start)
+                    .map(|c| c.phase)
+                    .unwrap_or(0),
+                Strand::Reverse => tr_cds
+                    .iter()
+                    .max_by_key(|c| c.end)
+                    .map(|c| c.phase)
+                    .unwrap_or(0),
             };
             match gff_phase {
                 1 => 2,
@@ -625,18 +657,30 @@ fn parse_gff3_lines(
                 let exon_len = exon.end - exon.start + 1;
                 match gff_tr.strand {
                     Strand::Forward => {
-                        if cs.is_none() && tl.genomic_start >= exon.start && tl.genomic_start <= exon.end {
+                        if cs.is_none()
+                            && tl.genomic_start >= exon.start
+                            && tl.genomic_start <= exon.end
+                        {
                             cs = Some(cdna_pos + (tl.genomic_start - exon.start) + 1);
                         }
-                        if ce.is_none() && tl.genomic_end >= exon.start && tl.genomic_end <= exon.end {
+                        if ce.is_none()
+                            && tl.genomic_end >= exon.start
+                            && tl.genomic_end <= exon.end
+                        {
                             ce = Some(cdna_pos + (tl.genomic_end - exon.start) + 1);
                         }
                     }
                     Strand::Reverse => {
-                        if cs.is_none() && tl.genomic_end >= exon.start && tl.genomic_end <= exon.end {
+                        if cs.is_none()
+                            && tl.genomic_end >= exon.start
+                            && tl.genomic_end <= exon.end
+                        {
                             cs = Some(cdna_pos + (exon.end - tl.genomic_end) + 1);
                         }
-                        if ce.is_none() && tl.genomic_start >= exon.start && tl.genomic_start <= exon.end {
+                        if ce.is_none()
+                            && tl.genomic_start >= exon.start
+                            && tl.genomic_start <= exon.end
+                        {
                             ce = Some(cdna_pos + (exon.end - tl.genomic_start) + 1);
                         }
                     }
@@ -692,11 +736,7 @@ fn parse_gff3_lines(
             appris: None,
             ccds: gff_tr.ccds.clone(),
             protein_id: tr_cds.first().map(|c| c.protein_id.clone()),
-            protein_version: if !tr_cds.is_empty() {
-                Some(1)
-            } else {
-                None
-            },
+            protein_version: if !tr_cds.is_empty() { Some(1) } else { None },
             swissprot: vec![],
             trembl: vec![],
             uniparc: vec![],
@@ -895,7 +935,10 @@ chr1\tensembl\texon\t6000\t9000\t.\t-\t.\tID=exon:ENSE00000002;Parent=transcript
         assert_eq!(transcripts.len(), 2);
 
         // MANE Select transcript
-        let ms = transcripts.iter().find(|t| &*t.stable_id == "ENST00000001").unwrap();
+        let ms = transcripts
+            .iter()
+            .find(|t| &*t.stable_id == "ENST00000001")
+            .unwrap();
         assert!(ms.canonical);
         assert_eq!(ms.mane_select.as_deref(), Some("ENST00000001.7"));
         assert!(ms.mane_plus_clinical.is_none());
@@ -904,7 +947,10 @@ chr1\tensembl\texon\t6000\t9000\t.\t-\t.\tID=exon:ENSE00000002;Parent=transcript
         assert_eq!(ms.tsl, Some(1));
 
         // MANE Plus Clinical transcript
-        let mpc = transcripts.iter().find(|t| &*t.stable_id == "ENST00000002").unwrap();
+        let mpc = transcripts
+            .iter()
+            .find(|t| &*t.stable_id == "ENST00000002")
+            .unwrap();
         assert!(!mpc.canonical);
         assert!(mpc.mane_select.is_none());
         assert_eq!(mpc.mane_plus_clinical.as_deref(), Some("ENST00000002.3"));
@@ -965,8 +1011,7 @@ chr1\tensembl\tCDS\t1050\t1200\t.\t+\t0\tID=CDS:P1;Parent=transcript:TX3";
         // The merged-cache path relies on per-file source tagging — without
         // it, transcripts from Ensembl and RefSeq runs are indistinguishable
         // in the SOURCE column.
-        let transcripts =
-            parse_gff3_with_source(sample_gff3().as_bytes(), "RefSeq").unwrap();
+        let transcripts = parse_gff3_with_source(sample_gff3().as_bytes(), "RefSeq").unwrap();
         assert!(!transcripts.is_empty());
         for tr in &transcripts {
             assert_eq!(tr.source.as_deref(), Some("RefSeq"));

--- a/crates/fastvep-cache/src/info.rs
+++ b/crates/fastvep-cache/src/info.rs
@@ -117,6 +117,9 @@ source_assembly\tGRCh38.p14";
         assert_eq!(info.variation_cols[0], "variation_name");
         assert_eq!(info.valid_chromosomes.len(), 25);
         assert_eq!(info.valid_chromosomes[0], "1");
-        assert_eq!(info.version_data.get("source_gencode").unwrap(), "GENCODE 46");
+        assert_eq!(
+            info.version_data.get("source_gencode").unwrap(),
+            "GENCODE 46"
+        );
     }
 }

--- a/crates/fastvep-cache/src/lib.rs
+++ b/crates/fastvep-cache/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod annotation;
-pub mod gff;
 pub mod fasta;
+pub mod gff;
 pub mod info;
 pub mod normalize;
 pub mod providers;

--- a/crates/fastvep-cache/src/normalize.rs
+++ b/crates/fastvep-cache/src/normalize.rs
@@ -96,7 +96,10 @@ pub fn normalize_variant(
         // over unambiguous A/C/G/T — like vt/bcftools, stop at N so we never
         // produce an N-anchored representation inside an assembly gap.
         let prev = match seq.fetch_sequence(chrom, p - 1, p - 1) {
-            Ok(s) if s.len() == 1 && matches!(s[0].to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T') => {
+            Ok(s)
+                if s.len() == 1
+                    && matches!(s[0].to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T') =>
+            {
                 s[0].to_ascii_uppercase()
             }
             _ => break, // fetch failed / short read / N / ambiguous → stop here.
@@ -168,14 +171,27 @@ mod tests {
 
     #[test]
     fn snv_is_noop() {
-        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "ACGTACGT",
+        };
         let n = normalize_variant(&r, "chr1", 3, "G", "T");
-        assert_eq!(n, NormalizedVariant { pos: 3, ref_allele: "G".into(), alt_allele: "T".into() });
+        assert_eq!(
+            n,
+            NormalizedVariant {
+                pos: 3,
+                ref_allele: "G".into(),
+                alt_allele: "T".into()
+            }
+        );
     }
 
     #[test]
     fn mnv_equal_len_is_noop() {
-        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "ACGTACGT",
+        };
         let n = normalize_variant(&r, "chr1", 2, "CG", "TT");
         assert_eq!(n.pos, 2);
         assert_eq!(n.ref_allele, "CG");
@@ -186,7 +202,10 @@ mod tests {
     fn suffix_trim_deletion() {
         // ref=CAT alt=CT share suffix T → CA/C; then no left-repeat to shift.
         // Reference around pos 10: ...positions 10=C,11=A,12=T...
-        let r = StrRef { chrom: "chr1", seq: "NNNNNNNNNCATGGG" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "NNNNNNNNNCATGGG",
+        };
         let n = normalize_variant(&r, "chr1", 10, "CAT", "CT");
         // Suffix-trim T → (CA, C) at pos 10. Anchor 'C' shared; left base is
         // 'N' (pos 9) which is ACGTN but rolling would just walk through Ns;
@@ -199,12 +218,18 @@ mod tests {
         // Microsatellite: positions 1.. = "G TAAC TAAC TAAC ...".
         // Reference: G at 1, then TAAC repeated.
         // Seq: pos1=G,2=T,3=A,4=A,5=C,6=T,7=A,8=A,9=C,10=T,11=A,12=A,13=C,...
-        let r = StrRef { chrom: "chr2", seq: "GTAACTAACTAACTAACG" };
+        let r = StrRef {
+            chrom: "chr2",
+            seq: "GTAACTAACTAACTAACG",
+        };
         // A right-anchored 4-base (TAAC) contraction written at pos 6:
         // ref=CTAAC alt=C (delete one TAAC copy). Should left-align to pos 1
         // (anchor G) → ref=GTAAC, alt=G.
         let n = normalize_variant(&r, "chr2", 5, "CTAAC", "C");
-        assert_eq!(n.pos, 1, "deletion should left-align to the leftmost repeat copy");
+        assert_eq!(
+            n.pos, 1,
+            "deletion should left-align to the leftmost repeat copy"
+        );
         assert_eq!(n.ref_allele, "GTAAC");
         assert_eq!(n.alt_allele, "G");
     }
@@ -213,7 +238,10 @@ mod tests {
     fn insertion_left_align_in_homopolymer() {
         // Homopolymer A-run: pos1=C, 2..=AAAA. An inserted 'A' anywhere in the
         // run left-aligns to the C anchor at pos 1.
-        let r = StrRef { chrom: "chr3", seq: "CAAAAG" };
+        let r = StrRef {
+            chrom: "chr3",
+            seq: "CAAAAG",
+        };
         // Insertion written at pos 4: ref=A alt=AA → left-align to pos1 C anchor.
         let n = normalize_variant(&r, "chr3", 4, "A", "AA");
         assert_eq!(n.pos, 1);
@@ -224,7 +252,10 @@ mod tests {
     #[test]
     fn contig_start_boundary_no_panic() {
         // Deletion already adjacent to position 1 cannot shift further left.
-        let r = StrRef { chrom: "chr1", seq: "ATTTTG" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "ATTTTG",
+        };
         let n = normalize_variant(&r, "chr1", 1, "AT", "A");
         assert_eq!(n.pos, 1);
         assert!(!n.ref_allele.is_empty() && !n.alt_allele.is_empty());
@@ -242,7 +273,10 @@ mod tests {
 
     #[test]
     fn non_acgtn_is_noop() {
-        let r = StrRef { chrom: "chr1", seq: "ACGTACGT" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "ACGTACGT",
+        };
         let n = normalize_variant(&r, "chr1", 2, "C", "*");
         assert_eq!(n.alt_allele, "*");
         assert_eq!(n.pos, 2);
@@ -253,7 +287,10 @@ mod tests {
         // Reference: pos1=A, then an N-gap, then a real region. A deletion just
         // right of the N-run must NOT roll into the gap (vt/bcftools stop at N).
         // seq: pos1=A,2=N,3=N,4=C,5=A,6=T,7=G
-        let r = StrRef { chrom: "chr1", seq: "ANNCATG" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "ANNCATG",
+        };
         // ref=CAT alt=CT at pos4 → suffix-trim to (CA,C); left base pos3='N' → stop.
         let n = normalize_variant(&r, "chr1", 4, "CAT", "CT");
         assert_eq!(n.pos, 4);
@@ -264,7 +301,10 @@ mod tests {
     #[test]
     fn already_minimal_insertion_unchanged() {
         // ref=A alt=AT with no left repeat of T → stays put.
-        let r = StrRef { chrom: "chr1", seq: "GGAGGG" };
+        let r = StrRef {
+            chrom: "chr1",
+            seq: "GGAGGG",
+        };
         let n = normalize_variant(&r, "chr1", 3, "A", "AT");
         assert_eq!(n.pos, 3);
         assert_eq!(n.ref_allele, "A");

--- a/crates/fastvep-cache/src/providers.rs
+++ b/crates/fastvep-cache/src/providers.rs
@@ -101,7 +101,10 @@ impl IndexedTranscriptProvider {
             }
             suffix_max_end.insert(Arc::clone(chrom), sme);
         }
-        Self { by_chrom, suffix_max_end }
+        Self {
+            by_chrom,
+            suffix_max_end,
+        }
     }
 
     pub fn transcript_count(&self) -> usize {
@@ -115,9 +118,11 @@ impl IndexedTranscriptProvider {
         if let Some((k, _)) = self.by_chrom.get_key_value(chrom) {
             return Some(k.as_ref());
         }
-        chrom_aliases(chrom)
-            .into_iter()
-            .find_map(|alias| self.by_chrom.get_key_value(alias.as_str()).map(|(k, _)| k.as_ref()))
+        chrom_aliases(chrom).into_iter().find_map(|alias| {
+            self.by_chrom
+                .get_key_value(alias.as_str())
+                .map(|(k, _)| k.as_ref())
+        })
     }
 }
 
@@ -213,9 +218,13 @@ impl FastaSequenceProvider {
 
 impl SequenceProvider for FastaSequenceProvider {
     fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
-        fetch_circular(chrom, start, end, self.reader.sequence_length(chrom), |c, s, e| {
-            self.reader.fetch(c, s, e)
-        })
+        fetch_circular(
+            chrom,
+            start,
+            end,
+            self.reader.sequence_length(chrom),
+            |c, s, e| self.reader.fetch(c, s, e),
+        )
     }
 }
 
@@ -233,9 +242,13 @@ impl MmapFastaSequenceProvider {
 
 impl SequenceProvider for MmapFastaSequenceProvider {
     fn fetch_sequence(&self, chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
-        fetch_circular(chrom, start, end, self.reader.sequence_length(chrom), |c, s, e| {
-            self.reader.fetch(c, s, e)
-        })
+        fetch_circular(
+            chrom,
+            start,
+            end,
+            self.reader.sequence_length(chrom),
+            |c, s, e| self.reader.fetch(c, s, e),
+        )
     }
 }
 
@@ -305,9 +318,9 @@ impl VariationProvider for TabixVariationProvider {
             }
 
             // Check allele match
-            if let Some(matched_alt) = variation::match_alleles(
-                ref_allele, alt_allele, start, end, record,
-            ) {
+            if let Some(matched_alt) =
+                variation::match_alleles(ref_allele, alt_allele, start, end, record)
+            {
                 // Extract per-allele frequencies for the matched allele
                 let mut freqs = HashMap::new();
                 for (pop, freq_str) in &record.frequencies {
@@ -317,7 +330,8 @@ impl VariationProvider for TabixVariationProvider {
                 }
 
                 // Also include MAF if minor_allele matches
-                if let (Some(ref ma), Some(maf)) = (&record.minor_allele, record.minor_allele_freq) {
+                if let (Some(ref ma), Some(maf)) = (&record.minor_allele, record.minor_allele_freq)
+                {
                     if ma.eq_ignore_ascii_case(&matched_alt) {
                         freqs.entry("minor_allele_freq".into()).or_insert(maf);
                     }

--- a/crates/fastvep-cache/src/transcript_cache.rs
+++ b/crates/fastvep-cache/src/transcript_cache.rs
@@ -18,8 +18,8 @@ const CACHE_MAGIC_V1: &[u8; 8] = b"FSTVEP01";
 
 /// Save transcripts to a binary cache file (bincode + zstd).
 pub fn save_cache(transcripts: &[Transcript], path: &Path) -> Result<()> {
-    let file = File::create(path)
-        .with_context(|| format!("Creating cache file: {}", path.display()))?;
+    let file =
+        File::create(path).with_context(|| format!("Creating cache file: {}", path.display()))?;
     let writer = BufWriter::new(file);
     // zstd level 1: fast compression, still much better decompression than gzip
     let mut zst = zstd::Encoder::new(writer, 1)?;
@@ -39,15 +39,16 @@ pub fn save_cache(transcripts: &[Transcript], path: &Path) -> Result<()> {
 /// Load transcripts from a binary cache file.
 /// Supports both zstd (v2) and legacy gzip (v1) formats.
 pub fn load_cache(path: &Path) -> Result<Vec<Transcript>> {
-    let file = File::open(path)
-        .with_context(|| format!("Opening cache file: {}", path.display()))?;
+    let file =
+        File::open(path).with_context(|| format!("Opening cache file: {}", path.display()))?;
     let mut reader = BufReader::new(file);
 
     // Peek at the first bytes to detect format.
     // zstd frames start with 0x28B52FFD; gzip starts with 0x1F8B.
     use std::io::Read;
     let mut peek = [0u8; 4];
-    reader.read_exact(&mut peek)
+    reader
+        .read_exact(&mut peek)
         .with_context(|| "Reading cache header")?;
 
     // Rewind so the decompressor sees the full stream
@@ -156,17 +157,15 @@ mod tests {
             start: 1000,
             end: 5000,
             strand: Strand::Forward,
-            exons: vec![
-                Exon {
-                    stable_id: "ENSE001".into(),
-                    start: 1000,
-                    end: 1200,
-                    strand: Strand::Forward,
-                    phase: 0,
-                    end_phase: -1,
-                    rank: 1,
-                },
-            ],
+            exons: vec![Exon {
+                stable_id: "ENSE001".into(),
+                start: 1000,
+                end: 1200,
+                strand: Strand::Forward,
+                phase: 0,
+                end_phase: -1,
+                rank: 1,
+            }],
             translation: None,
             cdna_coding_start: Some(1),
             cdna_coding_end: Some(200),

--- a/crates/fastvep-cache/src/variation.rs
+++ b/crates/fastvep-cache/src/variation.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use noodles_bgzf as bgzf;
-use noodles_core::Position;
 use noodles_core::region::Interval;
+use noodles_core::Position;
 use noodles_csi::binning_index::BinningIndex;
 use noodles_tabix as tabix;
 use std::collections::HashMap;
@@ -132,14 +132,13 @@ impl VariationTabixReader {
 
         // Build query interval (noodles Position is 1-based, non-zero)
         // VEP cache uses 1-based coordinates already
-        let pos_start = Position::try_from(start as usize)
-            .context("Invalid start position")?;
-        let pos_end = Position::try_from(end as usize)
-            .context("Invalid end position")?;
+        let pos_start = Position::try_from(start as usize).context("Invalid start position")?;
+        let pos_end = Position::try_from(end as usize).context("Invalid end position")?;
         let query_interval: Interval = (pos_start..=pos_end).into();
 
         // Get chunks from index
-        let chunks = index.query(ref_id, query_interval)
+        let chunks = index
+            .query(ref_id, query_interval)
             .context("Tabix query failed")?;
 
         if chunks.is_empty() {
@@ -265,10 +264,22 @@ impl VariationTabixReader {
 
         // Collect population frequency columns
         let known_non_freq = [
-            "chr", "variation_name", "failed", "somatic", "start", "end",
-            "allele_string", "strand", "minor_allele", "minor_allele_freq",
-            "clin_sig", "phenotype_or_disease", "pubmed",
-            "clin_sig_allele", "clinical_impact", "var_synonyms",
+            "chr",
+            "variation_name",
+            "failed",
+            "somatic",
+            "start",
+            "end",
+            "allele_string",
+            "strand",
+            "minor_allele",
+            "minor_allele_freq",
+            "clin_sig",
+            "phenotype_or_disease",
+            "pubmed",
+            "clin_sig_allele",
+            "clinical_impact",
+            "var_synonyms",
         ];
         let mut frequencies = HashMap::new();
         for (col_name, value) in &col_map {
@@ -345,7 +356,10 @@ fn complement_base(b: u8) -> u8 {
 
 /// Reverse-complement a DNA string.
 fn reverse_complement(seq: &str) -> String {
-    seq.bytes().rev().map(|b| complement_base(b) as char).collect()
+    seq.bytes()
+        .rev()
+        .map(|b| complement_base(b) as char)
+        .collect()
 }
 
 /// Check if a variant's alleles match a known variant record, accounting for
@@ -543,11 +557,8 @@ mod tests {
             .map(String::from)
             .collect();
 
-        let reader = VariationTabixReader::new(
-            Path::new("/tmp/fake"),
-            &cols,
-            &["21".to_string()],
-        ).unwrap();
+        let reader =
+            VariationTabixReader::new(Path::new("/tmp/fake"), &cols, &["21".to_string()]).unwrap();
 
         let line = "21\trs559462325\t.\t.\t8522406\t.\tG/A\t.\tA\t0.0002\t.\t.\t.\tA:0\tA:0\tA:0.001\tA:0\tA:0\t.\t.";
         let record = reader.parse_line(line).unwrap();
@@ -573,8 +584,10 @@ mod tests {
     fn test_tabix_query_real_data() {
         // Use real VEP cache test data
         let cache_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent().unwrap()
-            .parent().unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
             .join("test_data/vep_cache/homo_sapiens/84_GRCh38");
 
         if !cache_dir.join("info.txt").exists() {
@@ -584,15 +597,16 @@ mod tests {
 
         let info = crate::info::CacheInfo::from_file(&cache_dir.join("info.txt")).unwrap();
 
-        let reader = VariationTabixReader::new(
-            &cache_dir,
-            &info.variation_cols,
-            &info.valid_chromosomes,
-        ).unwrap();
+        let reader =
+            VariationTabixReader::new(&cache_dir, &info.variation_cols, &info.valid_chromosomes)
+                .unwrap();
 
         // Query for a known variant: rs879182429 at chr21:8013350
         let records = reader.query("21", 8013350, 8013350).unwrap();
-        assert!(!records.is_empty(), "Expected at least one record at 21:8013350");
+        assert!(
+            !records.is_empty(),
+            "Expected at least one record at 21:8013350"
+        );
 
         let rs = records.iter().find(|r| r.variation_name == "rs879182429");
         assert!(rs.is_some(), "Expected rs879182429 in results");

--- a/crates/fastvep-classification/src/combiner.rs
+++ b/crates/fastvep-classification/src/combiner.rs
@@ -94,7 +94,10 @@ fn pathogenic_call_by_points(
     } else {
         return None;
     };
-    Some((cls, format!("{} pathogenic points (Tavtigian 2020)", points)))
+    Some((
+        cls,
+        format!("{} pathogenic points (Tavtigian 2020)", points),
+    ))
 }
 
 /// The Richards 2015 combining table on both sides. The tests use it directly
@@ -344,7 +347,12 @@ fn site_level_frequency_veto(criteria: &[EvidenceCriterion]) -> Option<String> {
         .iter()
         .filter(|c| !c.evaluated && matches!(c.code.as_str(), "BA1" | "BS1" | "BS2"))
         .find_map(|c| {
-            let flag = |key| c.details.get(key).and_then(|v| v.as_bool()).unwrap_or(false);
+            let flag = |key| {
+                c.details
+                    .get(key)
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            };
             let vetoed = flag(crate::criteria::FREQUENCY_BLOCKED_SITE_LEVEL)
                 && flag(crate::criteria::FREQUENCY_BLOCKED_WOULD_BE_BENIGN);
             vetoed.then(|| {
@@ -353,8 +361,15 @@ fn site_level_frequency_veto(criteria: &[EvidenceCriterion]) -> Option<String> {
                     .get("frequency_blocked")
                     .and_then(|v| v.as_str())
                     .unwrap_or("population frequency unusable at this site");
-                match c.details.get("frequency_blocked_af").and_then(|v| v.as_f64()) {
-                    Some(af) => format!("{} - and the frequency it suppressed, {:.3e}, would itself have met {}", reason, af, c.code),
+                match c
+                    .details
+                    .get("frequency_blocked_af")
+                    .and_then(|v| v.as_f64())
+                {
+                    Some(af) => format!(
+                        "{} - and the frequency it suppressed, {:.3e}, would itself have met {}",
+                        reason, af, c.code
+                    ),
                     None => reason.to_string(),
                 }
             })
@@ -517,10 +532,7 @@ mod tests {
 
     #[test]
     fn test_two_bs_benign() {
-        let criteria = vec![
-            met("BS1", Benign, Strong),
-            met("BS2", Benign, Strong),
-        ];
+        let criteria = vec![met("BS1", Benign, Strong), met("BS2", Benign, Strong)];
         let (cls, rule) = combine_by_table(&criteria);
         assert_eq!(cls, AcmgClassification::Benign);
         assert_eq!(rule.unwrap(), ">=2 BS");
@@ -679,10 +691,7 @@ mod tests {
 
     #[test]
     fn test_bs_plus_bp_likely_benign() {
-        let criteria = vec![
-            met("BS1", Benign, Strong),
-            met("BP7", Benign, Supporting),
-        ];
+        let criteria = vec![met("BS1", Benign, Strong), met("BP7", Benign, Supporting)];
         let (cls, rule) = combine_by_table(&criteria);
         assert_eq!(cls, AcmgClassification::LikelyBenign);
         assert_eq!(rule.unwrap(), "BS + BP");
@@ -836,7 +845,11 @@ mod tests {
     fn lone_pvs1_is_likely_pathogenic_under_points_and_vus_under_the_table() {
         // The disagreement that motivated the change. 2,319 truth-pathogenic
         // variants sat in VUS on exactly this signature in run v10.
-        let criteria = vec![met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong)];
+        let criteria = vec![met(
+            "PVS1",
+            EvidenceDirection::Pathogenic,
+            EvidenceStrength::VeryStrong,
+        )];
         assert_eq!(points_of(&criteria).0, AcmgClassification::LikelyPathogenic);
         assert_eq!(
             combine_by_table(&criteria).0,
@@ -848,11 +861,23 @@ mod tests {
     fn ten_points_reaches_pathogenic() {
         // PVS1 (8) + PM2_Supporting (1) = 9 → LP; add a Moderate → 11 → P.
         let mut criteria = vec![
-            met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
-            met("PM2_Supporting", EvidenceDirection::Pathogenic, EvidenceStrength::Supporting),
+            met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
+            met(
+                "PM2_Supporting",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Supporting,
+            ),
         ];
         assert_eq!(points_of(&criteria).0, AcmgClassification::LikelyPathogenic);
-        criteria.push(met("PM1", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate));
+        criteria.push(met(
+            "PM1",
+            EvidenceDirection::Pathogenic,
+            EvidenceStrength::Moderate,
+        ));
         assert_eq!(points_of(&criteria).0, AcmgClassification::Pathogenic);
     }
 
@@ -860,23 +885,53 @@ mod tests {
     fn five_pathogenic_points_stay_uncertain() {
         // PM1 (2) + PM5 (2) + PM2_Supporting (1) = 5, one short of the band.
         let criteria = vec![
-            met("PM1", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
-            met("PM5", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
-            met("PM2_Supporting", EvidenceDirection::Pathogenic, EvidenceStrength::Supporting),
+            met(
+                "PM1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
+            met(
+                "PM5",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
+            met(
+                "PM2_Supporting",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Supporting,
+            ),
         ];
-        assert_eq!(points_of(&criteria).0, AcmgClassification::UncertainSignificance);
+        assert_eq!(
+            points_of(&criteria).0,
+            AcmgClassification::UncertainSignificance
+        );
     }
 
     #[test]
     fn the_benign_side_keeps_the_2015_table_under_points() {
         // The measured reason for the split: Tavtigian's Likely Benign band
         // opens at -1, so a lone BP4 would be a benign call. It must not be.
-        let criteria = vec![met("BP4", EvidenceDirection::Benign, EvidenceStrength::Supporting)];
-        assert_eq!(points_of(&criteria).0, AcmgClassification::UncertainSignificance);
+        let criteria = vec![met(
+            "BP4",
+            EvidenceDirection::Benign,
+            EvidenceStrength::Supporting,
+        )];
+        assert_eq!(
+            points_of(&criteria).0,
+            AcmgClassification::UncertainSignificance
+        );
         // Two supporting benign criteria do reach Likely Benign, as Richards says.
         let criteria = vec![
-            met("BP4", EvidenceDirection::Benign, EvidenceStrength::Supporting),
-            met("BP7", EvidenceDirection::Benign, EvidenceStrength::Supporting),
+            met(
+                "BP4",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
+            met(
+                "BP7",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
         ];
         assert_eq!(points_of(&criteria).0, AcmgClassification::LikelyBenign);
     }
@@ -886,8 +941,16 @@ mod tests {
         // A lone PVS1 now reaches LP on the pathogenic side, so the guard that
         // sends definite-vs-definite to VUS has to keep working over it.
         let criteria = vec![
-            met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
-            met("BA1", EvidenceDirection::Benign, EvidenceStrength::Standalone),
+            met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
+            met(
+                "BA1",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Standalone,
+            ),
         ];
         let (cls, rule) = points_of(&criteria);
         assert_eq!(cls, AcmgClassification::UncertainSignificance);
@@ -898,9 +961,20 @@ mod tests {
     fn graded_subcodes_score_at_their_effective_strength() {
         // PVS1_Moderate is 2 points, not 8 — the grading has to reach the sum.
         let criteria = vec![
-            met("PVS1_Moderate", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
-            met("PM2_Supporting", EvidenceDirection::Pathogenic, EvidenceStrength::Supporting),
+            met(
+                "PVS1_Moderate",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
+            met(
+                "PM2_Supporting",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Supporting,
+            ),
         ];
-        assert_eq!(points_of(&criteria).0, AcmgClassification::UncertainSignificance);
+        assert_eq!(
+            points_of(&criteria).0,
+            AcmgClassification::UncertainSignificance
+        );
     }
 }

--- a/crates/fastvep-classification/src/config.rs
+++ b/crates/fastvep-classification/src/config.rs
@@ -611,11 +611,23 @@ impl Ba1Exception {
         hgvs_c: Option<&str>,
         coordinates: Option<(&str, u64, &str, &str)>,
     ) -> bool {
-        if let (Some((chrom, pos, ref_allele, alt)), Some(e_chrom), Some(e_pos), Some(e_ref), Some(e_alt)) =
-            (coordinates, self.chrom.as_deref(), self.pos, self.ref_allele.as_deref(), self.alt.as_deref())
-        {
+        if let (
+            Some((chrom, pos, ref_allele, alt)),
+            Some(e_chrom),
+            Some(e_pos),
+            Some(e_ref),
+            Some(e_alt),
+        ) = (
+            coordinates,
+            self.chrom.as_deref(),
+            self.pos,
+            self.ref_allele.as_deref(),
+            self.alt.as_deref(),
+        ) {
             if self.assembly.eq_ignore_ascii_case("GRCh38")
-                && e_chrom.trim_start_matches("chr").eq_ignore_ascii_case(chrom.trim_start_matches("chr"))
+                && e_chrom
+                    .trim_start_matches("chr")
+                    .eq_ignore_ascii_case(chrom.trim_start_matches("chr"))
                 && e_pos == pos
                 && e_ref.eq_ignore_ascii_case(ref_allele)
                 && e_alt.eq_ignore_ascii_case(alt)
@@ -823,37 +835,48 @@ impl AcmgConfig {
 
     /// Get effective BA1 threshold for a gene (gene-specific or default).
     pub fn effective_ba1_threshold(&self, gene: Option<&str>) -> f64 {
-        gene.and_then(|g| {
-            self.gene_overrides
-                .get(g)
-                .and_then(|o| o.ba1_af_threshold)
-        })
-        .unwrap_or(self.ba1_af_threshold)
+        gene.and_then(|g| self.gene_overrides.get(g).and_then(|o| o.ba1_af_threshold))
+            .unwrap_or(self.ba1_af_threshold)
     }
 
     /// Get effective BS1 threshold for a gene (gene-specific or default).
     pub fn effective_bs1_threshold(&self, gene: Option<&str>) -> f64 {
-        gene.and_then(|g| {
-            self.gene_overrides
-                .get(g)
-                .and_then(|o| o.bs1_af_threshold)
-        })
-        .unwrap_or(self.bs1_af_threshold)
+        gene.and_then(|g| self.gene_overrides.get(g).and_then(|o| o.bs1_af_threshold))
+            .unwrap_or(self.bs1_af_threshold)
     }
-
 }
 
 // Default value functions for serde
-fn default_ba1() -> f64 { 0.05 }
-fn default_bs1() -> f64 { 0.005 }
-fn default_pm2() -> f64 { 0.0001 }
-fn default_pm2_ad() -> f64 { 0.00004 }
-fn default_pm2_ar() -> f64 { 0.00007 }
-fn default_bs2_ad_min_ac() -> u64 { 5 }
-fn default_bs2_ar_min_hom() -> u64 { 2 }
-fn default_bs2_prevalence() -> f64 { 1e-3 }
-fn default_bp1_max_pathogenic_missense() -> u32 { 3 }
-fn default_bp7_max_intron_offset() -> u64 { 300 }
+fn default_ba1() -> f64 {
+    0.05
+}
+fn default_bs1() -> f64 {
+    0.005
+}
+fn default_pm2() -> f64 {
+    0.0001
+}
+fn default_pm2_ad() -> f64 {
+    0.00004
+}
+fn default_pm2_ar() -> f64 {
+    0.00007
+}
+fn default_bs2_ad_min_ac() -> u64 {
+    5
+}
+fn default_bs2_ar_min_hom() -> u64 {
+    2
+}
+fn default_bs2_prevalence() -> f64 {
+    1e-3
+}
+fn default_bp1_max_pathogenic_missense() -> u32 {
+    3
+}
+fn default_bp7_max_intron_offset() -> u64 {
+    300
+}
 
 /// Genes whose gnomAD frequencies are unreliable because of paralogue,
 /// pseudogene or segmental-duplication mismapping (Mandelker et al. 2016,
@@ -867,9 +890,9 @@ fn default_homology_unreliable_genes() -> Vec<String> {
         "CYP21A2", "STRC", "HBA1", "HBA2",
         // Canonical members of the Mandelker 2016 set that also appear in
         // clinical panels and carry a pseudogene or near-identical paralogue.
-        "SMN1", "SMN2", "PMS2", "NEB", "OTOA", "GBA", "IKBKG", "CFC1", "NCF1",
-        "TTN", "CYP11B1", "CYP11B2", "HBB", "HBD", "SBDS", "FCGR3A", "FCGR3B",
-        "CR1", "C4A", "C4B", "TUBB8", "MOCS1", "OPN1LW", "OPN1MW", "GTF2I",
+        "SMN1", "SMN2", "PMS2", "NEB", "OTOA", "GBA", "IKBKG", "CFC1", "NCF1", "TTN", "CYP11B1",
+        "CYP11B2", "HBB", "HBD", "SBDS", "FCGR3A", "FCGR3B", "CR1", "C4A", "C4B", "TUBB8", "MOCS1",
+        "OPN1LW", "OPN1MW", "GTF2I",
     ]
     .iter()
     .map(|s| s.to_string())
@@ -948,23 +971,57 @@ fn default_gene_mechanisms() -> HashMap<String, String> {
     .collect()
 }
 
-fn default_pp3_supporting() -> f64 { 0.644 }
-fn default_pp3_moderate() -> f64 { 0.773 }
-fn default_pp3_strong() -> f64 { 0.932 }
-fn default_bp4_supporting() -> f64 { 0.290 }
-fn default_bp4_moderate() -> f64 { 0.183 }
-fn default_bp4_strong() -> f64 { 0.016 }
-fn default_bp4_very_strong() -> f64 { 0.003 }
-fn default_spliceai_pathogenic() -> f64 { 0.2 }
-fn default_spliceai_benign() -> f64 { 0.1 }
-fn default_phylop() -> f64 { 2.0 }
-fn default_pli() -> f64 { 0.9 }
-fn default_loeuf() -> f64 { 0.35 }
-fn default_misz() -> f64 { 3.09 }
-fn default_pm1_window() -> u64 { 5 }
-fn default_pm1_threshold() -> u32 { 3 }
-fn default_true() -> bool { true }
-fn default_min_an() -> u64 { 2000 }
+fn default_pp3_supporting() -> f64 {
+    0.644
+}
+fn default_pp3_moderate() -> f64 {
+    0.773
+}
+fn default_pp3_strong() -> f64 {
+    0.932
+}
+fn default_bp4_supporting() -> f64 {
+    0.290
+}
+fn default_bp4_moderate() -> f64 {
+    0.183
+}
+fn default_bp4_strong() -> f64 {
+    0.016
+}
+fn default_bp4_very_strong() -> f64 {
+    0.003
+}
+fn default_spliceai_pathogenic() -> f64 {
+    0.2
+}
+fn default_spliceai_benign() -> f64 {
+    0.1
+}
+fn default_phylop() -> f64 {
+    2.0
+}
+fn default_pli() -> f64 {
+    0.9
+}
+fn default_loeuf() -> f64 {
+    0.35
+}
+fn default_misz() -> f64 {
+    3.09
+}
+fn default_pm1_window() -> u64 {
+    5
+}
+fn default_pm1_threshold() -> u32 {
+    3
+}
+fn default_true() -> bool {
+    true
+}
+fn default_min_an() -> u64 {
+    2000
+}
 
 /// Default BA1 exception list (Ghosh et al. 2018, Hum Mutat — 9 variants).
 /// The ClinGen SVI BA1 exception list (Ghosh 2018, PMID 30311378, Table 1).
@@ -982,7 +1039,14 @@ fn default_min_an() -> u64 { 2000 }
 /// reports `c.1270G>C` on the Ensembl canonical transcript, and ACAD9's
 /// `c.-44_-41dupTAAG` is the same variant fastVEP spells `c.-45_-44insTAAG`.
 fn default_ba1_exceptions() -> Vec<Ba1Exception> {
-    let mk = |gene: &str, hgvs: &str, clinvar_id: &str, chrom: &str, pos: u64, r: &str, a: &str, reason: &str| {
+    let mk = |gene: &str,
+              hgvs: &str,
+              clinvar_id: &str,
+              chrom: &str,
+              pos: u64,
+              r: &str,
+              a: &str,
+              reason: &str| {
         Ba1Exception {
             gene: gene.to_string(),
             hgvs_c: hgvs.to_string(),
@@ -996,16 +1060,17 @@ fn default_ba1_exceptions() -> Vec<Ba1Exception> {
             blocks: default_exception_blocks(),
         }
     };
-    let hypomorph = |gene: &str, hgvs: &str, chrom: &str, pos: u64, r: &str, a: &str, reason: &str| {
-        Ba1Exception {
-            blocks: vec!["BA1".into(), "BS1".into(), "BS2".into()],
-            // No ClinVar variation ID: these entries are curated from the
-            // mechanism, not lifted from a published table, so there is no
-            // source row to point at.
-            clinvar_id: None,
-            ..mk(gene, hgvs, "", chrom, pos, r, a, reason)
-        }
-    };
+    let hypomorph =
+        |gene: &str, hgvs: &str, chrom: &str, pos: u64, r: &str, a: &str, reason: &str| {
+            Ba1Exception {
+                blocks: vec!["BA1".into(), "BS1".into(), "BS2".into()],
+                // No ClinVar variation ID: these entries are curated from the
+                // mechanism, not lifted from a published table, so there is no
+                // source row to point at.
+                clinvar_id: None,
+                ..mk(gene, hgvs, "", chrom, pos, r, a, reason)
+            }
+        };
     let mut entries = vec![
         mk("ACAD9", "c.-44_-41dupTAAG", "1018", "3", 128_879_647, "C", "CTAAG",
            "Ghosh 2018 BA1 exception (VUS); 12.6 % in African/African American"),
@@ -1110,13 +1175,17 @@ ba1_af_threshold = 8.3e-5
         // nothing, and this classifier has already shipped three criteria that
         // never fired for want of exactly that signal.
         for toml in [
-            "bs1_af_thresold = 0.001",                       // transposed letters
-            "[gene_overrides.BRCA1]\nba1_threshold = 0.01",  // wrong field name
+            "bs1_af_thresold = 0.001",                      // transposed letters
+            "[gene_overrides.BRCA1]\nba1_threshold = 0.01", // wrong field name
             "[[ba1_exceptions]]\ngene = \"HFE\"\nhgvs_c = \"c.845G>A\"\nblock = [\"BS1\"]",
             "[trio]\nproband = \"P\"\nmin_dpeth = 20",
         ] {
             let parsed = toml::from_str::<AcmgConfig>(toml);
-            assert!(parsed.is_err(), "expected a rejection, got a silent default: {}", toml);
+            assert!(
+                parsed.is_err(),
+                "expected a rejection, got a silent default: {}",
+                toml
+            );
         }
     }
 
@@ -1166,7 +1235,10 @@ ba1_af_threshold = 8.3e-5
     fn test_curated_mechanisms_ship_by_default() {
         let cfg = AcmgConfig::default();
         assert_eq!(cfg.effective_mechanism(Some("PCSK9")), Some("GOF"));
-        assert_eq!(cfg.effective_mechanism(Some("MYH7")), Some("DOMINANT_NEGATIVE"));
+        assert_eq!(
+            cfg.effective_mechanism(Some("MYH7")),
+            Some("DOMINANT_NEGATIVE")
+        );
         assert_eq!(cfg.effective_mechanism(Some("RYR1")), Some("LOF_and_GOF"));
         assert_eq!(cfg.effective_mechanism(Some("BRCA1")), None);
         assert_eq!(cfg.effective_mechanism(None), None);
@@ -1176,23 +1248,21 @@ ba1_af_threshold = 8.3e-5
 
     #[test]
     fn test_gene_overrides_mechanism_wins_over_the_curated_table() {
-        let cfg: AcmgConfig = toml::from_str(
-            "[gene_overrides.PCSK9]\nmechanism = \"LOF\"\n",
-        )
-        .unwrap();
+        let cfg: AcmgConfig =
+            toml::from_str("[gene_overrides.PCSK9]\nmechanism = \"LOF\"\n").unwrap();
         assert_eq!(cfg.effective_mechanism(Some("PCSK9")), Some("LOF"));
         // ... and the rest of the shipped table survives that override.
-        assert_eq!(cfg.effective_mechanism(Some("MYH7")), Some("DOMINANT_NEGATIVE"));
+        assert_eq!(
+            cfg.effective_mechanism(Some("MYH7")),
+            Some("DOMINANT_NEGATIVE")
+        );
     }
 
     #[test]
     fn test_gene_mechanisms_table_can_be_replaced_wholesale() {
         // Documented behaviour in ACMG.md: naming the table in TOML replaces
         // it, exactly as `homology_unreliable_genes` and `ba1_exceptions` do.
-        let cfg: AcmgConfig = toml::from_str(
-            "[gene_mechanisms]\nMYGENE = \"GOF\"\n",
-        )
-        .unwrap();
+        let cfg: AcmgConfig = toml::from_str("[gene_mechanisms]\nMYGENE = \"GOF\"\n").unwrap();
         assert_eq!(cfg.effective_mechanism(Some("MYGENE")), Some("GOF"));
         assert_eq!(cfg.effective_mechanism(Some("PCSK9")), None);
     }

--- a/crates/fastvep-classification/src/criteria/benign_standalone.rs
+++ b/crates/fastvep-classification/src/criteria/benign_standalone.rs
@@ -10,10 +10,7 @@ use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 /// p.Cys282Tyr — hereditary hemochromatosis; F5 / GJB2 founder alleles).
 /// The exception list is configurable via `config.ba1_exceptions` so VCEPs
 /// can extend it.
-pub fn evaluate_ba1(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+pub fn evaluate_ba1(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     // Per-gene where a VCEP has published one, global otherwise.
     let threshold = config.effective_ba1_threshold(input.gene_symbol.as_deref());
 
@@ -56,7 +53,10 @@ pub fn evaluate_ba1(
     if let Some(blocker) = super::frequency_gate::benign_blocker(input, config) {
         blocker.record(&mut details);
         super::frequency_gate::note_withheld_benign_frequency(
-            input, config, threshold, &mut details,
+            input,
+            config,
+            threshold,
+            &mut details,
         );
         return EvidenceCriterion {
             code: "BA1".to_string(),
@@ -121,14 +121,30 @@ pub fn evaluate_ba1(
 
             // Add per-population breakdown for transparency
             let mut pop_afs = serde_json::Map::new();
-            if let Some(v) = gnomad.all_af { pop_afs.insert("all".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.afr_af { pop_afs.insert("afr".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.nfe_af { pop_afs.insert("nfe".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.eas_af { pop_afs.insert("eas".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.amr_af { pop_afs.insert("amr".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.asj_af { pop_afs.insert("asj".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.fin_af { pop_afs.insert("fin".into(), serde_json::json!(v)); }
-            if let Some(v) = gnomad.sas_af { pop_afs.insert("sas".into(), serde_json::json!(v)); }
+            if let Some(v) = gnomad.all_af {
+                pop_afs.insert("all".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.afr_af {
+                pop_afs.insert("afr".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.nfe_af {
+                pop_afs.insert("nfe".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.eas_af {
+                pop_afs.insert("eas".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.amr_af {
+                pop_afs.insert("amr".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.asj_af {
+                pop_afs.insert("asj".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.fin_af {
+                pop_afs.insert("fin".into(), serde_json::json!(v));
+            }
+            if let Some(v) = gnomad.sas_af {
+                pop_afs.insert("sas".into(), serde_json::json!(v));
+            }
             details.insert("population_afs".into(), serde_json::Value::Object(pop_afs));
 
             if af > threshold {
@@ -149,10 +165,16 @@ pub fn evaluate_ba1(
                 )
             }
         } else {
-            (false, "gnomAD data present but no allele frequency values".to_string())
+            (
+                false,
+                "gnomAD data present but no allele frequency values".to_string(),
+            )
         }
     } else {
-        (false, "No gnomAD population frequency data available".to_string())
+        (
+            false,
+            "No gnomAD population frequency data available".to_string(),
+        )
     };
 
     EvidenceCriterion {
@@ -170,8 +192,8 @@ pub fn evaluate_ba1(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::GnomadData;
+    use crate::test_support::minimal_input;
 
     #[test]
     fn test_ba1_common_variant() {
@@ -224,7 +246,10 @@ mod tests {
             ..minimal_input()
         };
         let result = evaluate_ba1(&input, &AcmgConfig::default());
-        assert!(!result.met, "BA1 must not fire for HFE c.845G>A (Ghosh 2018 exception)");
+        assert!(
+            !result.met,
+            "BA1 must not fire for HFE c.845G>A (Ghosh 2018 exception)"
+        );
         assert!(result.evaluated);
         assert!(result.summary.contains("exception"));
     }
@@ -235,7 +260,10 @@ mod tests {
         let input = ClassificationInput {
             impact: fastvep_core::Impact::Modifier,
             gene_symbol: Some("hfe".to_string()),
-            gnomad: Some(GnomadData { all_af: Some(0.10), ..Default::default() }),
+            gnomad: Some(GnomadData {
+                all_af: Some(0.10),
+                ..Default::default()
+            }),
             hgvs_c: Some("C.845G>A".to_string()),
             ..minimal_input()
         };
@@ -250,7 +278,11 @@ mod tests {
         let input = ClassificationInput {
             impact: fastvep_core::Impact::Modifier,
             gene_symbol: Some("HFE".to_string()),
-            gnomad: Some(GnomadData { all_af: Some(0.10), all_an: Some(100_000), ..Default::default() }),
+            gnomad: Some(GnomadData {
+                all_af: Some(0.10),
+                all_an: Some(100_000),
+                ..Default::default()
+            }),
             hgvs_c: Some("c.999A>T".to_string()),
             ..minimal_input()
         };
@@ -358,17 +390,80 @@ mod tests {
     fn test_every_ghosh_2018_exception_blocks_ba1_in_pipeline_form() {
         // (gene, transcript-prefixed HGVS as fastVEP emits it, chrom, pos, ref, alt)
         let cases = [
-            ("ACAD9", "ENST00000308982.12:c.-45_-44insTAAG", "3", 128_879_647, "C", "CTAAG"),
-            ("GJB2", "ENST00000382848.5:c.109G>A", "13", 20_189_473, "C", "T"),
-            ("HFE", "ENST00000357618.10:c.187C>G", "6", 26_090_951, "C", "G"),
-            ("HFE", "ENST00000357618.10:c.845G>A", "6", 26_092_913, "G", "A"),
-            ("MEFV", "ENST00000219596.6:c.1105C>T", "16", 3_249_586, "G", "A"),
-            ("MEFV", "ENST00000219596.6:c.1223G>A", "16", 3_249_468, "C", "T"),
-            ("PIBF1", "ENST00000326291.11:c.1214G>A", "13", 72_835_359, "G", "A"),
-            ("ACADS", "ENST00000242592.9:c.511C>T", "12", 120_737_875, "C", "T"),
+            (
+                "ACAD9",
+                "ENST00000308982.12:c.-45_-44insTAAG",
+                "3",
+                128_879_647,
+                "C",
+                "CTAAG",
+            ),
+            (
+                "GJB2",
+                "ENST00000382848.5:c.109G>A",
+                "13",
+                20_189_473,
+                "C",
+                "T",
+            ),
+            (
+                "HFE",
+                "ENST00000357618.10:c.187C>G",
+                "6",
+                26_090_951,
+                "C",
+                "G",
+            ),
+            (
+                "HFE",
+                "ENST00000357618.10:c.845G>A",
+                "6",
+                26_092_913,
+                "G",
+                "A",
+            ),
+            (
+                "MEFV",
+                "ENST00000219596.6:c.1105C>T",
+                "16",
+                3_249_586,
+                "G",
+                "A",
+            ),
+            (
+                "MEFV",
+                "ENST00000219596.6:c.1223G>A",
+                "16",
+                3_249_468,
+                "C",
+                "T",
+            ),
+            (
+                "PIBF1",
+                "ENST00000326291.11:c.1214G>A",
+                "13",
+                72_835_359,
+                "G",
+                "A",
+            ),
+            (
+                "ACADS",
+                "ENST00000242592.9:c.511C>T",
+                "12",
+                120_737_875,
+                "C",
+                "T",
+            ),
             // BTD is the one no HGVS match can reach: Ghosh lists c.1330G>C on
             // NM_000060.4, fastVEP reports c.1270G>C on the Ensembl canonical.
-            ("BTD", "ENST00000643237.3:c.1270G>C", "3", 15_645_186, "G", "C"),
+            (
+                "BTD",
+                "ENST00000643237.3:c.1270G>C",
+                "3",
+                15_645_186,
+                "G",
+                "C",
+            ),
         ];
         let cfg = AcmgConfig::default();
         for (gene, hgvs, chrom, pos, ref_allele, alt) in cases {
@@ -408,7 +503,12 @@ mod tests {
             impact: fastvep_core::Impact::Modifier,
             gene_symbol: Some("BTD".to_string()),
             hgvs_c: None,
-            variant_coordinates: Some(("chr3".to_string(), 15_645_186, "G".to_string(), "C".to_string())),
+            variant_coordinates: Some((
+                "chr3".to_string(),
+                15_645_186,
+                "G".to_string(),
+                "C".to_string(),
+            )),
             gnomad: Some(GnomadData {
                 all_af: Some(0.20),
                 all_an: Some(100_000),
@@ -419,7 +519,11 @@ mod tests {
         };
         let result = evaluate_ba1(&input, &AcmgConfig::default());
         assert!(!result.met, "{}", result.summary);
-        assert!(result.summary.contains("exception list"), "{}", result.summary);
+        assert!(
+            result.summary.contains("exception list"),
+            "{}",
+            result.summary
+        );
     }
 
     #[test]
@@ -429,7 +533,12 @@ mod tests {
             impact: fastvep_core::Impact::Modifier,
             gene_symbol: Some("BTD".to_string()),
             hgvs_c: Some("ENST00000643237.3:c.1271G>C".to_string()),
-            variant_coordinates: Some(("3".to_string(), 15_645_187, "G".to_string(), "C".to_string())),
+            variant_coordinates: Some((
+                "3".to_string(),
+                15_645_187,
+                "G".to_string(),
+                "C".to_string(),
+            )),
             gnomad: Some(GnomadData {
                 all_af: Some(0.20),
                 all_an: Some(100_000),

--- a/crates/fastvep-classification/src/criteria/benign_strong.rs
+++ b/crates/fastvep-classification/src/criteria/benign_strong.rs
@@ -4,10 +4,7 @@ use crate::sa_extract::ClassificationInput;
 use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 
 /// Evaluate all benign strong criteria: BS1, BS2, BS3, BS4.
-pub fn evaluate_all(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Vec<EvidenceCriterion> {
+pub fn evaluate_all(input: &ClassificationInput, config: &AcmgConfig) -> Vec<EvidenceCriterion> {
     vec![
         evaluate_bs1(input, config),
         evaluate_bs2(input, config),
@@ -22,9 +19,8 @@ pub fn evaluate_all(
 /// Wilson-Hilferty expansion above the table.
 fn poisson_lower_95(observed: u64) -> f64 {
     const TABLE: [f64; 21] = [
-        0.0, 0.0513, 0.3554, 0.8177, 1.3663, 1.9702, 2.6130, 3.2853, 3.9808,
-        4.6952, 5.4254, 6.1690, 6.9242, 7.6896, 8.4639, 9.2463, 10.0360,
-        10.8324, 11.6350, 12.4432, 13.2547,
+        0.0, 0.0513, 0.3554, 0.8177, 1.3663, 1.9702, 2.6130, 3.2853, 3.9808, 4.6952, 5.4254,
+        6.1690, 6.9242, 7.6896, 8.4639, 9.2463, 10.0360, 10.8324, 11.6350, 12.4432, 13.2547,
     ];
     if (observed as usize) < TABLE.len() {
         return TABLE[observed as usize];
@@ -36,10 +32,7 @@ fn poisson_lower_95(observed: u64) -> f64 {
 }
 
 /// BS1: Allele frequency is greater than expected for disorder.
-fn evaluate_bs1(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bs1(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let threshold = config.effective_bs1_threshold(input.gene_symbol.as_deref());
 
     let mut details = serde_json::Map::new();
@@ -65,7 +58,10 @@ fn evaluate_bs1(
     if let Some(blocker) = benign_blocker(input, config) {
         blocker.record(&mut details);
         super::frequency_gate::note_withheld_benign_frequency(
-            input, config, threshold, &mut details,
+            input,
+            config,
+            threshold,
+            &mut details,
         );
         return EvidenceCriterion {
             code: "BS1".to_string(),
@@ -207,10 +203,7 @@ fn evaluate_bs1(
 ///
 /// Inheritance is inferred from the disease-gene `.oga` (ClinGen GDV
 /// preferred, OMIM accepted as legacy).
-fn evaluate_bs2(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bs2(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     // A hypomorphic allele is expected to be seen homozygous in unaffected
@@ -269,7 +262,10 @@ fn evaluate_bs2(
         let hemizygote_an = gnomad.hemizygote_individuals().unwrap_or(0);
         if hemizygotes > 0 || hemizygote_an > 0 {
             details.insert("gnomad_hemizygotes".into(), serde_json::json!(hemizygotes));
-            details.insert("gnomad_xy_individuals".into(), serde_json::json!(hemizygote_an));
+            details.insert(
+                "gnomad_xy_individuals".into(),
+                serde_json::json!(hemizygote_an),
+            );
         }
 
         // Individuals surveyed. XX samples contribute two alleles each and XY
@@ -312,16 +308,19 @@ fn evaluate_bs2(
             let null_individuals = hc + hemizygotes;
             let freq_lower_95 = poisson_lower_95(null_individuals) / individuals as f64;
             details.insert("gnomad_individuals".into(), serde_json::json!(individuals));
-            details.insert("null_individuals".into(), serde_json::json!(null_individuals));
             details.insert(
-                "hom_freq_lower_95".into(),
-                serde_json::json!(freq_lower_95),
+                "null_individuals".into(),
+                serde_json::json!(null_individuals),
             );
+            details.insert("hom_freq_lower_95".into(), serde_json::json!(freq_lower_95));
             details.insert(
                 "prevalence_threshold".into(),
                 serde_json::json!(config.bs2_hom_prevalence_threshold),
             );
-            details.insert("bs2_ar_min_hom".into(), serde_json::json!(config.bs2_ar_min_hom));
+            details.insert(
+                "bs2_ar_min_hom".into(),
+                serde_json::json!(config.bs2_ar_min_hom),
+            );
 
             // Describe what was actually counted, so a reviewer can tell an
             // X-linked hemizygous observation from an autosomal homozygous one.
@@ -371,11 +370,7 @@ fn evaluate_bs2(
                 ),
             )
         } else {
-            (
-                false,
-                true,
-                "No homozygotes observed in gnomAD".to_string(),
-            )
+            (false, true, "No homozygotes observed in gnomAD".to_string())
         }
     } else {
         (false, false, "No gnomAD data available".to_string())
@@ -398,10 +393,7 @@ fn evaluate_bs2(
 ///
 /// The benign-direction twin of PS3, read from the same curated
 /// `--functional-evidence` file. See [`crate::functional`].
-fn evaluate_bs3(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bs3(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     super::functional_criterion(
         input,
         crate::functional::FunctionalCriterion::Bs3,
@@ -411,10 +403,7 @@ fn evaluate_bs3(
 }
 
 /// BS4: Lack of segregation in affected members of a family.
-fn evaluate_bs4(
-    _input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bs4(_input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     EvidenceCriterion {
         code: "BS4".to_string(),
         direction: EvidenceDirection::Benign,
@@ -422,7 +411,9 @@ fn evaluate_bs4(
         default_strength: EvidenceStrength::Strong,
         met: false,
         evaluated: false,
-        summary: "Requires multi-generation pedigree with affection status to assess lack of segregation".to_string(),
+        summary:
+            "Requires multi-generation pedigree with affection status to assess lack of segregation"
+                .to_string(),
         details: serde_json::Value::Null,
     }
 }
@@ -430,8 +421,8 @@ fn evaluate_bs4(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::GnomadData;
+    use crate::test_support::minimal_input;
 
     fn make_input(gnomad: Option<GnomadData>) -> ClassificationInput {
         ClassificationInput {
@@ -448,9 +439,36 @@ mod tests {
     #[test]
     fn test_hypomorphic_alleles_block_bs1_and_bs2_in_pipeline_form() {
         let cases = [
-            ("GAA", "ENST00000302262.8:c.-32-13T>G", "17", 80_104_542u64, "T", "G", 5.4e-3, 23u64),
-            ("CFTR", "ENST00000003084.11:c.1210-11T>G", "7", 117_548_630, "T", "G", 9.8e-3, 27),
-            ("SPTA1", "ENST00000643759.2:c.4339-99C>T", "1", 158_643_524, "G", "A", 6.6e-3, 40),
+            (
+                "GAA",
+                "ENST00000302262.8:c.-32-13T>G",
+                "17",
+                80_104_542u64,
+                "T",
+                "G",
+                5.4e-3,
+                23u64,
+            ),
+            (
+                "CFTR",
+                "ENST00000003084.11:c.1210-11T>G",
+                "7",
+                117_548_630,
+                "T",
+                "G",
+                9.8e-3,
+                27,
+            ),
+            (
+                "SPTA1",
+                "ENST00000643759.2:c.4339-99C>T",
+                "1",
+                158_643_524,
+                "G",
+                "A",
+                6.6e-3,
+                40,
+            ),
         ];
         let config = AcmgConfig::default();
         for (gene, hgvs, chrom, pos, r, a, af, hc) in cases {
@@ -486,7 +504,12 @@ mod tests {
         let input = ClassificationInput {
             gene_symbol: Some("GJB2".to_string()),
             hgvs_c: Some("ENST00000382844.2:c.109G>A".to_string()),
-            variant_coordinates: Some(("13".to_string(), 20_189_473, "C".to_string(), "T".to_string())),
+            variant_coordinates: Some((
+                "13".to_string(),
+                20_189_473,
+                "C".to_string(),
+                "T".to_string(),
+            )),
             gnomad: Some(GnomadData {
                 all_af: Some(0.02),
                 all_an: Some(1_400_000),
@@ -746,7 +769,10 @@ mod tests {
         // it must not be read as tolerance. This was the single largest source
         // of false-benign calls in the round-2 medical-genetics review.
         let r = evaluate_bs2(&recessive_input(1, 1_460_000), &AcmgConfig::default());
-        assert!(!r.met, "1 homozygote among 730 K individuals must not fire BS2");
+        assert!(
+            !r.met,
+            "1 homozygote among 730 K individuals must not fire BS2"
+        );
     }
 
     #[test]
@@ -755,7 +781,10 @@ mod tests {
         // on their frequency above the 1e-3 prevalence bar, i.e. above the
         // prevalence of the most common Mendelian disorders.
         let r = evaluate_bs2(&recessive_input(1_000, 1_460_000), &AcmgConfig::default());
-        assert!(r.met, "1,000 homozygotes among 730 K individuals should fire BS2");
+        assert!(
+            r.met,
+            "1,000 homozygotes among 730 K individuals should fire BS2"
+        );
         assert!(r.summary.contains("tolerated in healthy adults"));
     }
 
@@ -766,7 +795,10 @@ mod tests {
         // above any Mendelian prevalence; 3 among 730 K is not.
         let small = evaluate_bs2(&recessive_input(3, 1_000), &AcmgConfig::default());
         let large = evaluate_bs2(&recessive_input(3, 1_460_000), &AcmgConfig::default());
-        assert!(small.met, "3 homozygotes among 500 individuals should fire BS2");
+        assert!(
+            small.met,
+            "3 homozygotes among 500 individuals should fire BS2"
+        );
         assert!(
             !large.met,
             "3 homozygotes among 730 K individuals should not fire BS2"
@@ -802,8 +834,14 @@ mod tests {
         // an X-linked gene with thousands of hemizygous carriers looked to BS2
         // as though gnomAD had never seen a null individual, which is why FMR1
         // and IDS were flagged in the round-2 medical-genetics review.
-        let r = evaluate_bs2(&x_linked_input(1275, 1_039_980, 327_798), &AcmgConfig::default());
-        assert!(r.met, "1275 hemizygotes among 327 K XY samples should fire BS2");
+        let r = evaluate_bs2(
+            &x_linked_input(1275, 1_039_980, 327_798),
+            &AcmgConfig::default(),
+        );
+        assert!(
+            r.met,
+            "1275 hemizygotes among 327 K XY samples should fire BS2"
+        );
         assert!(r.summary.contains("hemizygote"), "got: {}", r.summary);
     }
 
@@ -812,7 +850,10 @@ mod tests {
         // The cohort-scaling test applies to hemizygotes exactly as it does to
         // homozygotes: one observation in a large cohort is what a late-onset
         // or reduced-penetrance disorder looks like.
-        let r = evaluate_bs2(&x_linked_input(1, 1_039_980, 327_798), &AcmgConfig::default());
+        let r = evaluate_bs2(
+            &x_linked_input(1, 1_039_980, 327_798),
+            &AcmgConfig::default(),
+        );
         assert!(!r.met);
     }
 
@@ -824,7 +865,10 @@ mod tests {
         let mut input = x_linked_input(1275, 1_039_980, 327_798);
         input.gnomad.as_mut().unwrap().non_par = false;
         let r = evaluate_bs2(&input, &AcmgConfig::default());
-        assert!(!r.met, "AC_XY must only count as hemizygotes outside the PAR");
+        assert!(
+            !r.met,
+            "AC_XY must only count as hemizygotes outside the PAR"
+        );
     }
 
     #[test]
@@ -845,7 +889,10 @@ mod tests {
         input.gene_symbol = Some("CYP21A2".to_string());
         let r = evaluate_bs2(&input, &AcmgConfig::default());
         assert!(!r.met);
-        assert!(!r.evaluated, "BS2 should be NotEvaluated, not a negative call");
+        assert!(
+            !r.evaluated,
+            "BS2 should be NotEvaluated, not a negative call"
+        );
         assert!(r.summary.contains("homology"));
     }
 
@@ -884,7 +931,11 @@ mod tests {
         }));
         let r = evaluate_bs1(&input, &AcmgConfig::default());
         assert!(r.met, "max-pop AF should drive BS1, not cohort AF");
-        assert!(r.summary.contains("max population AF"), "got: {}", r.summary);
+        assert!(
+            r.summary.contains("max population AF"),
+            "got: {}",
+            r.summary
+        );
     }
 
     // ── BS1 against the filtering allele frequency (Whiffin 2017) ──
@@ -903,7 +954,10 @@ mod tests {
             ..Default::default()
         }));
         let r = evaluate_bs1(&input, &AcmgConfig::default());
-        assert!(!r.met, "BS1 must not fire on a point estimate the FAF contradicts");
+        assert!(
+            !r.met,
+            "BS1 must not fire on a point estimate the FAF contradicts"
+        );
         assert!(r.summary.contains("filtering AF"), "got: {}", r.summary);
     }
 
@@ -950,6 +1004,9 @@ mod tests {
             ..Default::default()
         };
         let r = evaluate_bs1(&input, &config);
-        assert!(r.met, "with the FAF disabled BS1 reverts to the point estimate");
+        assert!(
+            r.met,
+            "with the FAF disabled BS1 reverts to the point estimate"
+        );
     }
 }

--- a/crates/fastvep-classification/src/criteria/benign_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/benign_supporting.rs
@@ -5,10 +5,7 @@ use crate::sa_extract::ClassificationInput;
 use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 
 /// Evaluate all benign supporting criteria: BP1, BP2, BP3, BP4, BP5, BP6, BP7.
-pub fn evaluate_all(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Vec<EvidenceCriterion> {
+pub fn evaluate_all(input: &ClassificationInput, config: &AcmgConfig) -> Vec<EvidenceCriterion> {
     let mut criteria = vec![
         evaluate_bp1(input, config),
         evaluate_bp2(input, config),
@@ -41,10 +38,7 @@ pub fn evaluate_all(
 /// found BP1 firing on ENG, CFH, FGFR3, APC, ANKRD11, PKD1 and a dozen more
 /// genes whose spectrum plainly includes pathogenic missense. Constraint
 /// metrics describe population tolerance, not disease mechanism.
-fn evaluate_bp1(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp1(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let is_missense = input
         .consequences
         .iter()
@@ -91,9 +85,7 @@ fn evaluate_bp1(
     let (met, evaluated, summary) = if !is_missense {
         (false, true, "Not a missense variant".to_string())
     } else if let Some(ref gc) = input.gene_constraints {
-        let pli_high = gc
-            .pli
-            .is_some_and(|p| p >= config.pli_lof_intolerant);
+        let pli_high = gc.pli.is_some_and(|p| p >= config.pli_lof_intolerant);
         let misz_low = gc.mis_z.is_some_and(|z| z < 2.0);
 
         if let Some(pli) = gc.pli {
@@ -126,7 +118,11 @@ fn evaluate_bp1(
             )
         }
     } else {
-        (false, false, "No gene constraint data available".to_string())
+        (
+            false,
+            false,
+            "No gene constraint data available".to_string(),
+        )
     };
 
     EvidenceCriterion {
@@ -147,10 +143,7 @@ fn evaluate_bp1(
 /// Two triggers:
 /// 1. Dominant disorders: variant is in trans with a ClinVar pathogenic variant (phased).
 /// 2. Any inheritance: variant is in cis with a ClinVar pathogenic variant (phased).
-fn evaluate_bp2(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp2(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     if input.companion_variants.is_empty() {
@@ -186,8 +179,14 @@ fn evaluate_bp2(
         .filter(|cv| cv.is_clinvar_pathogenic && cv.is_in_trans == Some(true))
         .collect();
 
-    details.insert("in_cis_pathogenic_count".into(), serde_json::json!(in_cis_pathogenic.len()));
-    details.insert("in_trans_pathogenic_count".into(), serde_json::json!(in_trans_pathogenic.len()));
+    details.insert(
+        "in_cis_pathogenic_count".into(),
+        serde_json::json!(in_cis_pathogenic.len()),
+    );
+    details.insert(
+        "in_trans_pathogenic_count".into(),
+        serde_json::json!(in_trans_pathogenic.len()),
+    );
 
     // Collect HGVSc for reporting
     let cis_ids: Vec<String> = in_cis_pathogenic
@@ -248,7 +247,8 @@ fn evaluate_bp2(
     let summary = if has_phased_data {
         "Phased companion variants do not meet BP2 criteria".to_string()
     } else {
-        "Companion variants are unphased; BP2 requires phased data to determine cis/trans".to_string()
+        "Companion variants are unphased; BP2 requires phased data to determine cis/trans"
+            .to_string()
     };
 
     EvidenceCriterion {
@@ -266,10 +266,7 @@ fn evaluate_bp2(
 /// BP3: In-frame deletions/insertions in a repetitive region without a known function.
 ///
 /// Uses RepeatMasker interval annotations when available.
-fn evaluate_bp3(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp3(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let is_inframe_indel = input.consequences.iter().any(|c| {
         matches!(
             c,
@@ -306,7 +303,8 @@ fn evaluate_bp3(
         }
     } else {
         let summary = if is_inframe_indel {
-            "In-frame indel detected, but repeat region data not available (load RepeatMasker .osi)".to_string()
+            "In-frame indel detected, but repeat region data not available (load RepeatMasker .osi)"
+                .to_string()
         } else {
             "Not an in-frame insertion or deletion".to_string()
         };
@@ -337,10 +335,7 @@ fn evaluate_bp3(
 /// Per Walker 2023 (ClinGen SVI Splicing Subgroup): SpliceAI ≤ 0.1 yields BP4
 /// at Supporting strength when a SpliceAI score is available (scores between
 /// 0.1 and 0.2 are uninformative).
-fn evaluate_bp4(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp4(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
     let mut evidence_lines: Vec<String> = Vec::new();
 
@@ -505,10 +500,7 @@ fn evaluate_bp4(
     // Resolve final strength. REVEL (missense, already strength-graded) takes
     // precedence over splice. If both fire, prefer the stronger.
     let (met, strength) = match (revel_met, splice_supporting) {
-        (true, _) => (
-            true,
-            revel_strength.unwrap_or(EvidenceStrength::Supporting),
-        ),
+        (true, _) => (true, revel_strength.unwrap_or(EvidenceStrength::Supporting)),
         (false, true) => (true, EvidenceStrength::Supporting),
         (false, false) => (false, EvidenceStrength::Supporting),
     };
@@ -549,10 +541,7 @@ fn evaluate_bp4(
 }
 
 /// BP5: Variant found in a case with an alternate molecular basis for disease.
-fn evaluate_bp5(
-    _input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp5(_input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     EvidenceCriterion {
         code: "BP5".to_string(),
         direction: EvidenceDirection::Benign,
@@ -569,14 +558,13 @@ fn evaluate_bp5(
 ///
 /// Note: ClinGen SVI recommends against using BP6 without reviewing underlying evidence.
 /// Disabled by default (config.use_pp5_bp6 = false).
-fn evaluate_bp6(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp6(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
     details.insert(
         "svi_note".into(),
-        serde_json::json!("ClinGen SVI recommends against using BP6 without reviewing underlying evidence"),
+        serde_json::json!(
+            "ClinGen SVI recommends against using BP6 without reviewing underlying evidence"
+        ),
     );
 
     let (met, evaluated, summary) = if let Some(ref clinvar) = input.clinvar {
@@ -645,10 +633,7 @@ fn evaluate_bp6(
 /// When the pipeline does not populate `at_exon_edge` / `intronic_offset`
 /// (current default), behavior reverts to the legacy synonymous-only rule
 /// for backward compatibility.
-fn evaluate_bp7(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_bp7(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let is_synonymous = input
         .consequences
         .iter()
@@ -742,11 +727,7 @@ fn evaluate_bp7(
     // SpliceAI is genuinely insensitive to pseudoexon activation, which is
     // what `bp7_max_intron_offset` addresses instead. This gate is still
     // correct - it just turned out to be about a different set of variants.
-    let Some(max_ds) = input
-        .splice_ai
-        .as_ref()
-        .and_then(|s| s.max_delta_score())
-    else {
+    let Some(max_ds) = input.splice_ai.as_ref().and_then(|s| s.max_delta_score()) else {
         details.insert("spliceai_max_ds".into(), serde_json::Value::Null);
         return EvidenceCriterion {
             code: "BP7".to_string(),
@@ -811,10 +792,10 @@ fn evaluate_bp7(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::{
         ClinvarProteinData, ClinvarProteinVariant, GnomadGeneData, RevelData, SpliceAiData,
     };
+    use crate::test_support::minimal_input;
     use fastvep_core::Impact;
 
     fn make_input(
@@ -970,7 +951,10 @@ mod tests {
         // A missense that ALSO overlaps a splice region is splice-assessable, so
         // a low SpliceAI score still yields BP4 Supporting (Walker 2023).
         let input = make_input(
-            vec![Consequence::MissenseVariant, Consequence::SpliceRegionVariant],
+            vec![
+                Consequence::MissenseVariant,
+                Consequence::SpliceRegionVariant,
+            ],
             None,
             Some(0.0),
             None,
@@ -1061,13 +1045,21 @@ mod tests {
         let unknown = evaluate_bp3(&input, &config);
         assert!(!unknown.met);
         assert!(!unknown.evaluated, "no database: BP3 has nothing to say");
-        assert!(unknown.summary.contains("not available"), "got: {}", unknown.summary);
+        assert!(
+            unknown.summary.contains("not available"),
+            "got: {}",
+            unknown.summary
+        );
 
         input.in_repeat_region = Some(false);
         let looked = evaluate_bp3(&input, &config);
         assert!(!looked.met);
         assert!(looked.evaluated, "database loaded: BP3 looked and declined");
-        assert!(looked.summary.contains("not in a repetitive region"), "got: {}", looked.summary);
+        assert!(
+            looked.summary.contains("not in a repetitive region"),
+            "got: {}",
+            looked.summary
+        );
 
         input.in_repeat_region = Some(true);
         let hit = evaluate_bp3(&input, &config);
@@ -1089,12 +1081,18 @@ mod tests {
         );
         let config = AcmgConfig::default();
         input.intronic_offset = Some(300);
-        assert!(evaluate_bp7(&input, &config).met, "at the boundary BP7 still applies");
+        assert!(
+            evaluate_bp7(&input, &config).met,
+            "at the boundary BP7 still applies"
+        );
 
         input.intronic_offset = Some(301);
         let result = evaluate_bp7(&input, &config);
         assert!(!result.met);
-        assert!(result.evaluated, "declined on the merits, not left unexamined");
+        assert!(
+            result.evaluated,
+            "declined on the merits, not left unexamined"
+        );
         assert!(result.summary.contains("far boundary"));
 
         // Symmetric on the acceptor side.
@@ -1157,7 +1155,7 @@ mod tests {
         let mut input = make_input(
             vec![Consequence::IntronVariant],
             None,
-            None, // no SpliceAI
+            None,      // no SpliceAI
             Some(0.4), // deep intron, unconserved
             None,
         );
@@ -1165,11 +1163,21 @@ mod tests {
         let r = evaluate_bp7(&input, &AcmgConfig::default());
         assert!(!r.met);
         assert!(!r.evaluated, "absent data is not an assessment");
-        assert!(r.summary.contains("no SpliceAI prediction"), "got: {}", r.summary);
+        assert!(
+            r.summary.contains("no SpliceAI prediction"),
+            "got: {}",
+            r.summary
+        );
 
         // A synonymous variant is held to the same requirement: Richards 2015
         // words BP7 as "splicing prediction algorithms predict no impact".
-        let syn = make_input(vec![Consequence::SynonymousVariant], None, None, Some(0.2), None);
+        let syn = make_input(
+            vec![Consequence::SynonymousVariant],
+            None,
+            None,
+            Some(0.2),
+            None,
+        );
         assert!(!evaluate_bp7(&syn, &AcmgConfig::default()).met);
     }
 
@@ -1289,7 +1297,9 @@ mod tests {
         let result = evaluate_bp1(&input, &AcmgConfig::default());
         assert!(!result.met);
         assert!(result.evaluated);
-        assert!(result.summary.contains("missense is an established mechanism"));
+        assert!(result
+            .summary
+            .contains("missense is an established mechanism"));
     }
 
     #[test]
@@ -1347,7 +1357,10 @@ mod tests {
         // An in-frame indel that also overlaps a splice region is genuinely
         // splice-assessable, so Walker 2023 BP4-splice still applies.
         let input = make_input(
-            vec![Consequence::InframeDeletion, Consequence::SpliceRegionVariant],
+            vec![
+                Consequence::InframeDeletion,
+                Consequence::SpliceRegionVariant,
+            ],
             None,
             Some(0.0),
             None,

--- a/crates/fastvep-classification/src/criteria/frequency_gate.rs
+++ b/crates/fastvep-classification/src/criteria/frequency_gate.rs
@@ -46,11 +46,17 @@ pub(crate) struct FrequencyBlocker {
 
 impl FrequencyBlocker {
     fn gene_level(reason: String) -> Self {
-        Self { reason, site_level: false }
+        Self {
+            reason,
+            site_level: false,
+        }
     }
 
     fn site_level(reason: String) -> Self {
-        Self { reason, site_level: true }
+        Self {
+            reason,
+            site_level: true,
+        }
     }
 
     /// Record this blocker in a criterion's `details`, under the two keys the
@@ -87,11 +93,18 @@ pub(crate) fn note_withheld_benign_frequency(
     threshold: f64,
     details: &mut serde_json::Map<String, serde_json::Value>,
 ) {
-    let Some((af, _)) = input.gnomad.as_ref().and_then(|g| benign_test_af(g, config)) else {
+    let Some((af, _)) = input
+        .gnomad
+        .as_ref()
+        .and_then(|g| benign_test_af(g, config))
+    else {
         return;
     };
     if af > threshold {
-        details.insert(FREQUENCY_BLOCKED_WOULD_BE_BENIGN.into(), serde_json::json!(true));
+        details.insert(
+            FREQUENCY_BLOCKED_WOULD_BE_BENIGN.into(),
+            serde_json::json!(true),
+        );
         details.insert("frequency_blocked_af".into(), serde_json::json!(af));
     }
 }
@@ -243,7 +256,10 @@ pub(crate) fn benign_test_af(
 ) -> Option<(f64, &'static str)> {
     if config.use_filtering_af {
         if let Some(faf) = gnomad.filtering_af() {
-            return Some((faf, "filtering AF (95% CI lower bound, max across ancestry groups)"));
+            return Some((
+                faf,
+                "filtering AF (95% CI lower bound, max across ancestry groups)",
+            ));
         }
     }
     gnomad.max_pop_af().map(|af| (af, "max population AF"))
@@ -273,9 +289,18 @@ mod tests {
     #[test]
     fn test_failed_filter_blocks_in_both_directions() {
         for gnomad in [
-            GnomadData { filter_ac0: true, ..Default::default() },
-            GnomadData { filter_vqsr: true, ..Default::default() },
-            GnomadData { filter_inbreeding: true, ..Default::default() },
+            GnomadData {
+                filter_ac0: true,
+                ..Default::default()
+            },
+            GnomadData {
+                filter_vqsr: true,
+                ..Default::default()
+            },
+            GnomadData {
+                filter_inbreeding: true,
+                ..Default::default()
+            },
         ] {
             let input = input_with(gnomad);
             let blocker = data_blocker(&input, &AcmgConfig::default())
@@ -292,18 +317,27 @@ mod tests {
     fn test_segdup_and_lcr_block_when_enabled() {
         for (gnomad, expected) in [
             (
-                GnomadData { segdup: true, ..Default::default() },
+                GnomadData {
+                    segdup: true,
+                    ..Default::default()
+                },
                 "segmental duplication",
             ),
             (
-                GnomadData { lcr: true, ..Default::default() },
+                GnomadData {
+                    lcr: true,
+                    ..Default::default()
+                },
                 "low-complexity region",
             ),
         ] {
             let input = input_with(gnomad);
             let blocker = data_blocker(&input, &AcmgConfig::default()).expect("should block");
             assert!(blocker.reason.contains(expected), "got: {}", blocker.reason);
-            assert!(blocker.site_level, "a region flag is a verdict on this site's reads");
+            assert!(
+                blocker.site_level,
+                "a region flag is a verdict on this site's reads"
+            );
         }
     }
 
@@ -316,10 +350,16 @@ mod tests {
         input.gene_symbol = Some("PMS2".to_string());
         let config = AcmgConfig::default();
         if let Some(blocker) = data_blocker(&input, &config) {
-            assert!(!blocker.site_level, "curated homology is a gene-level claim");
+            assert!(
+                !blocker.site_level,
+                "curated homology is a gene-level claim"
+            );
         }
 
-        let mut input = input_with(GnomadData { all_af: Some(0.01), ..Default::default() });
+        let mut input = input_with(GnomadData {
+            all_af: Some(0.01),
+            ..Default::default()
+        });
         input.clinvar = Some(crate::sa_extract::ClinvarData {
             significance: Some(vec!["Pathogenic,_low_penetrance".to_string()]),
             review_status: Some("criteria_provided,_multiple_submitters,_no_conflicts".to_string()),
@@ -334,7 +374,10 @@ mod tests {
 
     #[test]
     fn test_region_flags_can_be_disabled() {
-        let input = input_with(GnomadData { segdup: true, ..Default::default() });
+        let input = input_with(GnomadData {
+            segdup: true,
+            ..Default::default()
+        });
         let config = AcmgConfig {
             gnomad_region_flags_block_frequency: false,
             ..Default::default()
@@ -342,7 +385,10 @@ mod tests {
         assert!(data_blocker(&input, &config).is_none());
         // The FILTER gate is not covered by that switch: a record gnomAD
         // itself rejected is never usable.
-        let input = input_with(GnomadData { filter_ac0: true, ..Default::default() });
+        let input = input_with(GnomadData {
+            filter_ac0: true,
+            ..Default::default()
+        });
         assert!(data_blocker(&input, &config).is_some());
     }
 

--- a/crates/fastvep-classification/src/criteria/gene_disease.rs
+++ b/crates/fastvep-classification/src/criteria/gene_disease.rs
@@ -40,10 +40,7 @@ use crate::sa_extract::ClassificationInput;
 /// yet. The genes it was meant to catch (RYK, GIGYF2) are absent from ClinGen
 /// too, so absence-blocking was not even selecting for the right thing - it was
 /// selecting for curation coverage.
-pub(crate) fn validity_blocker(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Option<String> {
+pub(crate) fn validity_blocker(input: &ClassificationInput, config: &AcmgConfig) -> Option<String> {
     if !config.require_gene_disease_validity {
         return None;
     }
@@ -171,14 +168,25 @@ mod tests {
 
     #[test]
     fn test_curated_as_weak_or_refuted_blocks() {
-        for class in ["Limited", "Disputed", "Refuted", "No Known Disease Relationship"] {
+        for class in [
+            "Limited",
+            "Disputed",
+            "Refuted",
+            "No Known Disease Relationship",
+        ] {
             let input = with_phenotypes(&[&format!(
                 "a proposed disease (ClinGen {class}/AD, MONDO:0000001)"
             )]);
             let reason = validity_blocker(&input, &AcmgConfig::default())
                 .unwrap_or_else(|| panic!("{class} must block"));
-            assert!(reason.contains("no_valid_gene_disease_relationship"), "got: {reason}");
-            assert!(reason.contains("TEST"), "the reason must name the gene: {reason}");
+            assert!(
+                reason.contains("no_valid_gene_disease_relationship"),
+                "got: {reason}"
+            );
+            assert!(
+                reason.contains("TEST"),
+                "the reason must name the gene: {reason}"
+            );
         }
     }
 
@@ -206,7 +214,10 @@ mod tests {
         // A record carrying only a mimNumber is not a curation finding.
         let mut input = minimal_input();
         for phenotypes in [None, Some(vec![])] {
-            input.omim = Some(OmimData { mim_number: Some(0), phenotypes });
+            input.omim = Some(OmimData {
+                mim_number: Some(0),
+                phenotypes,
+            });
             assert!(validity_blocker(&input, &AcmgConfig::default()).is_none());
         }
     }
@@ -214,7 +225,10 @@ mod tests {
     #[test]
     fn test_validity_gate_is_switchable() {
         let input = with_phenotypes(&["x (ClinGen Refuted/AD, MONDO:0000001)"]);
-        let config = AcmgConfig { require_gene_disease_validity: false, ..Default::default() };
+        let config = AcmgConfig {
+            require_gene_disease_validity: false,
+            ..Default::default()
+        };
         assert!(validity_blocker(&input, &config).is_none());
     }
 
@@ -222,7 +236,10 @@ mod tests {
     fn test_gof_only_mechanism_blocks_pvs1() {
         let (input, config) = with_mechanism("PCSK9", "GOF");
         let reason = lof_mechanism_blocker(&input, &config).expect("GOF-only must block");
-        assert!(reason.contains("mechanism_not_loss_of_function"), "got: {reason}");
+        assert!(
+            reason.contains("mechanism_not_loss_of_function"),
+            "got: {reason}"
+        );
         assert!(reason.contains("PCSK9"));
     }
 
@@ -303,10 +320,8 @@ mod tests {
         // The reason the curated mechanisms live in their own map: a TOML that
         // sets a single [gene_overrides.X] block replaces `gene_overrides`
         // wholesale, and would take the shipped table with it.
-        let config: AcmgConfig = toml::from_str(
-            "[gene_overrides.BRCA1]\nmechanism = \"LOF\"\n",
-        )
-        .expect("config must parse");
+        let config: AcmgConfig = toml::from_str("[gene_overrides.BRCA1]\nmechanism = \"LOF\"\n")
+            .expect("config must parse");
         let mut input = minimal_input();
         input.gene_symbol = Some("PCSK9".to_string());
         assert!(lof_mechanism_blocker(&input, &config).is_some());

--- a/crates/fastvep-classification/src/criteria/mod.rs
+++ b/crates/fastvep-classification/src/criteria/mod.rs
@@ -1,15 +1,13 @@
 pub(crate) mod frequency_gate;
-pub(crate) use frequency_gate::{
-    FREQUENCY_BLOCKED_SITE_LEVEL, FREQUENCY_BLOCKED_WOULD_BE_BENIGN,
-};
-pub(crate) mod gene_disease;
-pub mod pvs1;
-pub mod pathogenic_strong;
-pub mod pathogenic_moderate;
-pub mod pathogenic_supporting;
+pub(crate) use frequency_gate::{FREQUENCY_BLOCKED_SITE_LEVEL, FREQUENCY_BLOCKED_WOULD_BE_BENIGN};
 pub mod benign_standalone;
 pub mod benign_strong;
 pub mod benign_supporting;
+pub(crate) mod gene_disease;
+pub mod pathogenic_moderate;
+pub mod pathogenic_strong;
+pub mod pathogenic_supporting;
+pub mod pvs1;
 
 use crate::config::AcmgConfig;
 use crate::sa_extract::ClassificationInput;
@@ -29,7 +27,12 @@ pub fn evaluate_all_criteria(
     let mut criteria = Vec::with_capacity(28);
 
     // Pathogenic Very Strong
-    push_with_overrides(&mut criteria, pvs1::evaluate_pvs1(input, config), gene, config);
+    push_with_overrides(
+        &mut criteria,
+        pvs1::evaluate_pvs1(input, config),
+        gene,
+        config,
+    );
 
     // Pathogenic Strong
     for c in pathogenic_strong::evaluate_all(input, config) {
@@ -215,7 +218,10 @@ fn reconcile_evidence(criteria: &mut [EvidenceCriterion]) {
     // direction. That is deliberate. Where an assay says "damaging" and REVEL
     // says "benign", the predictor is not a dissenting vote to be counted, it
     // is superseded; and the reverse holds just as strongly.
-    if criteria.iter().any(|c| c.met && (c.code == "PS3" || c.code == "BS3")) {
+    if criteria
+        .iter()
+        .any(|c| c.met && (c.code == "PS3" || c.code == "BS3"))
+    {
         let evidence = criteria
             .iter()
             .find(|c| c.met && (c.code == "PS3" || c.code == "BS3"))
@@ -325,8 +331,14 @@ fn functional_criterion(
     };
 
     let mut details = serde_json::Map::new();
-    details.insert("source".into(), serde_json::json!("curated functional evidence"));
-    details.insert("strength".into(), serde_json::json!(entry.strength.as_str()));
+    details.insert(
+        "source".into(),
+        serde_json::json!("curated functional evidence"),
+    );
+    details.insert(
+        "strength".into(),
+        serde_json::json!(entry.strength.as_str()),
+    );
     if let Some(ref pmid) = entry.pmid {
         details.insert("pmid".into(), serde_json::json!(pmid));
     }
@@ -456,9 +468,17 @@ mod reconcile_tests {
     fn test_a_gene_strength_override_restrengths_and_renames() {
         let config = config_capping_pp3("MYH7", EvidenceStrength::Moderate);
         let mut out = Vec::new();
-        push_with_overrides(&mut out, pp3_at(EvidenceStrength::Strong), Some("MYH7"), &config);
+        push_with_overrides(
+            &mut out,
+            pp3_at(EvidenceStrength::Strong),
+            Some("MYH7"),
+            &config,
+        );
         assert_eq!(out[0].strength, EvidenceStrength::Moderate);
-        assert_eq!(out[0].code, "PP3_Moderate", "the code must not contradict the strength");
+        assert_eq!(
+            out[0].code, "PP3_Moderate",
+            "the code must not contradict the strength"
+        );
         assert!(out[0].summary.contains("was Strong"), "{}", out[0].summary);
     }
 
@@ -467,7 +487,12 @@ mod reconcile_tests {
         // PP3's default is Supporting, and bare `PP3` is how that is spelled.
         let config = config_capping_pp3("MYH7", EvidenceStrength::Supporting);
         let mut out = Vec::new();
-        push_with_overrides(&mut out, pp3_at(EvidenceStrength::Strong), Some("MYH7"), &config);
+        push_with_overrides(
+            &mut out,
+            pp3_at(EvidenceStrength::Strong),
+            Some("MYH7"),
+            &config,
+        );
         assert_eq!(out[0].code, "PP3");
         assert_eq!(out[0].strength, EvidenceStrength::Supporting);
     }
@@ -476,7 +501,12 @@ mod reconcile_tests {
     fn test_a_gene_override_does_not_reach_other_genes() {
         let config = config_capping_pp3("MYH7", EvidenceStrength::Moderate);
         let mut out = Vec::new();
-        push_with_overrides(&mut out, pp3_at(EvidenceStrength::Strong), Some("BRCA1"), &config);
+        push_with_overrides(
+            &mut out,
+            pp3_at(EvidenceStrength::Strong),
+            Some("BRCA1"),
+            &config,
+        );
         assert_eq!(out[0].code, "PP3_Strong");
         assert_eq!(out[0].strength, EvidenceStrength::Strong);
     }
@@ -504,7 +534,12 @@ mod reconcile_tests {
             .strength_overrides
             .insert("PP3_Strong".to_string(), EvidenceStrength::Supporting);
         let mut out = Vec::new();
-        push_with_overrides(&mut out, pp3_at(EvidenceStrength::Strong), Some("MYH7"), &config);
+        push_with_overrides(
+            &mut out,
+            pp3_at(EvidenceStrength::Strong),
+            Some("MYH7"),
+            &config,
+        );
         assert_eq!(out[0].code, "PP3");
     }
 
@@ -526,7 +561,11 @@ mod reconcile_tests {
         let mut out = Vec::new();
         push_with_overrides(
             &mut out,
-            met("BP1", EvidenceDirection::Benign, EvidenceStrength::Supporting),
+            met(
+                "BP1",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
             Some("PTEN"),
             &config,
         );
@@ -546,8 +585,15 @@ mod reconcile_tests {
         }
     }
 
-    fn not_met(code: &str, dir: EvidenceDirection, strength: EvidenceStrength) -> EvidenceCriterion {
-        EvidenceCriterion { met: false, ..met(code, dir, strength) }
+    fn not_met(
+        code: &str,
+        dir: EvidenceDirection,
+        strength: EvidenceStrength,
+    ) -> EvidenceCriterion {
+        EvidenceCriterion {
+            met: false,
+            ..met(code, dir, strength)
+        }
     }
 
     fn pp3_with_source(strength: EvidenceStrength, source: &str) -> EvidenceCriterion {
@@ -582,12 +628,19 @@ mod reconcile_tests {
         // Walker 2023: PVS1 already counts the splicing signal; PP3 from
         // SpliceAI must not double-count.
         let mut criteria = vec![
-            met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
+            met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
             pp3_with_source(EvidenceStrength::Supporting, "spliceai"),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PVS1").met, "PVS1 should remain met");
-        assert!(!find(&criteria, "PP3").met, "PP3(splice) should be suppressed");
+        assert!(
+            !find(&criteria, "PP3").met,
+            "PP3(splice) should be suppressed"
+        );
     }
 
     #[test]
@@ -595,11 +648,18 @@ mod reconcile_tests {
         // PP3 driven by REVEL (missense) is unrelated to splicing — PVS1 firing
         // for some other null variant in the same call must not suppress it.
         let mut criteria = vec![
-            met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
+            met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
             pp3_with_source(EvidenceStrength::Strong, "revel_missense"),
         ];
         reconcile_evidence(&mut criteria);
-        assert!(find(&criteria, "PP3").met, "PP3(REVEL) should not be suppressed by PVS1");
+        assert!(
+            find(&criteria, "PP3").met,
+            "PP3(REVEL) should not be suppressed by PVS1"
+        );
     }
 
     #[test]
@@ -607,34 +667,55 @@ mod reconcile_tests {
         // Pejaver 2022: PS1 already covers the residue-level pathogenicity
         // that REVEL captures.
         let mut criteria = vec![
-            met("PS1", EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
+            met(
+                "PS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Strong,
+            ),
             pp3_with_source(EvidenceStrength::Strong, "revel_missense"),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PS1").met);
-        assert!(!find(&criteria, "PP3").met, "PP3(REVEL) should be suppressed by PS1");
+        assert!(
+            !find(&criteria, "PP3").met,
+            "PP3(REVEL) should be suppressed by PS1"
+        );
     }
 
     #[test]
     fn pm5_plus_pp3_revel_suppresses_pp3() {
         let mut criteria = vec![
-            met("PM5", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
+            met(
+                "PM5",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
             pp3_with_source(EvidenceStrength::Moderate, "revel_missense"),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PM5").met);
-        assert!(!find(&criteria, "PP3").met, "PP3(REVEL) should be suppressed by PM5");
+        assert!(
+            !find(&criteria, "PP3").met,
+            "PP3(REVEL) should be suppressed by PM5"
+        );
     }
 
     #[test]
     fn ps1_does_not_suppress_pp3_splice() {
         // PS1 is missense; if PP3 came from SpliceAI it's a different signal.
         let mut criteria = vec![
-            met("PS1", EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
+            met(
+                "PS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Strong,
+            ),
             pp3_with_source(EvidenceStrength::Supporting, "spliceai"),
         ];
         reconcile_evidence(&mut criteria);
-        assert!(find(&criteria, "PP3").met, "PP3(splice) should not be suppressed by PS1");
+        assert!(
+            find(&criteria, "PP3").met,
+            "PP3(splice) should not be suppressed by PS1"
+        );
     }
 
     #[test]
@@ -643,11 +724,18 @@ mod reconcile_tests {
         // PP3_Strong (4) + PM1 (2) = 6 > 4 → drop PM1.
         let mut criteria = vec![
             pp3_with_source(EvidenceStrength::Strong, "revel_missense"),
-            met("PM1", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
+            met(
+                "PM1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PP3").met, "PP3_Strong should remain met");
-        assert!(!find(&criteria, "PM1").met, "PM1 should be suppressed under PP3_Strong cap");
+        assert!(
+            !find(&criteria, "PM1").met,
+            "PM1 should be suppressed under PP3_Strong cap"
+        );
     }
 
     #[test]
@@ -655,7 +743,11 @@ mod reconcile_tests {
         // PP3_Moderate (2) + PM1 (2) = 4 → at the Strong cap, both can stand.
         let mut criteria = vec![
             pp3_with_source(EvidenceStrength::Moderate, "revel_missense"),
-            met("PM1", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
+            met(
+                "PM1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PP3").met);
@@ -667,7 +759,11 @@ mod reconcile_tests {
         // PP3 (1) + PM1 (2) = 3 < 4 → both stand.
         let mut criteria = vec![
             pp3_with_source(EvidenceStrength::Supporting, "revel_missense"),
-            met("PM1", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
+            met(
+                "PM1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "PP3").met);
@@ -682,7 +778,11 @@ mod reconcile_tests {
         // matching so PVS1_* + PP3(splice) still drops PP3 (Walker 2023).
         for graded_code in ["PVS1_Strong", "PVS1_Moderate", "PVS1_Supporting"] {
             let mut criteria = vec![
-                met(graded_code, EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
+                met(
+                    graded_code,
+                    EvidenceDirection::Pathogenic,
+                    EvidenceStrength::Strong,
+                ),
                 pp3_with_source(EvidenceStrength::Supporting, "spliceai"),
             ];
             reconcile_evidence(&mut criteria);
@@ -699,10 +799,17 @@ mod reconcile_tests {
         // Same regression guard for PM1 graded codes (if ever introduced).
         let mut criteria = vec![
             pp3_with_source(EvidenceStrength::Strong, "revel_missense"),
-            met("PM1_Strong", EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
+            met(
+                "PM1_Strong",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Strong,
+            ),
         ];
         reconcile_evidence(&mut criteria);
-        assert!(!find(&criteria, "PM1").met, "graded PM1 should be capped under PP3_Strong");
+        assert!(
+            !find(&criteria, "PM1").met,
+            "graded PM1 should be capped under PP3_Strong"
+        );
     }
 
     // ── B8: curated functional evidence ──────────────────────────────────
@@ -714,19 +821,42 @@ mod reconcile_tests {
         // variant with published splice-defect data, where fastVEP was firing
         // BP7 and BP4 and calling it benign.
         let mut criteria = vec![
-            met("PS3", EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
+            met(
+                "PS3",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Strong,
+            ),
             pp3_with_source(EvidenceStrength::Strong, "revel_missense"),
-            met("BP4", EvidenceDirection::Benign, EvidenceStrength::Supporting),
-            met("BP7", EvidenceDirection::Benign, EvidenceStrength::Supporting),
-            met("PM2_Supporting", EvidenceDirection::Pathogenic, EvidenceStrength::Supporting),
+            met(
+                "BP4",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
+            met(
+                "BP7",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
+            met(
+                "PM2_Supporting",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Supporting,
+            ),
         ];
         reconcile_evidence(&mut criteria);
 
-        assert!(find(&criteria, "PS3").met, "the evidence itself must survive");
+        assert!(
+            find(&criteria, "PS3").met,
+            "the evidence itself must survive"
+        );
         for code in ["PP3", "BP4", "BP7"] {
             let c = find(&criteria, code);
             assert!(!c.met, "{code} should be superseded");
-            assert!(c.summary.contains("Superseded by functional evidence"), "got: {}", c.summary);
+            assert!(
+                c.summary.contains("Superseded by functional evidence"),
+                "got: {}",
+                c.summary
+            );
         }
         assert!(
             find(&criteria, "PM2_Supporting").met,
@@ -751,8 +881,16 @@ mod reconcile_tests {
     fn predictors_stand_when_there_is_no_functional_evidence() {
         // A PS3 that was evaluated but not met must not suppress anything.
         let mut criteria = vec![
-            not_met("PS3", EvidenceDirection::Pathogenic, EvidenceStrength::Strong),
-            met("BP4", EvidenceDirection::Benign, EvidenceStrength::Supporting),
+            not_met(
+                "PS3",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Strong,
+            ),
+            met(
+                "BP4",
+                EvidenceDirection::Benign,
+                EvidenceStrength::Supporting,
+            ),
         ];
         reconcile_evidence(&mut criteria);
         assert!(find(&criteria, "BP4").met);
@@ -799,13 +937,14 @@ mod reconcile_tests {
         // The honest default: no curated evidence means no assertion either
         // way, not an absence of effect.
         let input = minimal_input();
-        for c in [
-            ps3(&input),
-            bs3(&input),
-        ] {
+        for c in [ps3(&input), bs3(&input)] {
             assert!(!c.met);
             assert!(!c.evaluated);
-            assert!(c.summary.contains("--functional-evidence"), "got: {}", c.summary);
+            assert!(
+                c.summary.contains("--functional-evidence"),
+                "got: {}",
+                c.summary
+            );
         }
     }
 
@@ -850,7 +989,11 @@ mod reconcile_tests {
     // ── Walker 2023 Table 3: PS1's splice path graded against PVS1 ───────
 
     fn splice_ps1_supporting() -> EvidenceCriterion {
-        let mut c = met("PS1_Supporting", EvidenceDirection::Pathogenic, EvidenceStrength::Supporting);
+        let mut c = met(
+            "PS1_Supporting",
+            EvidenceDirection::Pathogenic,
+            EvidenceStrength::Supporting,
+        );
         c.details = serde_json::json!({"ps1_path": "splice_rna_match"});
         c
     }
@@ -858,7 +1001,11 @@ mod reconcile_tests {
     #[test]
     fn test_splice_ps1_stays_supporting_under_a_full_strength_pvs1() {
         let mut criteria = vec![
-            met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
+            met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
             splice_ps1_supporting(),
         ];
         grade_ps1_splice_against_pvs1(&mut criteria);
@@ -883,7 +1030,12 @@ mod reconcile_tests {
             ];
             grade_ps1_splice_against_pvs1(&mut criteria);
             assert_eq!(criteria[1].code, "PS1", "PVS1_{:?}", downgraded);
-            assert_eq!(criteria[1].strength, EvidenceStrength::Strong, "PVS1_{:?}", downgraded);
+            assert_eq!(
+                criteria[1].strength,
+                EvidenceStrength::Strong,
+                "PVS1_{:?}",
+                downgraded
+            );
         }
     }
 
@@ -893,7 +1045,11 @@ mod reconcile_tests {
         // (a gene with no established LOF mechanism, say), so the conservative
         // strength stands.
         let mut criteria = vec![
-            not_met("PVS1", EvidenceDirection::Pathogenic, EvidenceStrength::VeryStrong),
+            not_met(
+                "PVS1",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::VeryStrong,
+            ),
             splice_ps1_supporting(),
         ];
         grade_ps1_splice_against_pvs1(&mut criteria);
@@ -904,10 +1060,18 @@ mod reconcile_tests {
     fn test_missense_ps1_is_untouched_by_the_splice_grading() {
         // The missense path is Richards 2015 PS1 at full Strong and has
         // nothing to do with Table 3.
-        let mut ps1 = met("PS1", EvidenceDirection::Pathogenic, EvidenceStrength::Strong);
+        let mut ps1 = met(
+            "PS1",
+            EvidenceDirection::Pathogenic,
+            EvidenceStrength::Strong,
+        );
         ps1.details = serde_json::json!({"ps1_path": "missense_aa_match"});
         let mut criteria = vec![
-            met("PVS1_Moderate", EvidenceDirection::Pathogenic, EvidenceStrength::Moderate),
+            met(
+                "PVS1_Moderate",
+                EvidenceDirection::Pathogenic,
+                EvidenceStrength::Moderate,
+            ),
             ps1,
         ];
         grade_ps1_splice_against_pvs1(&mut criteria);

--- a/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_moderate.rs
@@ -5,10 +5,7 @@ use crate::sa_extract::ClassificationInput;
 use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 
 /// Evaluate all pathogenic moderate criteria: PM1, PM2, PM3, PM4, PM5, PM6.
-pub fn evaluate_all(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Vec<EvidenceCriterion> {
+pub fn evaluate_all(input: &ClassificationInput, config: &AcmgConfig) -> Vec<EvidenceCriterion> {
     vec![
         evaluate_pm1(input, config),
         evaluate_pm2(input, config),
@@ -24,10 +21,7 @@ pub fn evaluate_all(
 /// Approximated using ClinVar pathogenic variant density as a hotspot proxy:
 /// if >=N pathogenic variants exist within ±W amino acid positions, the region
 /// is considered a hotspot.
-fn evaluate_pm1(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm1(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
     let window = config.pm1_hotspot_window;
     let threshold = config.pm1_hotspot_min_pathogenic;
@@ -115,7 +109,9 @@ fn evaluate_pm1(
         let raw_nearby: usize = cpd
             .protein_variants
             .iter()
-            .filter(|v| v.pos >= low && v.pos <= high && v.sig.to_lowercase().contains("pathogenic"))
+            .filter(|v| {
+                v.pos >= low && v.pos <= high && v.sig.to_lowercase().contains("pathogenic")
+            })
             .count();
 
         // The index is built from ClinVar, so when the variant being
@@ -131,10 +127,16 @@ fn evaluate_pm1(
         };
         let nearby_pathogenic = raw_nearby.saturating_sub(self_contribution);
 
-        details.insert("nearby_pathogenic_count".into(), serde_json::json!(nearby_pathogenic));
+        details.insert(
+            "nearby_pathogenic_count".into(),
+            serde_json::json!(nearby_pathogenic),
+        );
         if self_contribution > 0 {
             details.insert("self_excluded_from_count".into(), serde_json::json!(true));
-            details.insert("nearby_pathogenic_raw".into(), serde_json::json!(raw_nearby));
+            details.insert(
+                "nearby_pathogenic_raw".into(),
+                serde_json::json!(raw_nearby),
+            );
         }
 
         // The other half of PM1's definition. Richards 2015 asks for a hotspot
@@ -165,7 +167,9 @@ fn evaluate_pm1(
             let raw = cpd
                 .protein_variants
                 .iter()
-                .filter(|v| v.pos >= low && v.pos <= high && v.sig.to_lowercase().contains("benign"))
+                .filter(|v| {
+                    v.pos >= low && v.pos <= high && v.sig.to_lowercase().contains("benign")
+                })
                 .count();
             let self_benign = if config.exclude_self_from_clinvar_evidence
                 && input.clinvar.as_ref().is_some_and(|c| c.has_benign())
@@ -179,14 +183,17 @@ fn evaluate_pm1(
             0
         };
         if benign_tested {
-            details.insert("nearby_benign_count".into(), serde_json::json!(nearby_benign));
+            details.insert(
+                "nearby_benign_count".into(),
+                serde_json::json!(nearby_benign),
+            );
             details.insert(
                 "max_benign_in_window".into(),
                 serde_json::json!(config.pm1_max_benign_in_window),
             );
         }
-        let benign_variation = benign_tested
-            && nearby_benign > config.pm1_max_benign_in_window as usize;
+        let benign_variation =
+            benign_tested && nearby_benign > config.pm1_max_benign_in_window as usize;
 
         let met = nearby_pathogenic >= threshold as usize && !benign_variation;
         let summary = if benign_variation {
@@ -224,7 +231,8 @@ fn evaluate_pm1(
             default_strength: EvidenceStrength::Moderate,
             met: false,
             evaluated: false,
-            summary: "ClinVar protein-position index not available for hotspot analysis".to_string(),
+            summary: "ClinVar protein-position index not available for hotspot analysis"
+                .to_string(),
             details: serde_json::Value::Object(details),
         }
     }
@@ -242,10 +250,7 @@ fn evaluate_pm1(
 /// Inheritance is inferred from OMIM phenotypes (`OmimData::has_recessive_inheritance` /
 /// `has_dominant_inheritance`). When a per-gene `pm2_af_threshold` override is
 /// configured, that value wins regardless of inheritance.
-fn evaluate_pm2(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm2(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     // "Absent from population databases" is only evidence when the database
     // could have seen the variant. Where reads pile up on a paralogue, or
     // gnomAD itself rejected the site, both a frequency and the absence of a
@@ -256,9 +261,17 @@ fn evaluate_pm2(
         let mut details = serde_json::Map::new();
         blocker.record(&mut details);
         return EvidenceCriterion {
-            code: if config.pm2_downgrade_to_supporting { "PM2_Supporting".to_string() } else { "PM2".to_string() },
+            code: if config.pm2_downgrade_to_supporting {
+                "PM2_Supporting".to_string()
+            } else {
+                "PM2".to_string()
+            },
             direction: EvidenceDirection::Pathogenic,
-            strength: if config.pm2_downgrade_to_supporting { EvidenceStrength::Supporting } else { EvidenceStrength::Moderate },
+            strength: if config.pm2_downgrade_to_supporting {
+                EvidenceStrength::Supporting
+            } else {
+                EvidenceStrength::Moderate
+            },
             default_strength: EvidenceStrength::Moderate,
             met: false,
             evaluated: false,
@@ -303,17 +316,21 @@ fn evaluate_pm2(
         .as_ref()
         .is_some_and(|o| o.has_dominant_inheritance());
 
-    let (threshold, inheritance_basis): (f64, &'static str) = if let Some(t) = gene_specific_threshold {
-        (t, "gene_override")
-    } else if is_recessive && !is_dominant {
-        (config.pm2_ar_af_threshold, "AR")
-    } else {
-        (config.pm2_ad_af_threshold, "AD_or_unknown")
-    };
+    let (threshold, inheritance_basis): (f64, &'static str) =
+        if let Some(t) = gene_specific_threshold {
+            (t, "gene_override")
+        } else if is_recessive && !is_dominant {
+            (config.pm2_ar_af_threshold, "AR")
+        } else {
+            (config.pm2_ad_af_threshold, "AD_or_unknown")
+        };
 
     let mut details = serde_json::Map::new();
     details.insert("af_threshold".into(), serde_json::json!(threshold));
-    details.insert("inheritance_basis".into(), serde_json::json!(inheritance_basis));
+    details.insert(
+        "inheritance_basis".into(),
+        serde_json::json!(inheritance_basis),
+    );
     details.insert("is_recessive".into(), serde_json::json!(is_recessive));
     details.insert("is_dominant".into(), serde_json::json!(is_dominant));
 
@@ -433,7 +450,8 @@ fn evaluate_pm2(
         (
             false,
             false,
-            "PM2 not evaluated: no gnomAD annotation present (pm2_absent_when_no_record disabled).".to_string(),
+            "PM2 not evaluated: no gnomAD annotation present (pm2_absent_when_no_record disabled)."
+                .to_string(),
         )
     };
 
@@ -475,10 +493,7 @@ fn evaluate_pm2(
 ///
 /// Companions in cis with a pathogenic variant are excluded (those count
 /// toward BP2 instead). Requires AR inheritance from OMIM.
-fn evaluate_pm3(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm3(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     // Recessive inheritance gate.
@@ -494,7 +509,8 @@ fn evaluate_pm3(
             EvidenceStrength::Moderate,
             false,
             true,
-            "Gene does not have autosomal recessive inheritance (PM3 requires recessive disorder)".to_string(),
+            "Gene does not have autosomal recessive inheritance (PM3 requires recessive disorder)"
+                .to_string(),
             details,
         );
     }
@@ -512,9 +528,11 @@ fn evaluate_pm3(
             false,
             proband.is_some(),
             if proband.is_some() {
-                "Proband is neither het nor hom-alt for this variant (PM3 requires presence)".to_string()
+                "Proband is neither het nor hom-alt for this variant (PM3 requires presence)"
+                    .to_string()
             } else {
-                "Proband genotype not available; PM3 requires trio VCF for compound-het analysis".to_string()
+                "Proband genotype not available; PM3 requires trio VCF for compound-het analysis"
+                    .to_string()
             },
             details,
         );
@@ -544,7 +562,11 @@ fn evaluate_pm3(
             continue;
         }
         let confirmed_trans = cv.is_in_trans == Some(true);
-        let pts = match (confirmed_trans, cv.is_clinvar_pathogenic, cv.is_clinvar_likely_pathogenic) {
+        let pts = match (
+            confirmed_trans,
+            cv.is_clinvar_pathogenic,
+            cv.is_clinvar_likely_pathogenic,
+        ) {
             (true, true, _) => 1.0,
             (true, _, true) => 0.5,
             (false, true, _) => 0.5,
@@ -554,7 +576,11 @@ fn evaluate_pm3(
         if pts == 0.0 {
             continue;
         }
-        let label = match (confirmed_trans, cv.is_clinvar_pathogenic, cv.is_clinvar_likely_pathogenic) {
+        let label = match (
+            confirmed_trans,
+            cv.is_clinvar_pathogenic,
+            cv.is_clinvar_likely_pathogenic,
+        ) {
             (true, true, _) => "trans+P",
             (true, _, true) => "trans+LP",
             (false, true, _) => "unphased+P",
@@ -623,10 +649,7 @@ fn mk_pm3(
 
 /// PM4: Protein length changes due to in-frame deletions/insertions in non-repeat region,
 /// or stop-loss variants.
-fn evaluate_pm4(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm4(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let is_length_change = input.consequences.iter().any(|c| {
         matches!(
             c,
@@ -675,10 +698,7 @@ fn evaluate_pm4(
 ///
 /// Uses the ClinVar protein-position index to check if pathogenic variants
 /// with a DIFFERENT amino acid change exist at the same protein position.
-fn evaluate_pm5(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm5(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let is_missense = input
         .consequences
         .iter()
@@ -740,7 +760,10 @@ fn evaluate_pm5(
         );
 
         if !different_aa_matches.is_empty() {
-            let other_aas: Vec<&str> = different_aa_matches.iter().map(|v| v.alt_aa.as_str()).collect();
+            let other_aas: Vec<&str> = different_aa_matches
+                .iter()
+                .map(|v| v.alt_aa.as_str())
+                .collect();
             details.insert("other_pathogenic_aas".into(), serde_json::json!(other_aas));
 
             return EvidenceCriterion {
@@ -788,10 +811,7 @@ fn evaluate_pm5(
 /// Fires when the proband carries the variant and only partial parental data is available
 /// (one parent specified or one parent fails quality), and the available parent(s) are hom_ref.
 /// PS2 and PM6 are mutually exclusive: if full trio data passes quality, PS2 takes priority.
-fn evaluate_pm6(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pm6(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     let trio = match &config.trio {
@@ -804,7 +824,9 @@ fn evaluate_pm6(
                 default_strength: EvidenceStrength::Moderate,
                 met: false,
                 evaluated: false,
-                summary: "Requires trio VCF with at least one parent to assess assumed de novo status".to_string(),
+                summary:
+                    "Requires trio VCF with at least one parent to assess assumed de novo status"
+                        .to_string(),
                 details: serde_json::Value::Null,
             };
         }
@@ -818,9 +840,20 @@ fn evaluate_pm6(
     let min_gq = trio.min_gq;
 
     if both_parents_configured && both_parents_present {
-        let mother_qc = input.mother_genotype.as_ref().unwrap().passes_quality(min_dp, min_gq);
-        let father_qc = input.father_genotype.as_ref().unwrap().passes_quality(min_dp, min_gq);
-        let proband_qc = input.proband_genotype.as_ref().is_some_and(|g| g.passes_quality(min_dp, min_gq));
+        let mother_qc = input
+            .mother_genotype
+            .as_ref()
+            .unwrap()
+            .passes_quality(min_dp, min_gq);
+        let father_qc = input
+            .father_genotype
+            .as_ref()
+            .unwrap()
+            .passes_quality(min_dp, min_gq);
+        let proband_qc = input
+            .proband_genotype
+            .as_ref()
+            .is_some_and(|g| g.passes_quality(min_dp, min_gq));
         if mother_qc && father_qc && proband_qc {
             // Full trio with good quality: PS2 applies instead
             return EvidenceCriterion {
@@ -830,7 +863,9 @@ fn evaluate_pm6(
                 default_strength: EvidenceStrength::Moderate,
                 met: false,
                 evaluated: true,
-                summary: "Both parents available with sufficient quality; PS2 applies instead of PM6".to_string(),
+                summary:
+                    "Both parents available with sufficient quality; PS2 applies instead of PM6"
+                        .to_string(),
                 details: serde_json::Value::Null,
             };
         }
@@ -874,7 +909,10 @@ fn evaluate_pm6(
     if let Some(ref mother_gt) = input.mother_genotype {
         if mother_gt.passes_quality(min_dp, min_gq) {
             available_parents_count += 1;
-            details.insert("mother_hom_ref".into(), serde_json::json!(mother_gt.is_hom_ref));
+            details.insert(
+                "mother_hom_ref".into(),
+                serde_json::json!(mother_gt.is_hom_ref),
+            );
             if mother_gt.is_hom_ref {
                 available_parents_ref += 1;
             }
@@ -886,7 +924,10 @@ fn evaluate_pm6(
     if let Some(ref father_gt) = input.father_genotype {
         if father_gt.passes_quality(min_dp, min_gq) {
             available_parents_count += 1;
-            details.insert("father_hom_ref".into(), serde_json::json!(father_gt.is_hom_ref));
+            details.insert(
+                "father_hom_ref".into(),
+                serde_json::json!(father_gt.is_hom_ref),
+            );
             if father_gt.is_hom_ref {
                 available_parents_ref += 1;
             }
@@ -895,8 +936,14 @@ fn evaluate_pm6(
         }
     }
 
-    details.insert("available_parents_passing_qc".into(), serde_json::json!(available_parents_count));
-    details.insert("available_parents_hom_ref".into(), serde_json::json!(available_parents_ref));
+    details.insert(
+        "available_parents_passing_qc".into(),
+        serde_json::json!(available_parents_count),
+    );
+    details.insert(
+        "available_parents_hom_ref".into(),
+        serde_json::json!(available_parents_ref),
+    );
 
     if available_parents_count == 0 {
         return EvidenceCriterion {
@@ -920,7 +967,8 @@ fn evaluate_pm6(
     } else {
         format!(
             "Not assumed de novo: {} of {} available parent(s) carry the variant",
-            available_parents_count - available_parents_ref, available_parents_count
+            available_parents_count - available_parents_ref,
+            available_parents_count
         )
     };
 
@@ -939,8 +987,8 @@ fn evaluate_pm6(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::{ClinvarData, GnomadData, OmimData};
+    use crate::test_support::minimal_input;
     use fastvep_core::Impact;
 
     fn make_input(
@@ -1130,7 +1178,10 @@ mod tests {
     fn test_pm2_strict_absence_remains_available() {
         // The literal Richards 2015 reading stays one config line away, for a
         // lab that wants it.
-        let strict = AcmgConfig { pm2_ad_af_threshold: 0.0, ..Default::default() };
+        let strict = AcmgConfig {
+            pm2_ad_af_threshold: 0.0,
+            ..Default::default()
+        };
         assert!(!evaluate_pm2(&dominant_at(0.000005, 1), &strict).met);
         assert!(evaluate_pm2(&dominant_at(0.0, 0), &strict).met);
     }
@@ -1372,7 +1423,7 @@ mod tests {
             clinvar_protein: Some(ClinvarProteinData {
                 protein_variants: neighbours,
                 benign_indexed: true,
-            ..Default::default()
+                ..Default::default()
             }),
             ..minimal_input()
         }
@@ -1410,7 +1461,9 @@ mod tests {
         let mut input = hotspot_missense("BRCA1");
         input.omim = Some(OmimData {
             mim_number: Some(0),
-            phenotypes: Some(vec!["hereditary breast cancer (ClinGen Definitive/AD)".into()]),
+            phenotypes: Some(vec![
+                "hereditary breast cancer (ClinGen Definitive/AD)".into()
+            ]),
         });
         assert!(evaluate_pm1(&input, &AcmgConfig::default()).met);
     }
@@ -1433,7 +1486,11 @@ mod tests {
                 pos: 100 + i,
                 ref_aa: "A".into(),
                 alt_aa: "G".into(),
-                sig: if i % 2 == 0 { "Benign".into() } else { "Likely_benign".into() },
+                sig: if i % 2 == 0 {
+                    "Benign".into()
+                } else {
+                    "Likely_benign".into()
+                },
                 n: 1,
             });
         }
@@ -1449,7 +1506,11 @@ mod tests {
         let r = evaluate_pm1(&input, &AcmgConfig::default());
         assert!(!r.met);
         assert!(r.evaluated, "declined on the evidence, not for lack of it");
-        assert!(r.summary.contains("without benign variation"), "got: {}", r.summary);
+        assert!(
+            r.summary.contains("without benign variation"),
+            "got: {}",
+            r.summary
+        );
     }
 
     #[test]

--- a/crates/fastvep-classification/src/criteria/pathogenic_strong.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_strong.rs
@@ -3,10 +3,7 @@ use crate::sa_extract::ClassificationInput;
 use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 
 /// Evaluate all pathogenic strong criteria: PS1, PS2, PS3, PS4.
-pub fn evaluate_all(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Vec<EvidenceCriterion> {
+pub fn evaluate_all(input: &ClassificationInput, config: &AcmgConfig) -> Vec<EvidenceCriterion> {
     vec![
         evaluate_ps1(input, config),
         evaluate_ps2(input, config),
@@ -47,10 +44,7 @@ pub fn evaluate_all(
 /// counting: the subgroup's response to feedback (22 March 2024, item 7b) reads
 /// "if there is a relevant pathogenic variant with the same predicted impact as
 /// the variant under assessment, then you can use PS1 as well as PVS1(RNA)".
-fn evaluate_ps1(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_ps1(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let is_missense = input
         .consequences
         .iter()
@@ -161,7 +155,11 @@ fn evaluate_ps1(
         let matches: Vec<&crate::sa_extract::ClinvarProteinVariant> = cpd
             .protein_variants
             .iter()
-            .filter(|v| v.pos == prot_pos && v.alt_aa == alt_aa && v.sig.to_lowercase().contains("pathogenic"))
+            .filter(|v| {
+                v.pos == prot_pos
+                    && v.alt_aa == alt_aa
+                    && v.sig.to_lowercase().contains("pathogenic")
+            })
             .collect();
 
         // Count distinct *nucleotide* changes, not index entries: the index
@@ -186,7 +184,10 @@ fn evaluate_ps1(
         let required_matches: u32 = if self_in_index { 2 } else { 1 };
         if self_in_index {
             details.insert("self_excluded_from_count".into(), serde_json::json!(true));
-            details.insert("required_matches".into(), serde_json::json!(required_matches));
+            details.insert(
+                "required_matches".into(),
+                serde_json::json!(required_matches),
+            );
         }
 
         if distinct_nucleotide_changes >= required_matches {
@@ -238,10 +239,7 @@ fn evaluate_ps1(
 ///
 /// Requires trio VCF with both parents. Proband carries the variant, both parents are
 /// homozygous reference, and all three pass depth/quality thresholds.
-fn evaluate_ps2(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_ps2(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     let trio = match &config.trio {
@@ -326,9 +324,18 @@ fn evaluate_ps2(
     let min_gq = trio.min_gq;
     details.insert("min_depth".into(), serde_json::json!(min_dp));
     details.insert("min_gq".into(), serde_json::json!(min_gq));
-    details.insert("proband_carries_variant".into(), serde_json::json!(proband_gt.carries_variant()));
-    details.insert("mother_hom_ref".into(), serde_json::json!(mother_gt.is_hom_ref));
-    details.insert("father_hom_ref".into(), serde_json::json!(father_gt.is_hom_ref));
+    details.insert(
+        "proband_carries_variant".into(),
+        serde_json::json!(proband_gt.carries_variant()),
+    );
+    details.insert(
+        "mother_hom_ref".into(),
+        serde_json::json!(mother_gt.is_hom_ref),
+    );
+    details.insert(
+        "father_hom_ref".into(),
+        serde_json::json!(father_gt.is_hom_ref),
+    );
     details.insert("proband_depth".into(), serde_json::json!(proband_gt.depth));
     details.insert("mother_depth".into(), serde_json::json!(mother_gt.depth));
     details.insert("father_depth".into(), serde_json::json!(father_gt.depth));
@@ -358,9 +365,15 @@ fn evaluate_ps2(
 
     if !proband_qc || !mother_qc || !father_qc {
         let mut fail_reasons = Vec::new();
-        if !proband_qc { fail_reasons.push("proband"); }
-        if !mother_qc { fail_reasons.push("mother"); }
-        if !father_qc { fail_reasons.push("father"); }
+        if !proband_qc {
+            fail_reasons.push("proband");
+        }
+        if !mother_qc {
+            fail_reasons.push("mother");
+        }
+        if !father_qc {
+            fail_reasons.push("father");
+        }
         return EvidenceCriterion {
             code: "PS2".to_string(),
             direction: EvidenceDirection::Pathogenic,
@@ -370,7 +383,9 @@ fn evaluate_ps2(
             evaluated: true,
             summary: format!(
                 "Genotype quality insufficient for {}: requires DP>={} and GQ>={}",
-                fail_reasons.join(", "), min_dp, min_gq
+                fail_reasons.join(", "),
+                min_dp,
+                min_gq
             ),
             details: serde_json::Value::Object(details),
         };
@@ -383,8 +398,12 @@ fn evaluate_ps2(
         "De novo variant: proband carries variant, both parents homozygous reference, all pass quality thresholds".to_string()
     } else {
         let mut reasons = Vec::new();
-        if !mother_ref { reasons.push("mother is not hom_ref"); }
-        if !father_ref { reasons.push("father is not hom_ref"); }
+        if !mother_ref {
+            reasons.push("mother is not hom_ref");
+        }
+        if !father_ref {
+            reasons.push("father is not hom_ref");
+        }
         format!("Not de novo: {}", reasons.join(", "))
     };
 
@@ -407,10 +426,7 @@ fn evaluate_ps2(
 /// curated `--functional-evidence` file. Without one, PS3 stays NotEvaluated.
 /// See [`crate::functional`] for the file format and for why an entry also
 /// suppresses the computational criteria.
-fn evaluate_ps3(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_ps3(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     super::functional_criterion(
         input,
         crate::functional::FunctionalCriterion::Ps3,
@@ -433,10 +449,7 @@ fn evaluate_ps3(
 /// Set `config.use_clinvar_stars_as_ps4_proxy = true` to opt back into
 /// the old proxy behavior — primarily for benchmarks against historical
 /// fastVEP runs.
-fn evaluate_ps4(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_ps4(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
 
     if !config.use_clinvar_stars_as_ps4_proxy {
@@ -453,7 +466,9 @@ fn evaluate_ps4(
             default_strength: EvidenceStrength::Strong,
             met: false,
             evaluated: false,
-            summary: "PS4 requires case-control statistics; not automatable from variant-level data".to_string(),
+            summary:
+                "PS4 requires case-control statistics; not automatable from variant-level data"
+                    .to_string(),
             details: serde_json::Value::Object(details),
         };
     }
@@ -461,7 +476,10 @@ fn evaluate_ps4(
     let (met, summary) = if let Some(ref clinvar) = input.clinvar {
         let stars = clinvar.review_stars();
         let is_pathogenic = clinvar.has_pathogenic();
-        details.insert("clinvar_pathogenic".into(), serde_json::json!(is_pathogenic));
+        details.insert(
+            "clinvar_pathogenic".into(),
+            serde_json::json!(is_pathogenic),
+        );
         details.insert("review_stars".into(), serde_json::json!(stars));
 
         if is_pathogenic && stars >= 3 {
@@ -501,8 +519,8 @@ fn evaluate_ps4(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::ClinvarData;
+    use crate::test_support::minimal_input;
     use fastvep_core::{Consequence, Impact};
 
     fn make_input(clinvar: Option<ClinvarData>) -> ClassificationInput {

--- a/crates/fastvep-classification/src/criteria/pathogenic_supporting.rs
+++ b/crates/fastvep-classification/src/criteria/pathogenic_supporting.rs
@@ -5,10 +5,7 @@ use crate::sa_extract::ClassificationInput;
 use crate::types::{EvidenceCriterion, EvidenceDirection, EvidenceStrength};
 
 /// Evaluate all pathogenic supporting criteria: PP1, PP2, PP3, PP4, PP5.
-pub fn evaluate_all(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> Vec<EvidenceCriterion> {
+pub fn evaluate_all(input: &ClassificationInput, config: &AcmgConfig) -> Vec<EvidenceCriterion> {
     let mut criteria = vec![
         evaluate_pp1(input, config),
         evaluate_pp2(input, config),
@@ -22,10 +19,7 @@ pub fn evaluate_all(
 }
 
 /// PP1: Co-segregation with disease in multiple affected family members.
-fn evaluate_pp1(
-    _input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pp1(_input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     EvidenceCriterion {
         code: "PP1".to_string(),
         direction: EvidenceDirection::Pathogenic,
@@ -33,17 +27,16 @@ fn evaluate_pp1(
         default_strength: EvidenceStrength::Supporting,
         met: false,
         evaluated: false,
-        summary: "Requires multi-generation pedigree with affection status to assess co-segregation".to_string(),
+        summary:
+            "Requires multi-generation pedigree with affection status to assess co-segregation"
+                .to_string(),
         details: serde_json::Value::Null,
     }
 }
 
 /// PP2: Missense variant in a gene that has a low rate of benign missense variation
 /// and in which missense variants are a common mechanism of disease.
-fn evaluate_pp2(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pp2(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let is_missense = input
         .consequences
         .iter()
@@ -126,10 +119,7 @@ fn evaluate_pp2(
 /// PP3 at *Supporting* strength only. SpliceAI alone does not reach Strong;
 /// experimental RNA evidence (PVS1_RNA / PS3) is required for Strong splicing
 /// claims.
-fn evaluate_pp3(
-    input: &ClassificationInput,
-    config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pp3(input: &ClassificationInput, config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
     let mut evidence_lines: Vec<String> = Vec::new();
 
@@ -296,10 +286,7 @@ fn evaluate_pp3(
 
 /// PP4: Patient's phenotype or family history is highly specific for a disease
 /// with a single genetic etiology.
-fn evaluate_pp4(
-    _input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pp4(_input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     EvidenceCriterion {
         code: "PP4".to_string(),
         direction: EvidenceDirection::Pathogenic,
@@ -307,7 +294,8 @@ fn evaluate_pp4(
         default_strength: EvidenceStrength::Supporting,
         met: false,
         evaluated: false,
-        summary: "Requires patient HPO phenotype terms matched to disease-gene associations".to_string(),
+        summary: "Requires patient HPO phenotype terms matched to disease-gene associations"
+            .to_string(),
         details: serde_json::Value::Null,
     }
 }
@@ -316,20 +304,22 @@ fn evaluate_pp4(
 ///
 /// Note: ClinGen SVI recommends against using PP5 without reviewing underlying evidence.
 /// Disabled by default (config.use_pp5_bp6 = false).
-fn evaluate_pp5(
-    input: &ClassificationInput,
-    _config: &AcmgConfig,
-) -> EvidenceCriterion {
+fn evaluate_pp5(input: &ClassificationInput, _config: &AcmgConfig) -> EvidenceCriterion {
     let mut details = serde_json::Map::new();
     details.insert(
         "svi_note".into(),
-        serde_json::json!("ClinGen SVI recommends against using PP5 without reviewing underlying evidence"),
+        serde_json::json!(
+            "ClinGen SVI recommends against using PP5 without reviewing underlying evidence"
+        ),
     );
 
     let (met, evaluated, summary) = if let Some(ref clinvar) = input.clinvar {
         let stars = clinvar.review_stars();
         let is_pathogenic = clinvar.has_pathogenic();
-        details.insert("clinvar_pathogenic".into(), serde_json::json!(is_pathogenic));
+        details.insert(
+            "clinvar_pathogenic".into(),
+            serde_json::json!(is_pathogenic),
+        );
         details.insert("review_stars".into(), serde_json::json!(stars));
 
         if is_pathogenic && stars >= 2 {
@@ -345,7 +335,10 @@ fn evaluate_pp5(
             (
                 false,
                 true,
-                format!("ClinVar not pathogenic or insufficient review ({} stars)", stars),
+                format!(
+                    "ClinVar not pathogenic or insufficient review ({} stars)",
+                    stars
+                ),
             )
         }
     } else {
@@ -367,17 +360,15 @@ fn evaluate_pp5(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sa_extract::{GnomadGeneData, OmimData, RevelData, SpliceAiData};
     use crate::test_support::minimal_input;
-    use crate::sa_extract::{GnomadGeneData, RevelData, OmimData, SpliceAiData};
     use fastvep_core::Impact;
 
     fn make_input_with_revel(score: f64) -> ClassificationInput {
         ClassificationInput {
             consequences: vec![Consequence::MissenseVariant],
             impact: Impact::Moderate,
-            revel: Some(RevelData {
-                score: Some(score),
-            }),
+            revel: Some(RevelData { score: Some(score) }),
             ..minimal_input()
         }
     }
@@ -396,7 +387,10 @@ mod tests {
         assert!(result.met);
         assert_eq!(result.strength, EvidenceStrength::Moderate);
         assert_eq!(
-            result.details.get("pp3_strength_capped_from").and_then(|v| v.as_str()),
+            result
+                .details
+                .get("pp3_strength_capped_from")
+                .and_then(|v| v.as_str()),
             Some("Strong")
         );
     }
@@ -595,7 +589,9 @@ mod tests {
         let mut input = constrained_missense("BRCA1");
         input.omim = Some(OmimData {
             mim_number: Some(0),
-            phenotypes: Some(vec!["hereditary breast cancer (ClinGen Definitive/AD)".into()]),
+            phenotypes: Some(vec![
+                "hereditary breast cancer (ClinGen Definitive/AD)".into()
+            ]),
         });
         assert!(evaluate_pp2(&input, &AcmgConfig::default()).met);
     }

--- a/crates/fastvep-classification/src/criteria/pvs1.rs
+++ b/crates/fastvep-classification/src/criteria/pvs1.rs
@@ -99,7 +99,10 @@ pub fn evaluate_pvs1(input: &ClassificationInput, config: &AcmgConfig) -> Eviden
             EvidenceStrength::VeryStrong,
             false,
             true,
-            format!("Null variant but gene {} is not established as LOF-intolerant", gene),
+            format!(
+                "Null variant but gene {} is not established as LOF-intolerant",
+                gene
+            ),
             details,
         );
     }
@@ -202,7 +205,10 @@ pub fn evaluate_pvs1(input: &ClassificationInput, config: &AcmgConfig) -> Eviden
                             EvidenceStrength::VeryStrong,
                             false,
                             true,
-                            format!("PVS1 splice track not applicable: {} (defer to PP3/BP4)", reason),
+                            format!(
+                                "PVS1 splice track not applicable: {} (defer to PP3/BP4)",
+                                reason
+                            ),
                             details,
                         );
                     }
@@ -427,7 +433,10 @@ fn grade_start_lost(
         // silently abs() it (which would let upstream / invalid distances
         // qualify the variant for PVS1_Moderate or _Supporting).
         if d < 0 {
-            details.insert("alt_start_codon_distance_invalid".into(), serde_json::json!(true));
+            details.insert(
+                "alt_start_codon_distance_invalid".into(),
+                serde_json::json!(true),
+            );
         } else {
             let d_codons = d as u64;
             // Note the field is being borrowed for a different question here.
@@ -514,11 +523,7 @@ fn is_lof_intolerant_gene(input: &ClassificationInput, config: &AcmgConfig) -> b
     // Validity (preferred — Strong/Definitive/Moderate only) or OMIM
     // `genemap2.txt` (legacy). Both share the `omim` json_key.
     if let Some(ref omim) = input.omim {
-        if omim
-            .phenotypes
-            .as_ref()
-            .is_some_and(|p| !p.is_empty())
-        {
+        if omim.phenotypes.as_ref().is_some_and(|p| !p.is_empty()) {
             return true;
         }
     }
@@ -529,11 +534,15 @@ fn is_lof_intolerant_gene(input: &ClassificationInput, config: &AcmgConfig) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::{GnomadGeneData, OmimData, SpliceAiData};
+    use crate::test_support::minimal_input;
     use fastvep_core::Impact;
 
-    fn make_input(consequences: Vec<Consequence>, gene_constraints: Option<GnomadGeneData>, omim: Option<OmimData>) -> ClassificationInput {
+    fn make_input(
+        consequences: Vec<Consequence>,
+        gene_constraints: Option<GnomadGeneData>,
+        omim: Option<OmimData>,
+    ) -> ClassificationInput {
         ClassificationInput {
             consequences,
             impact: Impact::High,
@@ -548,7 +557,11 @@ mod tests {
     fn test_pvs1_frameshift_lof_gene() {
         let input = make_input(
             vec![Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         let result = evaluate_pvs1(&input, &AcmgConfig::default());
@@ -561,7 +574,11 @@ mod tests {
     fn test_pvs1_missense_not_null() {
         let input = make_input(
             vec![Consequence::MissenseVariant],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         let result = evaluate_pvs1(&input, &AcmgConfig::default());
@@ -580,7 +597,10 @@ mod tests {
         let input = make_input(
             vec![Consequence::StopGained],
             None,
-            Some(OmimData { mim_number: Some(113705), phenotypes: Some(vec!["Breast cancer".to_string()]) }),
+            Some(OmimData {
+                mim_number: Some(113705),
+                phenotypes: Some(vec!["Breast cancer".to_string()]),
+            }),
         );
         let result = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(result.met); // OMIM disease association is proxy for LOF gene
@@ -593,7 +613,11 @@ mod tests {
         // must not fire — splicing signal is left to SpliceAI/PP3.
         let mut input = make_input(
             vec![Consequence::SpliceDonorVariant],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         input.intronic_offset = Some(12);
@@ -607,7 +631,11 @@ mod tests {
         // Canonical ±1/2 splice (offset = -2) keeps PVS1.
         let mut input = make_input(
             vec![Consequence::SpliceAcceptorVariant],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         input.intronic_offset = Some(-2);
@@ -622,13 +650,23 @@ mod tests {
         // deletion) AND frameshift must keep PVS1 via the frameshift track — the
         // genuine coding LOF must not be discarded by the splice offset gate.
         let mut input = make_input(
-            vec![Consequence::SpliceDonorVariant, Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            vec![
+                Consequence::SpliceDonorVariant,
+                Consequence::FrameshiftVariant,
+            ],
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         input.intronic_offset = Some(7); // outside canonical ±1/±2
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
-        assert!(r.met, "frameshift LOF should keep PVS1 despite deep splice offset");
+        assert!(
+            r.met,
+            "frameshift LOF should keep PVS1 despite deep splice offset"
+        );
         // No NMD/grading signals → frameshift legacy fallback → Very Strong.
         assert_eq!(r.strength, EvidenceStrength::VeryStrong);
     }
@@ -639,7 +677,11 @@ mod tests {
         // it downgrades to PVS1_Moderate instead of the legacy Very Strong.
         let mut input = make_input(
             vec![Consequence::StopGained],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(false);
@@ -656,7 +698,11 @@ mod tests {
     fn test_pvs1_nonsense_nmd_predicted_full_strength() {
         let mut input = make_input(
             vec![Consequence::StopGained],
-            Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                loeuf: Some(0.03),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(true);
@@ -670,7 +716,10 @@ mod tests {
     fn test_pvs1_nmd_escape_critical_region_strong() {
         let mut input = make_input(
             vec![Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(false);
@@ -685,7 +734,10 @@ mod tests {
     fn test_pvs1_nmd_escape_noncritical_large_truncation_moderate() {
         let mut input = make_input(
             vec![Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(false);
@@ -700,7 +752,10 @@ mod tests {
     fn test_pvs1_nmd_escape_noncritical_small_truncation_supporting() {
         let mut input = make_input(
             vec![Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(false);
@@ -715,7 +770,10 @@ mod tests {
     fn test_pvs1_canonical_splice_last_exon_moderate() {
         let mut input = make_input(
             vec![Consequence::SpliceDonorVariant],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         input.predicted_nmd = Some(false);
@@ -729,7 +787,10 @@ mod tests {
     fn test_pvs1_start_lost_no_signals_supporting() {
         let input = make_input(
             vec![Consequence::StartLost],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
@@ -742,7 +803,10 @@ mod tests {
     fn test_pvs1_start_lost_alt_start_with_pathogenic_upstream_moderate() {
         let mut input = make_input(
             vec![Consequence::StartLost],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         input.alt_start_codon_distance = Some(50);
@@ -757,7 +821,10 @@ mod tests {
         // No predicted_nmd → falls back to legacy full PVS1.
         let input = make_input(
             vec![Consequence::FrameshiftVariant],
-            Some(GnomadGeneData { pli: Some(1.0), ..Default::default() }),
+            Some(GnomadGeneData {
+                pli: Some(1.0),
+                ..Default::default()
+            }),
             None,
         );
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
@@ -767,7 +834,11 @@ mod tests {
     }
 
     fn lof_gene() -> Option<GnomadGeneData> {
-        Some(GnomadGeneData { pli: Some(1.0), loeuf: Some(0.03), ..Default::default() })
+        Some(GnomadGeneData {
+            pli: Some(1.0),
+            loeuf: Some(0.03),
+            ..Default::default()
+        })
     }
 
     #[test]
@@ -778,7 +849,10 @@ mod tests {
         // ambiguous alignment. ATM GTAATC>G (SpliceAI 0.00) is ClinVar
         // likely-benign and was collecting PVS1 this way.
         let mut input = make_input(vec![Consequence::SpliceDonorVariant], lof_gene(), None);
-        input.splice_ai = Some(SpliceAiData { ds_dl: Some(0.0), ..Default::default() });
+        input.splice_ai = Some(SpliceAiData {
+            ds_dl: Some(0.0),
+            ..Default::default()
+        });
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(!r.met);
         assert!(r.summary.contains("contradicts"));
@@ -787,7 +861,10 @@ mod tests {
     #[test]
     fn test_pvs1_splice_kept_when_spliceai_supports() {
         let mut input = make_input(vec![Consequence::SpliceDonorVariant], lof_gene(), None);
-        input.splice_ai = Some(SpliceAiData { ds_dl: Some(0.95), ..Default::default() });
+        input.splice_ai = Some(SpliceAiData {
+            ds_dl: Some(0.95),
+            ..Default::default()
+        });
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(r.met);
     }
@@ -808,7 +885,10 @@ mod tests {
     fn test_pvs1_splice_insertion_kept_with_spliceai_support() {
         let mut input = make_input(vec![Consequence::SpliceAcceptorVariant], lof_gene(), None);
         input.is_pure_insertion = Some(true);
-        input.splice_ai = Some(SpliceAiData { ds_al: Some(0.99), ..Default::default() });
+        input.splice_ai = Some(SpliceAiData {
+            ds_al: Some(0.99),
+            ..Default::default()
+        });
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(r.met);
     }
@@ -818,11 +898,17 @@ mod tests {
         // An indel that both overlaps the splice site and deletes coding
         // sequence still carries PVS1 through the frameshift track.
         let mut input = make_input(
-            vec![Consequence::SpliceDonorVariant, Consequence::FrameshiftVariant],
+            vec![
+                Consequence::SpliceDonorVariant,
+                Consequence::FrameshiftVariant,
+            ],
             lof_gene(),
             None,
         );
-        input.splice_ai = Some(SpliceAiData { ds_dl: Some(0.0), ..Default::default() });
+        input.splice_ai = Some(SpliceAiData {
+            ds_dl: Some(0.0),
+            ..Default::default()
+        });
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(r.met, "coding-null track should still carry PVS1");
     }
@@ -848,7 +934,10 @@ mod tests {
         }); // ClinGen curated it and found nothing
         let r = evaluate_pvs1(&input, &AcmgConfig::default());
         assert!(!r.met);
-        assert!(!r.evaluated, "unknown gene-disease validity is not an assessment");
+        assert!(
+            !r.evaluated,
+            "unknown gene-disease validity is not an assessment"
+        );
         assert!(
             r.summary.contains("no_valid_gene_disease_relationship"),
             "got: {}",
@@ -870,11 +959,12 @@ mod tests {
         let mut input = constrained_frameshift("BRCA1");
         input.omim = Some(OmimData {
             mim_number: Some(0),
-            phenotypes: Some(vec!["hereditary breast cancer (ClinGen Definitive/AD)".into()]),
+            phenotypes: Some(vec![
+                "hereditary breast cancer (ClinGen Definitive/AD)".into()
+            ]),
         });
         assert!(evaluate_pvs1(&input, &AcmgConfig::default()).met);
     }
-
 
     #[test]
     fn test_pvs1_survives_for_a_gene_clingen_has_not_curated() {
@@ -951,9 +1041,15 @@ mod tests {
 
     #[test]
     fn test_50nt_rule_on_grades_the_escape_down() {
-        let config = AcmgConfig { pvs1_nmd_50nt_rule: true, ..Default::default() };
+        let config = AcmgConfig {
+            pvs1_nmd_50nt_rule: true,
+            ..Default::default()
+        };
         let r = evaluate_pvs1(&penultimate_exon_escape(), &config);
-        assert_eq!(r.code, "PVS1_Strong", "Abou Tayoun: NMD escape in a critical region");
+        assert_eq!(
+            r.code, "PVS1_Strong",
+            "Abou Tayoun: NMD escape in a critical region"
+        );
         assert_eq!(r.strength, EvidenceStrength::Strong);
     }
 
@@ -963,8 +1059,14 @@ mod tests {
         // absent and the proxy must still answer.
         let mut input = penultimate_exon_escape();
         input.nmd_escape_50nt = None;
-        let config = AcmgConfig { pvs1_nmd_50nt_rule: true, ..Default::default() };
-        assert_eq!(evaluate_pvs1(&input, &config).strength, EvidenceStrength::VeryStrong);
+        let config = AcmgConfig {
+            pvs1_nmd_50nt_rule: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            evaluate_pvs1(&input, &config).strength,
+            EvidenceStrength::VeryStrong
+        );
     }
 
     #[test]
@@ -976,7 +1078,10 @@ mod tests {
         input.predicted_nmd = Some(true);
         input.nmd_escape_50nt = Some(false);
         for on in [false, true] {
-            let config = AcmgConfig { pvs1_nmd_50nt_rule: on, ..Default::default() };
+            let config = AcmgConfig {
+                pvs1_nmd_50nt_rule: on,
+                ..Default::default()
+            };
             let r = evaluate_pvs1(&input, &config);
             assert_eq!(r.code, "PVS1", "flag={on}");
         }
@@ -984,7 +1089,10 @@ mod tests {
 
     #[test]
     fn test_mechanism_gate_can_be_switched_off() {
-        let config = AcmgConfig { mechanism_gates_pvs1: false, ..Default::default() };
+        let config = AcmgConfig {
+            mechanism_gates_pvs1: false,
+            ..Default::default()
+        };
         assert!(evaluate_pvs1(&constrained_frameshift("PCSK9"), &config).met);
     }
 }

--- a/crates/fastvep-classification/src/functional.rs
+++ b/crates/fastvep-classification/src/functional.rs
@@ -134,9 +134,9 @@ impl FunctionalEvidenceIndex {
                 ));
             }
 
-            let pos: u64 = at(1)
-                .parse()
-                .map_err(|_| format!("line {}: position {:?} is not a number", lineno + 1, at(1)))?;
+            let pos: u64 = at(1).parse().map_err(|_| {
+                format!("line {}: position {:?} is not a number", lineno + 1, at(1))
+            })?;
 
             let criterion = match at(4).to_ascii_uppercase().as_str() {
                 "PS3" => FunctionalCriterion::Ps3,
@@ -226,7 +226,13 @@ impl FunctionalEvidenceIndex {
     }
 
     /// Look up one variant. `chrom` may carry a `chr` prefix or not.
-    pub fn get(&self, chrom: &str, pos: u64, reference: &str, alt: &str) -> Option<&FunctionalEvidence> {
+    pub fn get(
+        &self,
+        chrom: &str,
+        pos: u64,
+        reference: &str,
+        alt: &str,
+    ) -> Option<&FunctionalEvidence> {
         self.entries.get(&(
             normalize_chrom(chrom),
             pos,
@@ -284,8 +290,14 @@ mod tests {
     #[test]
     fn test_strength_defaults_to_strong_and_is_optional() {
         let idx = parse("1\t10\tA\tT\tPS3\n1\t20\tA\tT\tBS3\t.\n").unwrap();
-        assert_eq!(idx.get("1", 10, "A", "T").unwrap().strength, EvidenceStrength::Strong);
-        assert_eq!(idx.get("1", 20, "A", "T").unwrap().strength, EvidenceStrength::Strong);
+        assert_eq!(
+            idx.get("1", 10, "A", "T").unwrap().strength,
+            EvidenceStrength::Strong
+        );
+        assert_eq!(
+            idx.get("1", 20, "A", "T").unwrap().strength,
+            EvidenceStrength::Strong
+        );
     }
 
     #[test]
@@ -293,7 +305,10 @@ mod tests {
         // Brnich 2020: assay strength is a judgement about the assay, so a
         // curator must be able to say Supporting.
         let idx = parse("1\t10\tA\tT\tPS3\tModerate\n").unwrap();
-        assert_eq!(idx.get("1", 10, "A", "T").unwrap().strength, EvidenceStrength::Moderate);
+        assert_eq!(
+            idx.get("1", 10, "A", "T").unwrap().strength,
+            EvidenceStrength::Moderate
+        );
     }
 
     #[test]
@@ -305,7 +320,10 @@ mod tests {
             ("1\t10\tA\tT\tPS3\tVeryWeak\n", "unknown strength"),
         ] {
             let err = parse(bad).expect_err("must reject");
-            assert!(err.contains(expect), "{bad:?} gave {err:?}, wanted {expect:?}");
+            assert!(
+                err.contains(expect),
+                "{bad:?} gave {err:?}, wanted {expect:?}"
+            );
         }
     }
 

--- a/crates/fastvep-classification/src/lib.rs
+++ b/crates/fastvep-classification/src/lib.rs
@@ -55,8 +55,8 @@ pub fn classify(input: &ClassificationInput, config: &AcmgConfig) -> AcmgResult 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::minimal_input;
     use crate::sa_extract::*;
+    use crate::test_support::minimal_input;
     use fastvep_core::{Consequence, Impact};
 
     /// Helper to build a ClassificationInput with common defaults.
@@ -75,11 +75,7 @@ mod tests {
 
     #[test]
     fn test_classify_common_variant_benign() {
-        let mut input = make_input(
-            vec![Consequence::MissenseVariant],
-            Impact::Moderate,
-            "TEST",
-        );
+        let mut input = make_input(vec![Consequence::MissenseVariant], Impact::Moderate, "TEST");
         input.gnomad = Some(GnomadData {
             all_af: Some(0.10),
             afr_af: Some(0.15),
@@ -93,17 +89,19 @@ mod tests {
         // own. The rule string names the arithmetic under the point system and
         // the rule id under the table, so assert on the evidence instead.
         assert!(result.criteria.iter().any(|c| c.code == "BA1" && c.met));
-        let table = AcmgConfig { use_point_system: false, ..Default::default() };
-        assert_eq!(classify(&input, &table).triggered_rule.as_deref(), Some("BA1"));
+        let table = AcmgConfig {
+            use_point_system: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            classify(&input, &table).triggered_rule.as_deref(),
+            Some("BA1")
+        );
     }
 
     #[test]
     fn test_classify_frameshift_lof_gene_likely_pathogenic() {
-        let mut input = make_input(
-            vec![Consequence::FrameshiftVariant],
-            Impact::High,
-            "BRCA1",
-        );
+        let mut input = make_input(vec![Consequence::FrameshiftVariant], Impact::High, "BRCA1");
         // High pLI → PVS1
         input.gene_constraints = Some(GnomadGeneData {
             pli: Some(1.0),
@@ -137,11 +135,7 @@ mod tests {
         // not contribute to non-missense classification. Without other
         // pathogenic-Strong evidence, PVS1 + PM2_Supporting tops out at LP
         // via the ClinGen SVI PVS+PP rule.
-        let mut input = make_input(
-            vec![Consequence::FrameshiftVariant],
-            Impact::High,
-            "BRCA1",
-        );
+        let mut input = make_input(vec![Consequence::FrameshiftVariant], Impact::High, "BRCA1");
         input.gene_constraints = Some(GnomadGeneData {
             pli: Some(1.0),
             loeuf: Some(0.03),
@@ -163,11 +157,7 @@ mod tests {
 
     #[test]
     fn test_classify_synonymous_no_splice_not_conserved() {
-        let mut input = make_input(
-            vec![Consequence::SynonymousVariant],
-            Impact::Low,
-            "TEST",
-        );
+        let mut input = make_input(vec![Consequence::SynonymousVariant], Impact::Low, "TEST");
         input.splice_ai = Some(SpliceAiData {
             ds_ag: Some(0.01),
             ds_al: Some(0.02),
@@ -213,11 +203,7 @@ mod tests {
         // reach a definite call on either side (PVS1 needs PS/PM/PP to fire
         // a pathogenic rule, and BS1 alone is sub-threshold for Benign).
         // Result is plain VUS without a "Conflicting" label.
-        let mut input = make_input(
-            vec![Consequence::FrameshiftVariant],
-            Impact::High,
-            "GENE",
-        );
+        let mut input = make_input(vec![Consequence::FrameshiftVariant], Impact::High, "GENE");
         input.gene_constraints = Some(GnomadGeneData {
             pli: Some(1.0),
             loeuf: Some(0.03),
@@ -244,7 +230,10 @@ mod tests {
 
         // Richards 2015 Table 5: no row matches one Very Strong alone, so the
         // table returns Uncertain Significance.
-        let table = AcmgConfig { use_point_system: false, ..Default::default() };
+        let table = AcmgConfig {
+            use_point_system: false,
+            ..Default::default()
+        };
         let result = classify(&input, &table);
         assert_eq!(
             result.classification,
@@ -264,11 +253,7 @@ mod tests {
 
     #[test]
     fn test_acmg_result_serialization() {
-        let input = make_input(
-            vec![Consequence::MissenseVariant],
-            Impact::Moderate,
-            "TEST",
-        );
+        let input = make_input(vec![Consequence::MissenseVariant], Impact::Moderate, "TEST");
         let result = classify(&input, &AcmgConfig::default());
         let json = serde_json::to_value(&result).unwrap();
 

--- a/crates/fastvep-classification/src/sa_extract.rs
+++ b/crates/fastvep-classification/src/sa_extract.rs
@@ -1,6 +1,6 @@
-use fastvep_core::{GeneAnnotation, SupplementaryAnnotation};
 use fastvep_core::{is_canonical_dinucleotide_offset, parse_intronic_offset};
 use fastvep_core::{Consequence, Impact};
+use fastvep_core::{GeneAnnotation, SupplementaryAnnotation};
 use serde::Deserialize;
 
 /// gnomAD population frequency data.
@@ -80,8 +80,17 @@ impl GnomadData {
     /// gnomAD v2.1 codes (`oth`) and v4.1 codes (`mid`, `remaining`).
     pub fn max_pop_af(&self) -> Option<f64> {
         [
-            self.all_af, self.afr_af, self.nfe_af, self.eas_af, self.amr_af, self.asj_af,
-            self.fin_af, self.mid_af, self.oth_af, self.remaining_af, self.sas_af,
+            self.all_af,
+            self.afr_af,
+            self.nfe_af,
+            self.eas_af,
+            self.amr_af,
+            self.asj_af,
+            self.fin_af,
+            self.mid_af,
+            self.oth_af,
+            self.remaining_af,
+            self.sas_af,
         ]
         .into_iter()
         .flatten()
@@ -252,7 +261,8 @@ impl ClinvarData {
             Some(s) if s.contains("multiple_submitters") || s.contains("multiple submitters") => 2,
             Some(s)
                 if (s.contains("criteria_provided") || s.contains("criteria provided"))
-                    && !s.contains("no_assertion") && !s.contains("no assertion") =>
+                    && !s.contains("no_assertion")
+                    && !s.contains("no assertion") =>
             {
                 1
             }
@@ -321,17 +331,16 @@ impl DbNsfpData {
 
     /// Parse PolyPhen prediction from format "probably_damaging(0.998)".
     pub fn parse_polyphen(&self) -> Option<PredictionResult> {
-        self.polyphen.as_ref().and_then(|s| parse_prediction_string(s))
+        self.polyphen
+            .as_ref()
+            .and_then(|s| parse_prediction_string(s))
     }
 }
 
 fn parse_prediction_string(s: &str) -> Option<PredictionResult> {
     if let Some(paren_pos) = s.find('(') {
         let prediction = s[..paren_pos].to_string();
-        let score = s[paren_pos + 1..]
-            .trim_end_matches(')')
-            .parse::<f64>()
-            .ok();
+        let score = s[paren_pos + 1..].trim_end_matches(')').parse::<f64>().ok();
         Some(PredictionResult { prediction, score })
     } else {
         Some(PredictionResult {
@@ -404,12 +413,14 @@ impl OmimData {
     /// and BS2 both branch on it.
     pub fn has_dominant_inheritance(&self) -> bool {
         self.phenotypes.as_ref().is_some_and(|ps| {
-            ps.iter().filter(|p| !is_weak_clingen_classification(p)).any(|p| {
-                let lower = p.to_lowercase();
-                lower.contains("autosomal dominant")
-                    || lower.contains("{ad}")
-                    || (lower.contains("dominant") && !lower.contains("recessive"))
-            })
+            ps.iter()
+                .filter(|p| !is_weak_clingen_classification(p))
+                .any(|p| {
+                    let lower = p.to_lowercase();
+                    lower.contains("autosomal dominant")
+                        || lower.contains("{ad}")
+                        || (lower.contains("dominant") && !lower.contains("recessive"))
+                })
         })
     }
 
@@ -419,12 +430,14 @@ impl OmimData {
     /// [`Self::has_dominant_inheritance`].
     pub fn has_recessive_inheritance(&self) -> bool {
         self.phenotypes.as_ref().is_some_and(|ps| {
-            ps.iter().filter(|p| !is_weak_clingen_classification(p)).any(|p| {
-                let lower = p.to_lowercase();
-                lower.contains("autosomal recessive")
-                    || lower.contains("{ar}")
-                    || (lower.contains("recessive") && !lower.contains("dominant"))
-            })
+            ps.iter()
+                .filter(|p| !is_weak_clingen_classification(p))
+                .any(|p| {
+                    let lower = p.to_lowercase();
+                    lower.contains("autosomal recessive")
+                        || lower.contains("{ar}")
+                        || (lower.contains("recessive") && !lower.contains("dominant"))
+                })
         })
     }
 }
@@ -1062,7 +1075,7 @@ mod tests {
     fn test_clinvar_conflicting_not_pathogenic() {
         let c = ClinvarData {
             significance: Some(vec![
-                "Conflicting_interpretations_of_pathogenicity".to_string(),
+                "Conflicting_interpretations_of_pathogenicity".to_string()
             ]),
             ..Default::default()
         };
@@ -1223,8 +1236,14 @@ mod tests {
 
     #[test]
     fn test_predicted_nmd_is_the_last_exon_proxy() {
-        assert_eq!(extract(None, None, None, Some((10, 10)), None).predicted_nmd, Some(false));
-        assert_eq!(extract(None, None, None, Some((3, 10)), None).predicted_nmd, Some(true));
+        assert_eq!(
+            extract(None, None, None, Some((10, 10)), None).predicted_nmd,
+            Some(false)
+        );
+        assert_eq!(
+            extract(None, None, None, Some((3, 10)), None).predicted_nmd,
+            Some(true)
+        );
         assert_eq!(extract(None, None, None, None, None).predicted_nmd, None);
     }
 
@@ -1234,8 +1253,14 @@ mod tests {
         let input = extract(Some(91), Some(100), None, None, None);
         assert_eq!(input.protein_truncation_pct, Some(0.10));
         // Out-of-range or absent inputs produce no claim rather than a wrong one.
-        assert_eq!(extract(Some(101), Some(100), None, None, None).protein_truncation_pct, None);
-        assert_eq!(extract(Some(50), None, None, None, None).protein_truncation_pct, None);
+        assert_eq!(
+            extract(Some(101), Some(100), None, None, None).protein_truncation_pct,
+            None
+        );
+        assert_eq!(
+            extract(Some(50), None, None, None, None).protein_truncation_pct,
+            None
+        );
     }
 
     #[test]
@@ -1245,15 +1270,24 @@ mod tests {
             {"pos":100,"refAa":"A","altAa":"T","sig":"Pathogenic","n":2}
         ]}"#;
         // Truncating at 500 loses residue 900, which ClinVar calls pathogenic.
-        assert_eq!(extract(Some(500), None, None, None, Some(idx)).in_critical_region, Some(true));
+        assert_eq!(
+            extract(Some(500), None, None, None, Some(idx)).in_critical_region,
+            Some(true)
+        );
         // Truncating at 950 loses nothing ClinVar has an entry for.
-        assert_eq!(extract(Some(950), None, None, None, Some(idx)).in_critical_region, Some(false));
+        assert_eq!(
+            extract(Some(950), None, None, None, Some(idx)).in_critical_region,
+            Some(false)
+        );
     }
 
     #[test]
     fn test_in_critical_region_is_unknown_without_an_index() {
         // Absence of the .oga must never read as "the lost region is unimportant".
-        assert_eq!(extract(Some(500), None, None, None, None).in_critical_region, None);
+        assert_eq!(
+            extract(Some(500), None, None, None, None).in_critical_region,
+            None
+        );
     }
 
     #[test]
@@ -1261,7 +1295,10 @@ mod tests {
         let idx = r#"{"proteinVariants":[
             {"pos":900,"refAa":"R","altAa":"Q","sig":"Conflicting_interpretations_of_pathogenicity","n":1}
         ]}"#;
-        assert_eq!(extract(Some(500), None, None, None, Some(idx)).in_critical_region, Some(false));
+        assert_eq!(
+            extract(Some(500), None, None, None, Some(idx)).in_critical_region,
+            Some(false)
+        );
     }
 
     // ── PS1 splice path (Walker 2023 Table 3) ────────────────────────────
@@ -1278,7 +1315,13 @@ mod tests {
         }
     }
 
-    fn splice_ps1(index: Option<&GeneAnnotation>, hgvs: Option<&str>, pos: u64, r: &str, a: &str) -> Option<bool> {
+    fn splice_ps1(
+        index: Option<&GeneAnnotation>,
+        hgvs: Option<&str>,
+        pos: u64,
+        r: &str,
+        a: &str,
+    ) -> Option<bool> {
         let anns: Vec<&GeneAnnotation> = index.into_iter().collect();
         same_splice_position_pathogenic(
             &[Consequence::SpliceAcceptorVariant],
@@ -1293,7 +1336,10 @@ mod tests {
     #[test]
     fn test_ps1_splice_fires_on_a_different_allele_at_the_same_position() {
         let idx = splice_index(r#"{"pos":100,"ref":"A","alt":"G","off":-2,"sig":"Pathogenic"}"#);
-        assert_eq!(splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"), Some(true));
+        assert_eq!(
+            splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"),
+            Some(true)
+        );
     }
 
     #[test]
@@ -1302,7 +1348,10 @@ mod tests {
         // Pathogenic finds its own entry. A comparison variant is by
         // definition another variant, and firing off yourself is circular.
         let idx = splice_index(r#"{"pos":100,"ref":"A","alt":"G","off":-2,"sig":"Pathogenic"}"#);
-        assert_eq!(splice_ps1(Some(&idx), Some("c.376-2A>G"), 100, "A", "G"), Some(false));
+        assert_eq!(
+            splice_ps1(Some(&idx), Some("c.376-2A>G"), 100, "A", "G"),
+            Some(false)
+        );
     }
 
     #[test]
@@ -1310,7 +1359,10 @@ mod tests {
         // c.376-1 and c.376-2 are the two bases of one acceptor, genomically
         // adjacent on either strand.
         let idx = splice_index(r#"{"pos":101,"ref":"G","alt":"A","off":-1,"sig":"Pathogenic"}"#);
-        assert_eq!(splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"), Some(true));
+        assert_eq!(
+            splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"),
+            Some(true)
+        );
     }
 
     #[test]
@@ -1318,7 +1370,10 @@ mod tests {
         // Opposite-signed offsets are different splice sites even if the
         // coordinates were somehow adjacent.
         let idx = splice_index(r#"{"pos":101,"ref":"G","alt":"A","off":1,"sig":"Pathogenic"}"#);
-        assert_eq!(splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"), Some(false));
+        assert_eq!(
+            splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"),
+            Some(false)
+        );
     }
 
     #[test]
@@ -1326,8 +1381,12 @@ mod tests {
         // Table 3 reads N/A in the LP column for a canonical-dinucleotide
         // variant under assessment: an LP call at a ±1,2 position is too easy
         // to reach for its clinical evidence to be borrowable unchecked.
-        let idx = splice_index(r#"{"pos":100,"ref":"A","alt":"G","off":-2,"sig":"Likely_pathogenic"}"#);
-        assert_eq!(splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"), Some(false));
+        let idx =
+            splice_index(r#"{"pos":100,"ref":"A","alt":"G","off":-2,"sig":"Likely_pathogenic"}"#);
+        assert_eq!(
+            splice_ps1(Some(&idx), Some("c.376-2A>T"), 100, "A", "T"),
+            Some(false)
+        );
     }
 
     #[test]
@@ -1341,7 +1400,10 @@ mod tests {
             json_key: "clinvar_protein".to_string(),
             json_string: r#"{"benignIndexed":true,"proteinVariants":[]}"#.to_string(),
         };
-        assert_eq!(splice_ps1(Some(&old), Some("c.376-2A>T"), 100, "A", "T"), None);
+        assert_eq!(
+            splice_ps1(Some(&old), Some("c.376-2A>T"), 100, "A", "T"),
+            None
+        );
     }
 
     #[test]

--- a/crates/fastvep-classification/src/types.rs
+++ b/crates/fastvep-classification/src/types.rs
@@ -139,9 +139,7 @@ impl EvidenceCounts {
                 (EvidenceDirection::Benign, EvidenceStrength::Standalone) => {
                     counts.benign_standalone += 1
                 }
-                (EvidenceDirection::Benign, EvidenceStrength::Strong) => {
-                    counts.benign_strong += 1
-                }
+                (EvidenceDirection::Benign, EvidenceStrength::Strong) => counts.benign_strong += 1,
                 (EvidenceDirection::Benign, EvidenceStrength::Supporting) => {
                     counts.benign_supporting += 1
                 }

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -341,8 +341,20 @@ fn main() -> Result<()> {
                 show_progress: !no_progress,
             })?;
         }
-        Commands::Cache { gff3, fasta, synonyms, output, no_progress } => {
-            pipeline::run_cache_build(&gff3, fasta.as_deref(), synonyms.as_deref(), &output, !no_progress)?;
+        Commands::Cache {
+            gff3,
+            fasta,
+            synonyms,
+            output,
+            no_progress,
+        } => {
+            pipeline::run_cache_build(
+                &gff3,
+                fasta.as_deref(),
+                synonyms.as_deref(),
+                &output,
+                !no_progress,
+            )?;
         }
         Commands::Web { port, gff3, fasta } => {
             webserver::run_server(port, gff3, fasta)?;
@@ -356,18 +368,16 @@ fn main() -> Result<()> {
             info_fields,
             format,
             no_progress,
-        } => {
-            pipeline::run_sa_build_format(
-                &format,
-                &source,
-                &input,
-                &output,
-                &assembly,
-                name.as_deref(),
-                &info_fields,
-                !no_progress,
-            )?
-        }
+        } => pipeline::run_sa_build_format(
+            &format,
+            &source,
+            &input,
+            &output,
+            &assembly,
+            name.as_deref(),
+            &info_fields,
+            !no_progress,
+        )?,
         Commands::SaConvert {
             input,
             output,

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use flate2::read::MultiGzDecoder;
 use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, GeneAnnotationProvider};
 use fastvep_cache::fasta::FastaReader;
 use fastvep_cache::gff::parse_gff3_with_source;
@@ -14,6 +13,7 @@ use fastvep_hgvs;
 use fastvep_io::output;
 use fastvep_io::variant::{AlleleAnnotation, TranscriptVariation, VariationFeature};
 use fastvep_io::vcf::VcfParser;
+use flate2::read::MultiGzDecoder;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::File;
@@ -27,16 +27,16 @@ fn open_vcf_input_reader(input: &str) -> Result<Box<dyn io::Read>> {
     let reader: Box<dyn io::Read> = if input == "-" {
         Box::new(io::stdin())
     } else {
-        Box::new(
-            File::open(input)
-                .with_context(|| format!("Opening input file: {}", input))?,
-        )
+        Box::new(File::open(input).with_context(|| format!("Opening input file: {}", input))?)
     };
 
     wrap_maybe_gzip_reader(reader, input)
 }
 
-fn wrap_maybe_gzip_reader(mut reader: Box<dyn io::Read>, source: &str) -> Result<Box<dyn io::Read>> {
+fn wrap_maybe_gzip_reader(
+    mut reader: Box<dyn io::Read>,
+    source: &str,
+) -> Result<Box<dyn io::Read>> {
     let mut prefix = [0u8; 2];
     let bytes_read = reader.read(&mut prefix)?;
     let looks_like_gzip = bytes_read == 2 && prefix == [0x1f, 0x8b];
@@ -135,10 +135,7 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
     }
 
     // Parse `LABEL=path` syntax up front so a typo fails before we touch IO.
-    let gff3_specs: Vec<Gff3Spec> = config.gff3
-        .iter()
-        .map(|s| parse_gff3_arg(s))
-        .collect();
+    let gff3_specs: Vec<Gff3Spec> = config.gff3.iter().map(|s| parse_gff3_arg(s)).collect();
 
     // Load transcript models: try binary cache first, fall back to GFF3.
     // The auto-managed sidecar cache only kicks in for a single GFF3 — with
@@ -154,105 +151,136 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
     let cache_path = if sa_only {
         None
     } else {
-        config.transcript_cache.as_ref().map(|p| Path::new(p).to_path_buf())
-            .or_else(|| single_gff3.map(|s| fastvep_cache::transcript_cache::default_cache_path(Path::new(&s.path))))
+        config
+            .transcript_cache
+            .as_ref()
+            .map(|p| Path::new(p).to_path_buf())
+            .or_else(|| {
+                single_gff3.map(|s| {
+                    fastvep_cache::transcript_cache::default_cache_path(Path::new(&s.path))
+                })
+            })
     };
 
-    let mut transcripts = if sa_only { Vec::new() } else { 'load: {
-        // Cache-load gating:
-        //
-        // * Sidecar cache (`cache_path` derived from a single `--gff3`):
-        //   always considered authoritative when fresh against its source
-        //   GFF3. Re-stamp the source label so the user's current
-        //   --gff3 label/auto-detection wins over whatever was on disk.
-        //
-        // * Explicit `--transcript-cache <path>`: the *user* told us where
-        //   transcripts live. Honour the cache contents verbatim (do NOT
-        //   re-stamp), and for multi-GFF3 invocations be explicit that the
-        //   --gff3 arguments are being ignored. Without this, a user
-        //   running `--gff3 ens.gff3 --gff3 refseq.gff3 --transcript-cache
-        //   old_ens_only.cache` would silently get Ensembl-only output
-        //   and never know.
-        let explicit_cache = config.transcript_cache.is_some();
-        if let Some(ref cp) = cache_path {
-            if cp.exists() {
-                // Freshness check: only sidecar-cache mode does it (the
-                // user-provided --transcript-cache is always trusted).
-                let is_fresh = if explicit_cache {
-                    true
-                } else {
-                    single_gff3
-                        .map(|s| fastvep_cache::transcript_cache::cache_is_fresh(cp, Path::new(&s.path)))
-                        .unwrap_or(true)
-                };
-                if is_fresh {
-                    match fastvep_cache::transcript_cache::load_cache(cp) {
-                        Ok(mut trs) => {
-                            // Re-stamp only in sidecar-cache + single-GFF3
-                            // mode. For explicit --transcript-cache we
-                            // preserve the on-disk labels so a merged
-                            // cache built via `fastvep cache --gff3 ens
-                            // --gff3 refseq -o combined.cache` survives
-                            // round-tripping with the merged distinction
-                            // intact.
-                            if !explicit_cache {
-                                if let Some(spec) = single_gff3 {
-                                    for tr in &mut trs {
-                                        tr.source = Some(spec.source.clone());
+    let mut transcripts = if sa_only {
+        Vec::new()
+    } else {
+        'load: {
+            // Cache-load gating:
+            //
+            // * Sidecar cache (`cache_path` derived from a single `--gff3`):
+            //   always considered authoritative when fresh against its source
+            //   GFF3. Re-stamp the source label so the user's current
+            //   --gff3 label/auto-detection wins over whatever was on disk.
+            //
+            // * Explicit `--transcript-cache <path>`: the *user* told us where
+            //   transcripts live. Honour the cache contents verbatim (do NOT
+            //   re-stamp), and for multi-GFF3 invocations be explicit that the
+            //   --gff3 arguments are being ignored. Without this, a user
+            //   running `--gff3 ens.gff3 --gff3 refseq.gff3 --transcript-cache
+            //   old_ens_only.cache` would silently get Ensembl-only output
+            //   and never know.
+            let explicit_cache = config.transcript_cache.is_some();
+            if let Some(ref cp) = cache_path {
+                if cp.exists() {
+                    // Freshness check: only sidecar-cache mode does it (the
+                    // user-provided --transcript-cache is always trusted).
+                    let is_fresh = if explicit_cache {
+                        true
+                    } else {
+                        single_gff3
+                            .map(|s| {
+                                fastvep_cache::transcript_cache::cache_is_fresh(
+                                    cp,
+                                    Path::new(&s.path),
+                                )
+                            })
+                            .unwrap_or(true)
+                    };
+                    if is_fresh {
+                        match fastvep_cache::transcript_cache::load_cache(cp) {
+                            Ok(mut trs) => {
+                                // Re-stamp only in sidecar-cache + single-GFF3
+                                // mode. For explicit --transcript-cache we
+                                // preserve the on-disk labels so a merged
+                                // cache built via `fastvep cache --gff3 ens
+                                // --gff3 refseq -o combined.cache` survives
+                                // round-tripping with the merged distinction
+                                // intact.
+                                if !explicit_cache {
+                                    if let Some(spec) = single_gff3 {
+                                        for tr in &mut trs {
+                                            tr.source = Some(spec.source.clone());
+                                        }
                                     }
-                                }
-                            } else if !gff3_specs.is_empty() {
-                                // Loud warning: user-supplied --gff3
-                                // alongside --transcript-cache means the
-                                // GFF3 arguments are ignored.
-                                eprintln!(
+                                } else if !gff3_specs.is_empty() {
+                                    // Loud warning: user-supplied --gff3
+                                    // alongside --transcript-cache means the
+                                    // GFF3 arguments are ignored.
+                                    eprintln!(
                                     "warning: --transcript-cache {} takes precedence over --gff3 {:?}; the GFF3 file(s) will NOT be parsed. Drop --transcript-cache to load from GFF3 instead, or remove the --gff3 flags to silence this warning.",
                                     cp.display(),
                                     gff3_specs.iter().map(|s| s.path.as_str()).collect::<Vec<_>>(),
                                 );
+                                }
+                                eprintln!(
+                                    "Loaded {} transcripts from cache {}",
+                                    trs.len(),
+                                    cp.display()
+                                );
+                                break 'load trs;
                             }
-                            eprintln!("Loaded {} transcripts from cache {}", trs.len(), cp.display());
-                            break 'load trs;
+                            Err(e) => {
+                                eprintln!(
+                                    "Warning: cache load failed ({}), falling back to GFF3",
+                                    e
+                                );
+                            }
                         }
-                        Err(e) => {
-                            eprintln!("Warning: cache load failed ({}), falling back to GFF3", e);
-                        }
+                    } else {
+                        eprintln!("Cache is stale, rebuilding from GFF3");
                     }
-                } else {
-                    eprintln!("Cache is stale, rebuilding from GFF3");
                 }
             }
-        }
 
-        // Fall back to GFF3 parsing. With multiple sources, load each one and
-        // concatenate — IndexedTranscriptProvider sorts and indexes by chrom,
-        // and the consequence predictor doesn't require globally-unique
-        // stable_ids, so Ensembl + RefSeq can simply coexist.
-        if gff3_specs.is_empty() {
-            eprintln!("Warning: No GFF3 file provided. Only intergenic variants will be annotated.");
-            Vec::new()
-        } else {
-            let mut all: Vec<fastvep_genome::Transcript> = Vec::new();
-            for spec in &gff3_specs {
-                let trs = load_one_gff3(spec, &config.input, config.distance)?;
+            // Fall back to GFF3 parsing. With multiple sources, load each one and
+            // concatenate — IndexedTranscriptProvider sorts and indexes by chrom,
+            // and the consequence predictor doesn't require globally-unique
+            // stable_ids, so Ensembl + RefSeq can simply coexist.
+            if gff3_specs.is_empty() {
                 eprintln!(
-                    "Loaded {} transcripts from {} (source label: {})",
-                    trs.len(), spec.path, spec.source
+                    "Warning: No GFF3 file provided. Only intergenic variants will be annotated."
                 );
-                all.extend(trs);
-            }
-            if all.is_empty() {
-                return Err(anyhow::anyhow!(
+                Vec::new()
+            } else {
+                let mut all: Vec<fastvep_genome::Transcript> = Vec::new();
+                for spec in &gff3_specs {
+                    let trs = load_one_gff3(spec, &config.input, config.distance)?;
+                    eprintln!(
+                        "Loaded {} transcripts from {} (source label: {})",
+                        trs.len(),
+                        spec.path,
+                        spec.source
+                    );
+                    all.extend(trs);
+                }
+                if all.is_empty() {
+                    return Err(anyhow::anyhow!(
                     "GFF3 source(s) [{}] produced 0 transcripts — likely malformed, truncated, or unrecognized format. Refusing to continue with empty transcript set.",
                     gff3_specs.iter().map(|s| s.path.as_str()).collect::<Vec<_>>().join(", ")
                 ));
+                }
+                if gff3_specs.len() > 1 {
+                    eprintln!(
+                        "Merged {} GFF3 sources into {} total transcripts",
+                        gff3_specs.len(),
+                        all.len()
+                    );
+                }
+                all
             }
-            if gff3_specs.len() > 1 {
-                eprintln!("Merged {} GFF3 sources into {} total transcripts", gff3_specs.len(), all.len());
-            }
-            all
         }
-    }};
+    };
 
     // Load FASTA reference (prefer mmap with .fai index, fall back to in-memory).
     // Skipped in --sa-only mode.
@@ -262,8 +290,13 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
         let fai_path = format!("{}.fai", fasta_path);
         if Path::new(&fai_path).exists() {
             let reader = fastvep_cache::fasta::MmapFastaReader::open(Path::new(fasta_path))?;
-            eprintln!("Memory-mapped reference FASTA from {} (using .fai index)", fasta_path);
-            Some(Box::new(fastvep_cache::providers::MmapFastaSequenceProvider::new(reader)))
+            eprintln!(
+                "Memory-mapped reference FASTA from {} (using .fai index)",
+                fasta_path
+            );
+            Some(Box::new(
+                fastvep_cache::providers::MmapFastaSequenceProvider::new(reader),
+            ))
         } else {
             let fasta_file = File::open(fasta_path)
                 .with_context(|| format!("Opening FASTA file: {}", fasta_path))?;
@@ -276,7 +309,9 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
     };
 
     // Build sequences for coding transcripts from FASTA (skip if loaded from cache with sequences)
-    let needs_seq_build = transcripts.iter().any(|t| t.is_coding() && t.spliced_seq.is_none());
+    let needs_seq_build = transcripts
+        .iter()
+        .any(|t| t.is_coding() && t.spliced_seq.is_none());
     if needs_seq_build {
         if let Some(ref sp) = seq_provider {
             let built = AtomicUsize::new(0);
@@ -286,13 +321,19 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                         sp.fetch_sequence(chrom, start, end)
                             .map_err(|e| e.to_string())
                     }) {
-                        eprintln!("Warning: could not build sequences for {}: {}", tr.stable_id, e);
+                        eprintln!(
+                            "Warning: could not build sequences for {}: {}",
+                            tr.stable_id, e
+                        );
                     } else {
                         built.fetch_add(1, Ordering::Relaxed);
                     }
                 }
             });
-            eprintln!("Built sequences for {} coding transcripts", built.load(Ordering::Relaxed));
+            eprintln!(
+                "Built sequences for {} coding transcripts",
+                built.load(Ordering::Relaxed)
+            );
         }
     }
 
@@ -325,7 +366,9 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
             .with_context(|| format!("Reading cache info: {}", info_path.display()))?;
         eprintln!(
             "Loaded VEP cache info: species={}, assembly={}, {} variation columns",
-            cache_info.species, cache_info.assembly, cache_info.variation_cols.len()
+            cache_info.species,
+            cache_info.assembly,
+            cache_info.variation_cols.len()
         );
         Some(TabixVariationProvider::new(Path::new(dir), &cache_info)?)
     } else {
@@ -372,9 +415,7 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
             let oga_count = std::fs::read_dir(Path::new(dir))
                 .map(|it| {
                     it.flatten()
-                        .filter(|e| {
-                            e.path().extension().and_then(|s| s.to_str()) == Some("oga")
-                        })
+                        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("oga"))
                         .count()
                 })
                 .unwrap_or(0);
@@ -390,7 +431,11 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
     } else if let Some(ref dir) = config.sa_dir {
         let loaded = load_gene_providers(Path::new(dir))?;
         if !loaded.is_empty() {
-            eprintln!("Loaded {} gene-level annotation source(s) from {}", loaded.len(), dir);
+            eprintln!(
+                "Loaded {} gene-level annotation source(s) from {}",
+                loaded.len(),
+                dir
+            );
         }
         loaded
     } else {
@@ -541,19 +586,26 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
         Some(path) => {
             let idx = fastvep_classification::FunctionalEvidenceIndex::from_file(Path::new(path))
                 .map_err(anyhow::Error::msg)?;
-            eprintln!("Loaded {} curated functional-evidence entries from {}", idx.len(), path);
+            eprintln!(
+                "Loaded {} curated functional-evidence entries from {}",
+                idx.len(),
+                path
+            );
             Some(idx)
         }
         None => None,
     };
     let functional_evidence = functional_index.as_ref();
     let owned_vcf_info_ids = output::vcf_owned_info_ids(&sa_json_keys, &gene_json_keys);
-    let generated_vcf_headers =
-        output::vcf_info_header_lines(&sa_json_keys, &gene_json_keys, output::DEFAULT_CSQ_FIELDS, sa_only);
+    let generated_vcf_headers = output::vcf_info_header_lines(
+        &sa_json_keys,
+        &gene_json_keys,
+        output::DEFAULT_CSQ_FIELDS,
+        sa_only,
+    );
     // Precompute the loaded-source lookup once so the per-row tab writer
     // doesn't redo an O(specs × keys) membership scan for every variant.
-    let supplementary_specs =
-        output::LoadedSupplementarySpecs::new(&sa_json_keys, &gene_json_keys);
+    let supplementary_specs = output::LoadedSupplementarySpecs::new(&sa_json_keys, &gene_json_keys);
 
     // Write headers based on output format
     match config.output_format.as_str() {
@@ -616,7 +668,8 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
 
     loop {
         // Phase 1: Read a batch of variants (sequential - VCF parser is not Sync)
-        let mut batch: Vec<(VariationFeature, HashMap<String, Vec<MatchedVariant>>)> = Vec::with_capacity(BATCH_SIZE);
+        let mut batch: Vec<(VariationFeature, HashMap<String, Vec<MatchedVariant>>)> =
+            Vec::with_capacity(BATCH_SIZE);
         for _ in 0..BATCH_SIZE {
             match vcf_parser.next_variant()? {
                 Some(mut vf) => {
@@ -627,13 +680,15 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                             for alt in &vf.alt_alleles {
                                 let alt_str = alt.to_string();
                                 let ref_str = vf.ref_allele.to_string();
-                                let matches = vp.get_matched_variants(
-                                    &vf.position.chromosome,
-                                    vf.position.start,
-                                    vf.position.end,
-                                    &ref_str,
-                                    &alt_str,
-                                ).unwrap_or_default();
+                                let matches = vp
+                                    .get_matched_variants(
+                                        &vf.position.chromosome,
+                                        vf.position.start,
+                                        vf.position.end,
+                                        &ref_str,
+                                        &alt_str,
+                                    )
+                                    .unwrap_or_default();
                                 if !matches.is_empty() {
                                     by_allele.insert(alt_str, matches);
                                 }
@@ -647,17 +702,18 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                     for matches in matched_by_allele.values() {
                         for m in matches {
                             if !vf.existing_variants.iter().any(|kv| kv.name == m.name) {
-                                vf.existing_variants.push(fastvep_io::variant::KnownVariant {
-                                    name: m.name.clone(),
-                                    allele_string: None,
-                                    minor_allele: m.minor_allele.clone(),
-                                    minor_allele_freq: m.minor_allele_freq,
-                                    clinical_significance: m.clin_sig.clone(),
-                                    somatic: m.somatic,
-                                    phenotype_or_disease: m.phenotype_or_disease,
-                                    pubmed: m.pubmed.clone(),
-                                    frequencies: m.frequencies.clone(),
-                                });
+                                vf.existing_variants
+                                    .push(fastvep_io::variant::KnownVariant {
+                                        name: m.name.clone(),
+                                        allele_string: None,
+                                        minor_allele: m.minor_allele.clone(),
+                                        minor_allele_freq: m.minor_allele_freq,
+                                        clinical_significance: m.clin_sig.clone(),
+                                        somatic: m.somatic,
+                                        phenotype_or_disease: m.phenotype_or_disease,
+                                        pubmed: m.pubmed.clone(),
+                                        frequencies: m.frequencies.clone(),
+                                    });
                             }
                         }
                     }
@@ -677,9 +733,7 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
             // Collect all positions in this batch, grouped by chromosome
             let mut chrom_positions: HashMap<&str, Vec<u64>> = HashMap::new();
             for (vf, _) in &batch {
-                let positions = chrom_positions
-                    .entry(&vf.position.chromosome)
-                    .or_default();
+                let positions = chrom_positions.entry(&vf.position.chromosome).or_default();
                 positions.push(vf.position.start);
                 if let Some(vcf) = &vf.vcf_fields {
                     if vcf.pos != vf.position.start {
@@ -1469,12 +1523,9 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                         explicit_ref: config.explicit_alleles,
                         qc_class: qc_label,
                     };
-                    for line in output::format_tab_line_with(
-                        vf,
-                        &supplementary_specs,
-                        sa_only,
-                        opts,
-                    ) {
+                    for line in
+                        output::format_tab_line_with(vf, &supplementary_specs, sa_only, opts)
+                    {
                         writeln!(writer, "{}", line)?;
                     }
                 }
@@ -1602,9 +1653,8 @@ fn pick_best_transcript_idx_with(
     tvs: &[TranscriptVariation],
     order: &[PickCriterion],
 ) -> Option<usize> {
-    (0..tvs.len()).min_by(|&a, &b| {
-        pick_key_with(&tvs[a], order).cmp(&pick_key_with(&tvs[b], order))
-    })
+    (0..tvs.len())
+        .min_by(|&a, &b| pick_key_with(&tvs[a], order).cmp(&pick_key_with(&tvs[b], order)))
 }
 
 /// Index of the best transcript variation under VEP's default `--pick_order`.
@@ -1680,7 +1730,11 @@ fn appris_rank(appris: Option<&str>) -> u8 {
         return u8::MAX - 1;
     };
     let n: u8 = digits.parse().unwrap_or(9);
-    if is_alt { 5u8.saturating_add(n) } else { n }
+    if is_alt {
+        5u8.saturating_add(n)
+    } else {
+        n
+    }
 }
 
 /// Extract trio genotype information from a VariationFeature's VCF sample columns (CLI path).
@@ -1710,8 +1764,7 @@ fn extract_trio_genotypes_cli(
     let format_str = &vcf_fields.rest[0];
     let sample_strs: Vec<&str> = vcf_fields.rest[1..].iter().map(|s| s.as_str()).collect();
 
-    let samples =
-        fastvep_io::sample::parse_samples(format_str, &sample_strs, sample_names);
+    let samples = fastvep_io::sample::parse_samples(format_str, &sample_strs, sample_names);
 
     let proband_gt = samples
         .iter()
@@ -1746,9 +1799,7 @@ fn sample_data_to_genotype_info_cli(
     let is_missing = gt.is_none_or(|g| g.is_missing());
     let is_phased = gt.is_some_and(|g| g.phased);
 
-    let alt_allele_index = gt.and_then(|g| {
-        g.alleles.iter().filter_map(|a| *a).find(|&a| a > 0)
-    });
+    let alt_allele_index = gt.and_then(|g| g.alleles.iter().filter_map(|a| *a).find(|&a| a > 0));
 
     fastvep_classification::GenotypeInfo {
         is_het,
@@ -1944,9 +1995,16 @@ fn enrich_compound_het_batch(
                 aa.escapes_nmd,
                 repeat_db_loaded,
                 fastvep_annotate::splice_ps1_evidence(aa, &gene_anns, &query_alleles, alt_idx),
-                alt_idx.and_then(|i| query_alleles.get(i)).map(|(_, pos, r, a)| {
-                    (vf.position.chromosome.to_string(), *pos, r.clone(), a.clone())
-                }),
+                alt_idx
+                    .and_then(|i| query_alleles.get(i))
+                    .map(|(_, pos, r, a)| {
+                        (
+                            vf.position.chromosome.to_string(),
+                            *pos,
+                            r.clone(),
+                            a.clone(),
+                        )
+                    }),
                 fastvep_classification::is_pure_insertion(&vf.ref_allele),
                 alt_idx.and_then(|i| functional_by_alt[i].clone()),
                 &aa.supplementary,
@@ -1965,7 +2023,6 @@ fn enrich_compound_het_batch(
     }
 }
 
-
 fn write_vcf_line(writer: &mut impl Write, vf: &VariationFeature, sa_only: bool) -> Result<()> {
     if let Some(ref fields) = vf.vcf_fields {
         let csq = if sa_only {
@@ -1978,8 +2035,14 @@ fn write_vcf_line(writer: &mut impl Write, vf: &VariationFeature, sa_only: bool)
         write!(
             writer,
             "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            fields.chrom, fields.pos, fields.id, fields.ref_allele, fields.alt,
-            fields.qual, fields.filter, info
+            fields.chrom,
+            fields.pos,
+            fields.id,
+            fields.ref_allele,
+            fields.alt,
+            fields.qual,
+            fields.filter,
+            info
         )?;
 
         for rest_field in &fields.rest {
@@ -1990,7 +2053,6 @@ fn write_vcf_line(writer: &mut impl Write, vf: &VariationFeature, sa_only: bool)
 
     Ok(())
 }
-
 
 use serde_json;
 
@@ -2041,7 +2103,12 @@ pub fn run_filter(input: &str, output_path: &str, filter_expr: &str) -> Result<(
                     eprintln!(
                         "[filter] CSQ format: {} fields ({})",
                         csq_fields.len(),
-                        csq_fields.iter().take(5).cloned().collect::<Vec<_>>().join(", ")
+                        csq_fields
+                            .iter()
+                            .take(5)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     );
                 }
             }
@@ -2135,13 +2202,15 @@ pub fn run_cache_build(
     show_progress: bool,
 ) -> Result<()> {
     if gff3_paths.is_empty() {
-        return Err(anyhow::anyhow!("`fastvep cache` requires at least one --gff3"));
+        return Err(anyhow::anyhow!(
+            "`fastvep cache` requires at least one --gff3"
+        ));
     }
     let specs: Vec<Gff3Spec> = gff3_paths.iter().map(|s| parse_gff3_arg(s)).collect();
     let mut transcripts: Vec<fastvep_genome::Transcript> = Vec::new();
     for spec in &specs {
-        let gff_file = File::open(&spec.path)
-            .with_context(|| format!("Opening GFF3 file: {}", spec.path))?;
+        let gff_file =
+            File::open(&spec.path).with_context(|| format!("Opening GFF3 file: {}", spec.path))?;
         // Auto-decompress .gz / .bgz GFF3 inputs. Without this we'd silently
         // produce a 0-transcript cache.
         let trs = if spec.path.ends_with(".gz") || spec.path.ends_with(".bgz") {
@@ -2151,18 +2220,28 @@ pub fn run_cache_build(
         };
         eprintln!(
             "Loaded {} transcripts from {} (source label: {})",
-            trs.len(), spec.path, spec.source
+            trs.len(),
+            spec.path,
+            spec.source
         );
         transcripts.extend(trs);
     }
     if transcripts.is_empty() {
         return Err(anyhow::anyhow!(
             "GFF3 source(s) [{}] produced 0 transcripts — refusing to write an empty cache.",
-            specs.iter().map(|s| s.path.as_str()).collect::<Vec<_>>().join(", ")
+            specs
+                .iter()
+                .map(|s| s.path.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         ));
     }
     if specs.len() > 1 {
-        eprintln!("Merged {} GFF3 sources into {} total transcripts", specs.len(), transcripts.len());
+        eprintln!(
+            "Merged {} GFF3 sources into {} total transcripts",
+            specs.len(),
+            transcripts.len()
+        );
     }
 
     // Chromosome synonyms (VEP `chr_synonyms.txt`). An empty table still
@@ -2178,8 +2257,8 @@ pub fn run_cache_build(
     };
 
     if let Some(fasta) = fasta_path {
-        let fasta_file = File::open(fasta)
-            .with_context(|| format!("Opening FASTA file: {}", fasta))?;
+        let fasta_file =
+            File::open(fasta).with_context(|| format!("Opening FASTA file: {}", fasta))?;
         let reader = FastaReader::from_reader(fasta_file)?;
         eprintln!("Loaded reference FASTA from {}", fasta);
 
@@ -2189,8 +2268,11 @@ pub fn run_cache_build(
         // `annotate` matches a VCF regardless of which GFF3 the transcript
         // came from. RefSeq accessions only resolve when a synonyms file maps
         // them; chr↔bare / mito resolve with no synonyms file at all.
-        let contigs: std::collections::HashSet<String> =
-            reader.sequence_names().into_iter().map(|s| s.to_string()).collect();
+        let contigs: std::collections::HashSet<String> = reader
+            .sequence_names()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let mut resolved: HashMap<String, Option<std::sync::Arc<str>>> = HashMap::new();
         let mut unresolved: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
         for tr in &mut transcripts {
@@ -2243,7 +2325,10 @@ pub fn run_cache_build(
                     sp.fetch_sequence(chrom, start, end)
                         .map_err(|e| e.to_string())
                 }) {
-                    eprintln!("Warning: could not build sequences for {}: {}", tr.stable_id, e);
+                    eprintln!(
+                        "Warning: could not build sequences for {}: {}",
+                        tr.stable_id, e
+                    );
                 } else {
                     meter.update();
                 }
@@ -2320,11 +2405,15 @@ fn load_one_gff3(
 
     if spec.path.ends_with(".gz") && Path::new(&tbi_path).exists() {
         let regions = prescan_vcf_regions(vcf_input, distance)?;
-        eprintln!("Pre-scanned {} variant regions for {}", regions.len(), spec.path);
+        eprintln!(
+            "Pre-scanned {} variant regions for {}",
+            regions.len(),
+            spec.path
+        );
         fastvep_cache::gff::parse_gff3_indexed_with_source(gff_path, &regions, &spec.source)
     } else {
-        let gff_file = File::open(&spec.path)
-            .with_context(|| format!("Opening GFF3 file: {}", spec.path))?;
+        let gff_file =
+            File::open(&spec.path).with_context(|| format!("Opening GFF3 file: {}", spec.path))?;
         if spec.path.ends_with(".gz") || spec.path.ends_with(".bgz") {
             parse_gff3_with_source(flate2::read::MultiGzDecoder::new(gff_file), &spec.source)
         } else {
@@ -2342,10 +2431,18 @@ fn prescan_vcf_regions(vcf_path: &str, distance: u64) -> Result<Vec<(String, u64
 
     for line in reader.lines() {
         let line = line?;
-        if line.starts_with('#') || line.is_empty() { continue; }
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
         let mut fields = line.split('\t');
-        let chrom = match fields.next() { Some(c) => c.to_string(), None => continue };
-        let pos: u64 = match fields.next().and_then(|p| p.parse().ok()) { Some(p) => p, None => continue };
+        let chrom = match fields.next() {
+            Some(c) => c.to_string(),
+            None => continue,
+        };
+        let pos: u64 = match fields.next().and_then(|p| p.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
         let start = pos.saturating_sub(distance);
         let end = pos + distance;
 
@@ -2354,7 +2451,10 @@ fn prescan_vcf_regions(vcf_path: &str, distance: u64) -> Result<Vec<(String, u64
         entry.1 = entry.1.max(end);
     }
 
-    Ok(regions.into_iter().map(|(chrom, (s, e))| (chrom, s, e)).collect())
+    Ok(regions
+        .into_iter()
+        .map(|(chrom, (s, e))| (chrom, s, e))
+        .collect())
 }
 
 // =============================================================================
@@ -2415,7 +2515,10 @@ fn standard_chrom_map(assembly: &str) -> (Vec<String>, std::collections::HashMap
 /// When `byte_counter` is supplied the raw (still-compressed) file is wrapped in
 /// a `CountingReader` *before* decompression, so progress reflects compressed
 /// bytes consumed against the on-disk file size.
-fn open_sa_input(input: &str, byte_counter: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>) -> Result<Box<dyn io::Read>> {
+fn open_sa_input(
+    input: &str,
+    byte_counter: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+) -> Result<Box<dyn io::Read>> {
     let mut file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
     let mut magic = [0u8; 2];
     let n = file.read(&mut magic)?;
@@ -2459,8 +2562,8 @@ fn run_streaming_sa_build<'a, I>(
 where
     I: Iterator<Item = Result<fastvep_sa::common::AnnotationRecord>>,
 {
-    use std::sync::Arc;
     use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
 
     let output_path = Path::new(output);
     let mut writer = fastvep_sa::writer::SaWriter::new(header);
@@ -2527,7 +2630,11 @@ fn iter_phylop_auto<'a, R: BufRead + 'a>(
     if prefix.trim_start().starts_with("fixedStep") {
         Box::new(fastvep_sa::sources::scores::iter_wigfix(buf, chrom_to_idx))
     } else {
-        Box::new(fastvep_sa::sources::scores::iter_score_tsv(buf, chrom_to_idx, false))
+        Box::new(fastvep_sa::sources::scores::iter_score_tsv(
+            buf,
+            chrom_to_idx,
+            false,
+        ))
     }
 }
 
@@ -2545,7 +2652,10 @@ pub fn run_sa_build(
     use fastvep_sa::writer::SaWriter;
 
     // Gene-level sources (.oga) — dispatched separately from variant-level (.osa).
-    if matches!(source, "omim" | "gnomad_genes" | "gnomad_gene" | "clinvar_protein") {
+    if matches!(
+        source,
+        "omim" | "gnomad_genes" | "gnomad_gene" | "clinvar_protein"
+    ) {
         return run_oga_build(source, input, output, assembly);
     }
 
@@ -2728,7 +2838,12 @@ pub fn run_sa_build(
         ),
     };
 
-    eprintln!("Building {} .osa: {} -> {}", source, input, Path::new(output).with_extension("osa").display());
+    eprintln!(
+        "Building {} .osa: {} -> {}",
+        source,
+        input,
+        Path::new(output).with_extension("osa").display()
+    );
 
     // Large, coordinate-sorted population/score sources stream straight into
     // the writer instead of buffering every record (issue #55). They share one
@@ -2736,43 +2851,78 @@ pub fn run_sa_build(
     match source {
         "spliceai" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::spliceai::iter_spliceai_vcf(r, m),
             );
         }
         "gnomad" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::gnomad::iter_gnomad_vcf(r, m),
             );
         }
         "dbsnp" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::dbsnp::iter_dbsnp_vcf(r, m),
             );
         }
         "topmed" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::topmed::iter_topmed_vcf(r, m),
             );
         }
         "alphamissense" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::alphamissense::iter_alphamissense_tsv(r, m),
             );
         }
         "phylop" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 iter_phylop_auto,
             );
         }
         "gerp" | "dann" => {
             return run_streaming_sa_build(
-                input, output, header, &chrom_map, &chrom_list, show_progress,
+                input,
+                output,
+                header,
+                &chrom_map,
+                &chrom_list,
+                show_progress,
                 |r, m| fastvep_sa::sources::scores::iter_score_tsv(r, m, false),
             );
         }
@@ -2783,7 +2933,8 @@ pub fn run_sa_build(
 
     eprintln!(
         "INFO  ProgressMeter - Parsing '{}': {} -> {}",
-        source, input,
+        source,
+        input,
         Path::new(output).with_extension("osa").display()
     );
     let t_parse = std::time::Instant::now();
@@ -2881,8 +3032,14 @@ pub const OSA2_SUPPORTED_SOURCES: &[&str] = &[
 /// a conversion can only ever produce the blob encoding. For a source in this
 /// list, rebuilding from upstream yields a materially smaller file and the tool
 /// says so; for the others, converting is equivalent to a rebuild.
-pub const OSA2_DECOMPOSED_SOURCES: &[&str] =
-    &["gnomad", "onekg", "1000g", "topmed", "alphamissense", "spliceai"];
+pub const OSA2_DECOMPOSED_SOURCES: &[&str] = &[
+    "gnomad",
+    "onekg",
+    "1000g",
+    "topmed",
+    "alphamissense",
+    "spliceai",
+];
 
 /// Whether `--format osa2` (and `--format auto`) can build this source to v2.
 pub fn source_supports_osa2(source: &str) -> bool {
@@ -2932,17 +3089,45 @@ pub fn run_sa_build_format(
     show_progress: bool,
 ) -> Result<()> {
     match format {
-        "osa" | "v1" => {
-            run_sa_build(source, input, output, assembly, name, info_fields, show_progress)
-        }
-        "osa2" | "v2" => {
-            run_sa_build_v2(source, input, output, assembly, name, info_fields, show_progress)
-        }
+        "osa" | "v1" => run_sa_build(
+            source,
+            input,
+            output,
+            assembly,
+            name,
+            info_fields,
+            show_progress,
+        ),
+        "osa2" | "v2" => run_sa_build_v2(
+            source,
+            input,
+            output,
+            assembly,
+            name,
+            info_fields,
+            show_progress,
+        ),
         "auto" => {
             if source_supports_osa2(source) {
-                run_sa_build_v2(source, input, output, assembly, name, info_fields, show_progress)
+                run_sa_build_v2(
+                    source,
+                    input,
+                    output,
+                    assembly,
+                    name,
+                    info_fields,
+                    show_progress,
+                )
             } else {
-                run_sa_build(source, input, output, assembly, name, info_fields, show_progress)
+                run_sa_build(
+                    source,
+                    input,
+                    output,
+                    assembly,
+                    name,
+                    info_fields,
+                    show_progress,
+                )
             }
         }
         other => anyhow::bail!(
@@ -3008,7 +3193,11 @@ pub fn run_sa_build_v2(
             // live through the streaming loop.
             let bridge_fields = fields.clone();
             let mut v1 = onekg::parse_onekg_vcf(buf_reader, &chrom_map)?;
-            v1.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+            v1.sort_by(|a, b| {
+                a.chrom_idx
+                    .cmp(&b.chrom_idx)
+                    .then(a.position.cmp(&b.position))
+            });
             let records = bridge_v1_records(v1.into_iter().map(Ok), &chrom_list, &bridge_fields);
             finish_osa2_build(
                 &out_path,
@@ -3048,7 +3237,11 @@ pub fn run_sa_build_v2(
         // straight into v2 with a dedicated encoder (the generic v1 bridge
         // cannot encode categoricals) and a fixed 3-entry string table.
         "alphamissense" => {
-            eprintln!("Building alphamissense .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building alphamissense .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let records =
                 alphamissense::iter_alphamissense_osa2(buf_reader, &chrom_map, &chrom_list);
@@ -3069,7 +3262,11 @@ pub fn run_sa_build_v2(
         // vocabulary is only known once the input has streamed past, hence the
         // deferred string table.
         "spliceai" => {
-            eprintln!("Building spliceai .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building spliceai .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let genes = spliceai::GeneInterner::new();
             let records =
@@ -3089,7 +3286,11 @@ pub fn run_sa_build_v2(
         // A few thousand records; wired to v2 for format uniformity rather than
         // speed. See `mitomap_osa2_metadata`.
         "mitomap" => {
-            eprintln!("Building mitomap .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building mitomap .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let v1 = mitomap::parse_mitomap(buf_reader, &chrom_map)?;
             let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
@@ -3131,7 +3332,11 @@ pub fn run_sa_build_v2(
             // than degrading, so re-establish the ordering at the boundary
             // instead of depending on a cross-crate invariant. A no-op on
             // already-sorted input; same belt-and-braces as the onekg arm above.
-            v1.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+            v1.sort_by(|a, b| {
+                a.chrom_idx
+                    .cmp(&b.chrom_idx)
+                    .then(a.position.cmp(&b.position))
+            });
             let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
             finish_osa2_build(
                 &out_path,
@@ -3185,7 +3390,11 @@ pub fn run_sa_build_v2(
         // arrays, review status, population AFs). is_array=true is preserved in
         // the v2 metadata to match v1 exactly. Buffered+sorted by the v1 parser.
         "clinvar" => {
-            eprintln!("Building clinvar .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building clinvar .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let v1 = clinvar::parse_clinvar_vcf(buf_reader, &chrom_map)?;
             let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
@@ -3241,7 +3450,11 @@ pub fn run_sa_build_v2(
             )
         }
         "gerp" | "dann" => {
-            eprintln!("Building {source} .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building {source} .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let records = bridge_v1_raw_blobs(
                 scores::iter_score_tsv(buf_reader, &chrom_map, false),
@@ -3279,7 +3492,11 @@ pub fn run_sa_build_v2(
         }
         // PrimateAI: single `{"score":..}` object per allele, whole-record blob.
         "primateai" => {
-            eprintln!("Building primateai .osa2: {} -> {}", input, out_path.display());
+            eprintln!(
+                "Building primateai .osa2: {} -> {}",
+                input,
+                out_path.display()
+            );
             let (buf_reader, meter) = open_sa_reader_with_meter(input, show_progress)?;
             let v1 = primateai::parse_primateai(buf_reader, &chrom_map)?;
             let records = bridge_v1_raw_blobs(v1.into_iter().map(Ok), &chrom_list);
@@ -3351,7 +3568,10 @@ where
 fn open_sa_reader_with_meter(
     input: &str,
     show_progress: bool,
-) -> Result<(io::BufReader<Box<dyn io::Read>>, crate::progress::ProgressMeter)> {
+) -> Result<(
+    io::BufReader<Box<dyn io::Read>>,
+    crate::progress::ProgressMeter,
+)> {
     use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
 
@@ -3419,7 +3639,14 @@ fn finish_osa2_build_deferred<F>(
 where
     F: FnOnce() -> Vec<(usize, Vec<String>)>,
 {
-    let n = match write_osa2_stream(out_path, metadata, fields, records, &mut meter, string_tables) {
+    let n = match write_osa2_stream(
+        out_path,
+        metadata,
+        fields,
+        records,
+        &mut meter,
+        string_tables,
+    ) {
         Ok(n) => n,
         Err(e) => {
             let _ = std::fs::remove_file(out_path);
@@ -3518,12 +3745,13 @@ pub fn run_sa_convert(input: &str, output: &str, show_progress: bool) -> Result<
              using it as-is.",
             input,
             other,
-            if other == "osi" { "interval-level" } else { "gene-level" }
+            if other == "osi" {
+                "interval-level"
+            } else {
+                "gene-level"
+            }
         ),
-        _ => anyhow::bail!(
-            "sa-convert expects a v1 '.osa' input; got '{}'.",
-            input
-        ),
+        _ => anyhow::bail!("sa-convert expects a v1 '.osa' input; got '{}'.", input),
     }
 
     let out_path = Path::new(output).with_extension("osa2");
@@ -3701,7 +3929,11 @@ fn run_custom_vcf_build(
         "Building custom_vcf .osa from: {} (name={}, info_fields={})",
         input,
         resolved_name,
-        if info_fields.is_empty() { "<all>".to_string() } else { info_fields.join(",") }
+        if info_fields.is_empty() {
+            "<all>".to_string()
+        } else {
+            info_fields.join(",")
+        }
     );
 
     let header = IndexHeader {
@@ -3716,8 +3948,7 @@ fn run_custom_vcf_build(
         is_positional: false,
     };
 
-    let file = File::open(input)
-        .with_context(|| format!("Opening input file: {}", input))?;
+    let file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
     let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
         Box::new(flate2::read::MultiGzDecoder::new(file))
     } else {
@@ -3725,12 +3956,8 @@ fn run_custom_vcf_build(
     };
     let buf_reader = io::BufReader::new(reader);
 
-    let records = fastvep_sa::custom::parse_custom_vcf(
-        buf_reader,
-        &chrom_map,
-        &header.name,
-        info_fields,
-    )?;
+    let records =
+        fastvep_sa::custom::parse_custom_vcf(buf_reader, &chrom_map, &header.name, info_fields)?;
     if records.is_empty() {
         // Build proceeds (writes an empty .osa rather than failing) so the
         // user can iterate on their filter, but call this out clearly —
@@ -3774,8 +4001,7 @@ fn run_custom_bed_build(
         input, resolved_name
     );
 
-    let file = File::open(input)
-        .with_context(|| format!("Opening input file: {}", input))?;
+    let file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
     let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
         Box::new(flate2::read::MultiGzDecoder::new(file))
     } else {
@@ -3849,8 +4075,7 @@ pub fn run_oga_build(source: &str, input: &str, output: &str, assembly: &str) ->
 
     eprintln!("Building {} .oga from: {}", source, input);
 
-    let file = File::open(input)
-        .with_context(|| format!("Opening input file: {}", input))?;
+    let file = File::open(input).with_context(|| format!("Opening input file: {}", input))?;
     let reader: Box<dyn io::Read> = if input.ends_with(".gz") || input.ends_with(".bgz") {
         Box::new(flate2::read::MultiGzDecoder::new(file))
     } else {
@@ -3968,12 +4193,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_mane_select_over_canonical() {
         let tvs = vec![
-            make_tv("TX_CANON", true, "protein_coding",
+            make_tv(
+                "TX_CANON",
+                true,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_MANE", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                Some("TX_MANE.1"), None, None, None, None),
+                Some("TX_MANE.1"),
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -3981,12 +4222,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_mane_plus_clinical_over_canonical() {
         let tvs = vec![
-            make_tv("TX_CANON", true, "protein_coding",
+            make_tv(
+                "TX_CANON",
+                true,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_MANE_PC", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE_PC",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, Some("TX_MANE_PC.1"), None, None, None),
+                None,
+                Some("TX_MANE_PC.1"),
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -3994,12 +4251,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_mane_select_over_mane_plus_clinical() {
         let tvs = vec![
-            make_tv("TX_MANE_PC", true, "protein_coding",
+            make_tv(
+                "TX_MANE_PC",
+                true,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, Some("TX_MANE_PC.1"), None, None, None),
-            make_tv("TX_MANE", false, "protein_coding",
+                None,
+                Some("TX_MANE_PC.1"),
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                Some("TX_MANE.1"), None, None, None, None),
+                Some("TX_MANE.1"),
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4007,12 +4280,28 @@ mod pick_tests {
     #[test]
     fn pick_falls_back_to_canonical_when_no_mane() {
         let tvs = vec![
-            make_tv("TX_NONCAN", false, "protein_coding",
+            make_tv(
+                "TX_NONCAN",
+                false,
+                "protein_coding",
                 vec![Consequence::StopGained],
-                None, None, None, None, None),
-            make_tv("TX_CANON", true, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_CANON",
+                true,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         // Canonical wins even though TX_NONCAN has a more severe consequence.
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
@@ -4021,12 +4310,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_protein_coding_biotype() {
         let tvs = vec![
-            make_tv("TX_NONCODING", false, "lncRNA",
+            make_tv(
+                "TX_NONCODING",
+                false,
+                "lncRNA",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_PC", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_PC",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4034,12 +4339,28 @@ mod pick_tests {
     #[test]
     fn pick_uses_severity_when_other_fields_equal() {
         let tvs = vec![
-            make_tv("TX_A", false, "protein_coding",
+            make_tv(
+                "TX_A",
+                false,
+                "protein_coding",
                 vec![Consequence::SynonymousVariant],
-                None, None, None, None, None),
-            make_tv("TX_B", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_B",
+                false,
+                "protein_coding",
                 vec![Consequence::StopGained],
-                None, None, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4047,12 +4368,28 @@ mod pick_tests {
     #[test]
     fn pick_tie_breaks_alphabetically_on_transcript_id() {
         let tvs = vec![
-            make_tv("TX_Z", false, "protein_coding",
+            make_tv(
+                "TX_Z",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_A", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_A",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4060,12 +4397,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_lower_tsl() {
         let tvs = vec![
-            make_tv("TX_TSL5", false, "protein_coding",
+            make_tv(
+                "TX_TSL5",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, Some(5), None),
-            make_tv("TX_TSL1", false, "protein_coding",
+                None,
+                None,
+                None,
+                Some(5),
+                None,
+            ),
+            make_tv(
+                "TX_TSL1",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, Some(1), None),
+                None,
+                None,
+                None,
+                Some(1),
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4075,12 +4428,28 @@ mod pick_tests {
         // P1 should beat P3 even though both are APPRIS-tagged — would fail
         // if APPRIS were compared by presence-only.
         let tvs = vec![
-            make_tv("TX_P3", false, "protein_coding",
+            make_tv(
+                "TX_P3",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("P3"), None, None),
-            make_tv("TX_P1", false, "protein_coding",
+                None,
+                None,
+                Some("P3"),
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_P1",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("P1"), None, None),
+                None,
+                None,
+                Some("P1"),
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4088,12 +4457,28 @@ mod pick_tests {
     #[test]
     fn pick_prefers_principal_over_alternative_appris() {
         let tvs = vec![
-            make_tv("TX_A1", false, "protein_coding",
+            make_tv(
+                "TX_A1",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("A1"), None, None),
-            make_tv("TX_P5", false, "protein_coding",
+                None,
+                None,
+                Some("A1"),
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_P5",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("P5"), None, None),
+                None,
+                None,
+                Some("P5"),
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4102,12 +4487,28 @@ mod pick_tests {
     fn pick_accepts_long_form_appris_tags() {
         // Ensembl GFF3 sometimes uses "principal1" / "alternative2".
         let tvs = vec![
-            make_tv("TX_ALT", false, "protein_coding",
+            make_tv(
+                "TX_ALT",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("alternative2"), None, None),
-            make_tv("TX_PRINC", false, "protein_coding",
+                None,
+                None,
+                Some("alternative2"),
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_PRINC",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, Some("principal1"), None, None),
+                None,
+                None,
+                Some("principal1"),
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4128,12 +4529,28 @@ mod pick_tests {
         // CYP21A2 variants coming out on C4B `downstream_gene_variant`, and
         // STRC-region ones on TIMM9 `upstream_gene_variant`, are this rule.
         let tvs = vec![
-            make_tv("TX_DISRUPTED", false, "protein_coding",
+            make_tv(
+                "TX_DISRUPTED",
+                false,
+                "protein_coding",
                 vec![Consequence::StartLost],
-                None, None, None, None, None),
-            make_tv("TX_MANE_NEIGHBOUR", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE_NEIGHBOUR",
+                false,
+                "protein_coding",
                 vec![Consequence::UpstreamGeneVariant],
-                Some("TX_MANE_NEIGHBOUR.1"), None, None, None, None),
+                Some("TX_MANE_NEIGHBOUR.1"),
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
     }
@@ -4143,12 +4560,28 @@ mod pick_tests {
         // The clinical order. This is what makes the CYP21A2 and KIAA0586
         // rows report the gene the variant actually hits.
         let tvs = vec![
-            make_tv("TX_DISRUPTED", false, "protein_coding",
+            make_tv(
+                "TX_DISRUPTED",
+                false,
+                "protein_coding",
                 vec![Consequence::StartLost],
-                None, None, None, None, None),
-            make_tv("TX_MANE_NEIGHBOUR", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE_NEIGHBOUR",
+                false,
+                "protein_coding",
                 vec![Consequence::UpstreamGeneVariant],
-                Some("TX_MANE_NEIGHBOUR.1"), None, None, None, None),
+                Some("TX_MANE_NEIGHBOUR.1"),
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         let order = parse_pick_order("rank,mane_select,canonical").unwrap();
         assert_eq!(pick_best_transcript_idx_with(&tvs, &order), Some(0));
@@ -4159,12 +4592,28 @@ mod pick_tests {
         // Equal severity must fall through to MANE, or putting rank first
         // would turn every same-consequence choice into a transcript-ID sort.
         let tvs = vec![
-            make_tv("TX_PLAIN", false, "protein_coding",
+            make_tv(
+                "TX_PLAIN",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_MANE", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_MANE",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                Some("TX_MANE.1"), None, None, None, None),
+                Some("TX_MANE.1"),
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         let order = parse_pick_order("rank,mane_select,canonical").unwrap();
         assert_eq!(pick_best_transcript_idx_with(&tvs, &order), Some(1));
@@ -4184,12 +4633,28 @@ mod pick_tests {
         // Listing a subset drops the rest rather than appending them, which is
         // what lets a caller say "severity, then MANE, and nothing else".
         let tvs = vec![
-            make_tv("TX_A", true, "protein_coding",
+            make_tv(
+                "TX_A",
+                true,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
-            make_tv("TX_B", false, "protein_coding",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_B",
+                false,
+                "protein_coding",
                 vec![Consequence::MissenseVariant],
-                None, None, None, None, None),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
         ];
         // Canonical would pick index 0; with only `rank` the tie falls to the
         // transcript-ID tie-break, which is TX_A anyway - so use ccds to show
@@ -4209,7 +4674,10 @@ mod pick_tests {
             ("rank,length", "not supported"),
         ] {
             let err = parse_pick_order(spec).expect_err("must reject").to_string();
-            assert!(err.contains(expect), "{spec:?} gave {err:?}, wanted {expect:?}");
+            assert!(
+                err.contains(expect),
+                "{spec:?} gave {err:?}, wanted {expect:?}"
+            );
         }
     }
 }
@@ -4468,8 +4936,16 @@ mod custom_source_tests {
         )
         .expect_err("must error on unknown source");
         let msg = format!("{}", err);
-        assert!(msg.contains("custom_vcf"), "error message must mention custom_vcf: {}", msg);
-        assert!(msg.contains("custom_bed"), "error message must mention custom_bed: {}", msg);
+        assert!(
+            msg.contains("custom_vcf"),
+            "error message must mention custom_vcf: {}",
+            msg
+        );
+        assert!(
+            msg.contains("custom_bed"),
+            "error message must mention custom_bed: {}",
+            msg
+        );
     }
 
     #[test]

--- a/crates/fastvep-cli/src/progress.rs
+++ b/crates/fastvep-cli/src/progress.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Read};
 use std::sync::{
-    Arc,
     atomic::{AtomicU64, Ordering},
+    Arc,
 };
 use std::time::Instant;
 
@@ -94,12 +94,20 @@ impl ProgressMeter {
         }
 
         let elapsed_min = self.start.elapsed().as_secs_f64() / 60.0;
-        let rpm = if elapsed_min > 0.0 { self.records as f64 / elapsed_min } else { 0.0 };
+        let rpm = if elapsed_min > 0.0 {
+            self.records as f64 / elapsed_min
+        } else {
+            0.0
+        };
 
         if let Some(ref counter) = self.bytes_read {
             let done_frac = counter.load(Ordering::Relaxed) as f64 / self.total_bytes as f64;
             let pct = done_frac * 100.0;
-            let eta_min = if done_frac > 0.0 { elapsed_min * (1.0 / done_frac - 1.0) } else { 0.0 };
+            let eta_min = if done_frac > 0.0 {
+                elapsed_min * (1.0 / done_frac - 1.0)
+            } else {
+                0.0
+            };
             eprintln!(
                 "INFO  ProgressMeter -  {:>13.1}   {:>20}   {:>14.1}   {:>6.1}%   {:>9.1}",
                 elapsed_min,

--- a/crates/fastvep-cli/src/webserver.rs
+++ b/crates/fastvep-cli/src/webserver.rs
@@ -69,7 +69,10 @@ fn send_json(stream: &mut std::net::TcpStream, status: u16, body: &str) -> Resul
          Connection: close\r\n\
          \r\n\
          {}",
-        status, status_text, body.len(), body
+        status,
+        status_text,
+        body.len(),
+        body
     );
     stream.write_all(response.as_bytes())?;
     Ok(())
@@ -94,7 +97,11 @@ fn handle_request(stream: &mut std::net::TcpStream, ctx: &mut AnnotationContext)
         }
         let lower = line.to_ascii_lowercase();
         if lower.starts_with("content-length:") {
-            content_length = lower.trim_start_matches("content-length:").trim().parse().unwrap_or(0);
+            content_length = lower
+                .trim_start_matches("content-length:")
+                .trim()
+                .parse()
+                .unwrap_or(0);
         }
     }
 
@@ -163,8 +170,8 @@ fn handle_request(stream: &mut std::net::TcpStream, ctx: &mut AnnotationContext)
             reader.read_exact(&mut body)?;
             let body_str = String::from_utf8_lossy(&body);
 
-            let request: serde_json::Value = serde_json::from_str(&body_str)
-                .unwrap_or(serde_json::json!({}));
+            let request: serde_json::Value =
+                serde_json::from_str(&body_str).unwrap_or(serde_json::json!({}));
             let vcf_text = request["vcf"].as_str().unwrap_or("");
             let pick = request["pick"].as_bool().unwrap_or(false);
 

--- a/crates/fastvep-cli/tests/cache_synonyms.rs
+++ b/crates/fastvep-cli/tests/cache_synonyms.rs
@@ -28,7 +28,10 @@ const FASTA: &str = ">17\nACGTACGTACGTACGTACGTACGTACGTAC\n";
 const SYNONYMS: &str = "17\tchr17\tNC_000017.11\n";
 
 fn write(path: &Path, contents: &str) {
-    File::create(path).unwrap().write_all(contents.as_bytes()).unwrap();
+    File::create(path)
+        .unwrap()
+        .write_all(contents.as_bytes())
+        .unwrap();
 }
 
 #[test]
@@ -54,11 +57,23 @@ fn merged_cache_with_synonyms_canonicalizes_to_fasta_names() {
     .expect("merged cache build should succeed with a synonyms file");
 
     let transcripts = fastvep_cache::transcript_cache::load_cache(&out).unwrap();
-    assert_eq!(transcripts.len(), 2, "both sources should contribute a transcript");
+    assert_eq!(
+        transcripts.len(),
+        2,
+        "both sources should contribute a transcript"
+    );
     for tr in &transcripts {
         // (b) every transcript canonicalized to the FASTA contig name.
-        assert_eq!(&*tr.chromosome, "17", "transcript {} not canonicalized", tr.stable_id);
-        assert_eq!(&*tr.gene.chromosome, "17", "gene of {} not canonicalized", tr.stable_id);
+        assert_eq!(
+            &*tr.chromosome, "17",
+            "transcript {} not canonicalized",
+            tr.stable_id
+        );
+        assert_eq!(
+            &*tr.gene.chromosome, "17",
+            "gene of {} not canonicalized",
+            tr.stable_id
+        );
         // (c) coding sequences were built for both sources.
         assert!(
             tr.spliced_seq.is_some(),
@@ -91,8 +106,14 @@ fn refseq_unresolved_without_synonyms_but_build_still_succeeds() {
     .expect("build should not fail just because one contig is unresolved");
 
     let transcripts = fastvep_cache::transcript_cache::load_cache(&out).unwrap();
-    let ens_tr = transcripts.iter().find(|t| &*t.stable_id == "ENST1").unwrap();
-    let rs_tr = transcripts.iter().find(|t| &*t.stable_id == "RST1").unwrap();
+    let ens_tr = transcripts
+        .iter()
+        .find(|t| &*t.stable_id == "ENST1")
+        .unwrap();
+    let rs_tr = transcripts
+        .iter()
+        .find(|t| &*t.stable_id == "RST1")
+        .unwrap();
     // Ensembl transcript resolves and gets a sequence.
     assert_eq!(&*ens_tr.chromosome, "17");
     assert!(ens_tr.spliced_seq.is_some());

--- a/crates/fastvep-cli/tests/sa_build_oga.rs
+++ b/crates/fastvep-cli/tests/sa_build_oga.rs
@@ -468,7 +468,11 @@ fn annotate_vcf_replaces_existing_fastvep_info() {
     .unwrap();
 
     let annotated = fs::read_to_string(output_vcf).unwrap();
-    assert_eq!(annotated.matches("##INFO=<ID=CSQ,").count(), 1, "{annotated}");
+    assert_eq!(
+        annotated.matches("##INFO=<ID=CSQ,").count(),
+        1,
+        "{annotated}"
+    );
     assert_eq!(
         annotated.matches("##INFO=<ID=SpliceAI,").count(),
         1,
@@ -628,10 +632,7 @@ fn annotate_tab_emits_fastsa_columns_for_clinvar_and_gnomad() {
     );
 
     // At least one data row carries a populated FV_CLINVAR value at position 25000.
-    let data_rows: Vec<&str> = annotated
-        .lines()
-        .filter(|l| !l.starts_with('#'))
-        .collect();
+    let data_rows: Vec<&str> = annotated.lines().filter(|l| !l.starts_with('#')).collect();
     assert!(!data_rows.is_empty(), "tab output must contain data rows");
     let pos25k = data_rows
         .iter()
@@ -653,8 +654,16 @@ fn annotate_tab_emits_fastsa_columns_for_clinvar_and_gnomad() {
     );
 
     // Sanity: no raw JSON leaked into the tab file.
-    assert!(!annotated.contains('{'), "tab output must not contain raw JSON:\n{}", annotated);
-    assert!(!annotated.contains('}'), "tab output must not contain raw JSON:\n{}", annotated);
+    assert!(
+        !annotated.contains('{'),
+        "tab output must not contain raw JSON:\n{}",
+        annotated
+    );
+    assert!(
+        !annotated.contains('}'),
+        "tab output must not contain raw JSON:\n{}",
+        annotated
+    );
 }
 
 /// Build a minimal ClinVar SA database in a temp dir and return its path.
@@ -801,7 +810,12 @@ fn sa_only_tab_emits_minimal_columns() {
     assert!(!data_rows.is_empty(), "expected sa-only tab data rows");
     for row in &data_rows {
         let cols: Vec<&str> = row.split('\t').collect();
-        assert_eq!(cols.len(), 4, "sa-only tab row must have 4 columns: {}", row);
+        assert_eq!(
+            cols.len(),
+            4,
+            "sa-only tab row must have 4 columns: {}",
+            row
+        );
     }
     let pos25k = data_rows
         .iter()
@@ -889,7 +903,10 @@ fn sa_only_json_omits_transcript_consequences() {
         .as_array()
         .expect("clinvar.significance should be an array");
     assert_eq!(
-        significance.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>(),
+        significance
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>(),
         vec!["Pathogenic"],
         "clinvar.significance should be exactly [\"Pathogenic\"]: {}",
         clinvar
@@ -904,7 +921,10 @@ fn sa_only_json_omits_transcript_consequences() {
         .as_array()
         .expect("clinvar.phenotypes should be an array");
     assert_eq!(
-        phenotypes.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>(),
+        phenotypes
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>(),
         vec!["Breast_cancer"],
         "clinvar.phenotypes mismatch: {}",
         clinvar
@@ -1020,7 +1040,12 @@ fn sa_only_multi_allelic_emits_per_alt_rows_with_independent_sa_columns() {
         .lines()
         .filter(|l| !l.starts_with('#') && l.contains("1:30000\t"))
         .collect();
-    assert_eq!(rows_30k.len(), 2, "expected one row per ALT, got: {:?}", rows_30k);
+    assert_eq!(
+        rows_30k.len(),
+        2,
+        "expected one row per ALT, got: {:?}",
+        rows_30k
+    );
 
     let mut t_row = None;
     let mut a_row = None;
@@ -1165,10 +1190,18 @@ fn sa_only_strips_csq_when_in_middle_of_info_field() {
         .lines()
         .find(|l| !l.starts_with('#'))
         .expect("expected a data row");
-    assert!(!row.contains("CSQ=stale"), "stale CSQ in middle not stripped: {}", row);
+    assert!(
+        !row.contains("CSQ=stale"),
+        "stale CSQ in middle not stripped: {}",
+        row
+    );
     assert!(row.contains("AC=1"), "AC must be preserved: {}", row);
     assert!(row.contains("AF=0.5"), "AF must be preserved: {}", row);
-    assert!(row.contains("FV_CLINVAR="), "FV_CLINVAR must still be added: {}", row);
+    assert!(
+        row.contains("FV_CLINVAR="),
+        "FV_CLINVAR must still be added: {}",
+        row
+    );
 }
 
 #[test]
@@ -1483,4 +1516,3 @@ min_dp = 8
         row_30k
     );
 }
-

--- a/crates/fastvep-cli/tests/sa_build_osa2.rs
+++ b/crates/fastvep-cli/tests/sa_build_osa2.rs
@@ -836,7 +836,7 @@ fn spliceai_v1_v2_output_parity() {
         &[
             ("chr1", 100, "A", "G"),
             ("chr1", 100, "A", "T"),
-            ("chr1", 300, "C", "A"), // multi-gene site
+            ("chr1", 300, "C", "A"),       // multi-gene site
             ("chr2", 200, "GATTACA", "G"), // long variant
         ],
     );
@@ -869,7 +869,10 @@ fn spliceai_osa2_round_trips_scores_positions_and_gene() {
 
     let j = json_at(&reader, "chr1", 100, "A", "G").expect("chr1:100 A>G annotated");
     let v: serde_json::Value = serde_json::from_str(&j).unwrap();
-    assert_eq!(v["gene"], "BRCA1", "gene came back from the string table: {j}");
+    assert_eq!(
+        v["gene"], "BRCA1",
+        "gene came back from the string table: {j}"
+    );
     assert!((v["dsDg"].as_f64().unwrap() - 0.85).abs() < 1e-6, "{j}");
     assert!((v["dsAg"].as_f64().unwrap() - 0.01).abs() < 1e-6, "{j}");
     assert_eq!(v["dpAg"].as_i64(), Some(5), "{j}");
@@ -936,7 +939,10 @@ fn spliceai_json_from_both_formats_deserializes_for_the_acmg_classifier() {
     let v1 = SaReader::open(&v1_base.with_extension("osa")).unwrap();
     let v2 = Osa2Reader::open(&v2_base.with_extension("osa2")).unwrap();
 
-    for reader in [&v1 as &dyn AnnotationProvider, &v2 as &dyn AnnotationProvider] {
+    for reader in [
+        &v1 as &dyn AnnotationProvider,
+        &v2 as &dyn AnnotationProvider,
+    ] {
         let json = match reader.annotate_position("chr1", 100, "A", "G").unwrap() {
             Some(AnnotationValue::Json(j)) | Some(AnnotationValue::Positional(j)) => j,
             other => panic!("expected an annotation, got {other:?}"),
@@ -947,7 +953,10 @@ fn spliceai_json_from_both_formats_deserializes_for_the_acmg_classifier() {
         assert!((data.ds_dg.unwrap() - 0.85).abs() < 1e-6, "{json}");
         assert!((data.ds_ag.unwrap() - 0.01).abs() < 1e-6, "{json}");
         assert_eq!(data.dp_al, Some(-28), "{json}");
-        assert!((data.max_delta_score().unwrap() - 0.85).abs() < 1e-6, "{json}");
+        assert!(
+            (data.max_delta_score().unwrap() - 0.85).abs() < 1e-6,
+            "{json}"
+        );
     }
 }
 
@@ -959,9 +968,8 @@ fn spliceai_osa2_is_much_smaller_than_osa() {
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("spliceai.vcf");
 
-    let mut vcf = String::from(
-        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n",
-    );
+    let mut vcf =
+        String::from("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n");
     for i in 0..20_000u32 {
         let pos = 1000 + i * 3;
         let gene = format!("GENE{}", i % 200);
@@ -999,7 +1007,9 @@ fn spliceai_osa2_is_much_smaller_than_osa() {
     .unwrap();
 
     let v1_bytes = fs::metadata(v1_base.with_extension("osa")).unwrap().len()
-        + fs::metadata(v1_base.with_extension("osa.idx")).unwrap().len();
+        + fs::metadata(v1_base.with_extension("osa.idx"))
+            .unwrap()
+            .len();
     let v2_bytes = fs::metadata(v2_base.with_extension("osa2")).unwrap().len();
     assert!(
         v2_bytes < v1_bytes,
@@ -1107,7 +1117,11 @@ fn custom_vcf_v1_v2_output_parity() {
     let v1 = SaReader::open(&v1_base.with_extension("osa")).unwrap();
     let v2 = Osa2Reader::open(&v2_base.with_extension("osa2")).unwrap();
     assert_eq!(v1.json_key(), "myset");
-    assert_eq!(v2.json_key(), "myset", "the user's --name must survive into v2");
+    assert_eq!(
+        v2.json_key(),
+        "myset",
+        "the user's --name must survive into v2"
+    );
     assert_eq!(v1.name(), v2.name());
 
     for &(chrom, pos, r, a) in &[
@@ -1125,7 +1139,10 @@ fn custom_vcf_v1_v2_output_parity() {
         };
         // Whole-record blob encoding, so this is byte-for-byte, not just
         // numerically equivalent.
-        assert_eq!(j1, j2, "custom_vcf {chrom}:{pos} {r}>{a} must be byte-identical");
+        assert_eq!(
+            j1, j2,
+            "custom_vcf {chrom}:{pos} {r}>{a} must be byte-identical"
+        );
     }
 
     // Explicit INFO-field selection also survives the v2 path.
@@ -1183,18 +1200,29 @@ fn custom_vcf_osa2_sorts_unsorted_input() {
     .unwrap();
 
     let reader = Osa2Reader::open(&out.with_extension("osa2")).unwrap();
-    for (chrom, pos) in [("chr1", 100u64), ("chr1", 200), ("chr1", 9_000_000), ("chr2", 500)] {
+    for (chrom, pos) in [
+        ("chr1", 100u64),
+        ("chr1", 200),
+        ("chr1", 9_000_000),
+        ("chr2", 500),
+    ] {
         assert!(
-            reader.annotate_position(chrom, pos, "A", "G").unwrap().is_some(),
+            reader
+                .annotate_position(chrom, pos, "A", "G")
+                .unwrap()
+                .is_some(),
             "{chrom}:{pos} should be present despite unsorted input"
         );
     }
 }
 
 /// `--format auto` on `source`, returning `(built_osa, built_osa2, built_osi)`.
-fn auto_build_extensions(dir: &std::path::Path, source: &str, input_name: &str, body: &str)
-    -> (bool, bool, bool)
-{
+fn auto_build_extensions(
+    dir: &std::path::Path,
+    source: &str,
+    input_name: &str,
+    body: &str,
+) -> (bool, bool, bool) {
     let input = dir.join(input_name);
     fs::write(&input, body).unwrap();
     let out = dir.join(format!("out_{source}"));
@@ -1249,10 +1277,17 @@ fn format_auto_picks_v2_for_every_variant_level_source() {
 
     // custom_bed is interval-keyed, so it still builds .osi — v2 has no
     // interval container. This is a structural exception, not a gap.
-    let (osa, osa2, osi) =
-        auto_build_extensions(dir.path(), "custom_bed", "regions.bed", "chr1\t100\t200\tfoo\n");
+    let (osa, osa2, osi) = auto_build_extensions(
+        dir.path(),
+        "custom_bed",
+        "regions.bed",
+        "chr1\t100\t200\tfoo\n",
+    );
     assert!(osi, "auto+custom_bed should build .osi");
-    assert!(!osa && !osa2, "auto+custom_bed should build neither .osa nor .osa2");
+    assert!(
+        !osa && !osa2,
+        "auto+custom_bed should build neither .osa nor .osa2"
+    );
 }
 
 #[test]
@@ -1274,8 +1309,14 @@ fn format_osa_remains_the_explicit_v1_escape_hatch() {
         false,
     )
     .unwrap();
-    assert!(out.with_extension("osa").exists(), "--format osa should build .osa");
-    assert!(out.with_extension("osa.idx").exists(), "--format osa should build .osa.idx");
+    assert!(
+        out.with_extension("osa").exists(),
+        "--format osa should build .osa"
+    );
+    assert!(
+        out.with_extension("osa.idx").exists(),
+        "--format osa should build .osa.idx"
+    );
     assert!(
         !out.with_extension("osa2").exists(),
         "--format osa must not build .osa2"
@@ -1283,5 +1324,8 @@ fn format_osa_remains_the_explicit_v1_escape_hatch() {
     // And it is readable through the v1 reader.
     let reader = SaReader::open(&out.with_extension("osa")).unwrap();
     assert_eq!(reader.json_key(), "gnomad");
-    assert!(reader.annotate_position("chr1", 100, "A", "G").unwrap().is_some());
+    assert!(reader
+        .annotate_position("chr1", 100, "A", "G")
+        .unwrap()
+        .is_some());
 }

--- a/crates/fastvep-cli/tests/sa_build_streaming.rs
+++ b/crates/fastvep-cli/tests/sa_build_streaming.rs
@@ -88,8 +88,26 @@ fn streaming_build_detects_gzip_by_magic_bytes_not_extension() {
 
     let out_plain = tmp.path().join("plain_db");
     let out_gz = tmp.path().join("gz_db");
-    run_sa_build("gnomad", plain.to_str().unwrap(), out_plain.to_str().unwrap(), "GRCh38", None, &[], false).unwrap();
-    run_sa_build("gnomad", misnamed.to_str().unwrap(), out_gz.to_str().unwrap(), "GRCh38", None, &[], false).unwrap();
+    run_sa_build(
+        "gnomad",
+        plain.to_str().unwrap(),
+        out_plain.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
+    run_sa_build(
+        "gnomad",
+        misnamed.to_str().unwrap(),
+        out_gz.to_str().unwrap(),
+        "GRCh38",
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
 
     // Magic-byte detection must transparently decompress the misnamed gzip, so
     // both builds produce byte-identical databases. Before the fix the gzip
@@ -144,7 +162,9 @@ fixedStep chrom=chr2 start=50 step=1
         .unwrap()
         .expect("position 101 on chr1 should have a phyloP score");
     match hit {
-        AnnotationValue::Positional(v) => assert!(v.contains("0.75"), "unexpected phyloP value: {v}"),
+        AnnotationValue::Positional(v) => {
+            assert!(v.contains("0.75"), "unexpected phyloP value: {v}")
+        }
         other => panic!("expected a positional phyloP value, got {other:?}"),
     }
     assert!(
@@ -179,7 +199,9 @@ chr1\t200\t-0.5
         .unwrap()
         .expect("position 100 on chr1 should have a GERP score");
     match hit {
-        AnnotationValue::Positional(v) => assert!(v.contains("1.234"), "unexpected GERP value: {v}"),
+        AnnotationValue::Positional(v) => {
+            assert!(v.contains("1.234"), "unexpected GERP value: {v}")
+        }
         other => panic!("expected a positional GERP value, got {other:?}"),
     }
 }

--- a/crates/fastvep-cli/tests/sa_convert.rs
+++ b/crates/fastvep-cli/tests/sa_convert.rs
@@ -42,12 +42,23 @@ fn build_and_convert(
     .unwrap();
 
     let osa = base.with_extension("osa");
-    assert!(osa.exists(), "v1 build should have produced {}", osa.display());
+    assert!(
+        osa.exists(),
+        "v1 build should have produced {}",
+        osa.display()
+    );
     run_sa_convert(osa.to_str().unwrap(), base.to_str().unwrap(), false).unwrap();
 
     let osa2 = base.with_extension("osa2");
-    assert!(osa2.exists(), "conversion should have produced {}", osa2.display());
-    (SaReader::open(&osa).unwrap(), Osa2Reader::open(&osa2).unwrap())
+    assert!(
+        osa2.exists(),
+        "conversion should have produced {}",
+        osa2.display()
+    );
+    (
+        SaReader::open(&osa).unwrap(),
+        Osa2Reader::open(&osa2).unwrap(),
+    )
 }
 
 const CLINVAR_VCF: &str = "\
@@ -122,7 +133,10 @@ fn conversion_preserves_positional_matching() {
     let dir = tempfile::tempdir().unwrap();
     let (v1, v2) = build_and_convert(dir.path(), "phylop", PHYLOP_WIG, "phylop.wig");
 
-    assert!(v2.metadata().is_positional, "positional flag must survive conversion");
+    assert!(
+        v2.metadata().is_positional,
+        "positional flag must survive conversion"
+    );
     assert!(!v2.metadata().match_by_allele);
 
     for pos in [100u64, 101, 102] {
@@ -168,7 +182,10 @@ fn conversion_covers_every_record_not_just_the_queried_ones() {
         checked += 1;
     }
     assert_eq!(checked, expected.len());
-    assert_eq!(checked, 8_000, "sanity: the fixture should span many blocks");
+    assert_eq!(
+        checked, 8_000,
+        "sanity: the fixture should span many blocks"
+    );
 }
 
 #[test]
@@ -178,8 +195,12 @@ fn rejects_inputs_that_have_no_v2_form() {
     // Already v2.
     let osa2 = dir.path().join("already.osa2");
     fs::write(&osa2, b"whatever").unwrap();
-    let err = run_sa_convert(osa2.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
-        .unwrap_err();
+    let err = run_sa_convert(
+        osa2.to_str().unwrap(),
+        dir.path().join("o").to_str().unwrap(),
+        false,
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("already a v2"), "got: {err}");
 
     // Interval- and gene-level databases: v2 is a variant-level container, so
@@ -188,9 +209,12 @@ fn rejects_inputs_that_have_no_v2_form() {
     for (ext, expected) in [("osi", "interval-level"), ("oga", "gene-level")] {
         let path = dir.path().join(format!("db.{ext}"));
         fs::write(&path, b"whatever").unwrap();
-        let err =
-            run_sa_convert(path.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
-                .unwrap_err();
+        let err = run_sa_convert(
+            path.to_str().unwrap(),
+            dir.path().join("o").to_str().unwrap(),
+            false,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains(expected) && err.to_string().contains("variant-level"),
             "expected a {ext}-specific message, got: {err}"
@@ -200,8 +224,12 @@ fn rejects_inputs_that_have_no_v2_form() {
     // Anything else.
     let other = dir.path().join("notes.txt");
     fs::write(&other, b"whatever").unwrap();
-    let err = run_sa_convert(other.to_str().unwrap(), dir.path().join("o").to_str().unwrap(), false)
-        .unwrap_err();
+    let err = run_sa_convert(
+        other.to_str().unwrap(),
+        dir.path().join("o").to_str().unwrap(),
+        false,
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("expects a v1"), "got: {err}");
 }
 
@@ -255,7 +283,10 @@ fn a_failed_conversion_leaves_no_partial_output() {
 
     let out_base = dir.path().join("converted");
     let result = run_sa_convert(osa.to_str().unwrap(), out_base.to_str().unwrap(), false);
-    assert!(result.is_err(), "a truncated .osa must not convert successfully");
+    assert!(
+        result.is_err(),
+        "a truncated .osa must not convert successfully"
+    );
     assert!(
         !out_base.with_extension("osa2").exists(),
         "no partial .osa2 may be left behind"

--- a/crates/fastvep-consequence/src/predictor.rs
+++ b/crates/fastvep-consequence/src/predictor.rs
@@ -107,7 +107,8 @@ impl ConsequencePredictor {
         let mut transcript_consequences = Vec::new();
 
         for transcript in transcripts {
-            let tc = self.predict_transcript(position, ref_allele, alt_alleles, transcript, ref_seq);
+            let tc =
+                self.predict_transcript(position, ref_allele, alt_alleles, transcript, ref_seq);
             transcript_consequences.push(tc);
         }
 
@@ -239,11 +240,16 @@ impl ConsequencePredictor {
                 allele: alt_allele.clone(),
                 consequences,
                 impact,
-                cdna_start: None, cdna_end: None,
-                cds_start: None, cds_end: None,
-                protein_start: None, protein_end: None,
-                amino_acids: None, codons: None,
-                exon: None, intron: None,
+                cdna_start: None,
+                cdna_end: None,
+                cds_start: None,
+                cds_end: None,
+                protein_start: None,
+                protein_end: None,
+                amino_acids: None,
+                codons: None,
+                exon: None,
+                intron: None,
                 distance,
                 protein_length: None,
                 escapes_nmd: None,
@@ -256,10 +262,13 @@ impl ConsequencePredictor {
 
         // 3. Determine exon/intron location
         // Use range-based overlap for exon detection to handle large indels
-        let exon_info = transcript.exon_at(var_start)
+        let exon_info = transcript
+            .exon_at(var_start)
             .or_else(|| transcript.exon_overlapping(var_start, var_end))
             .map(|(i, t)| (i as u32 + 1, t as u32));
-        let intron_info = transcript.intron_at(var_start).map(|(i, t)| (i as u32 + 1, t as u32));
+        let intron_info = transcript
+            .intron_at(var_start)
+            .map(|(i, t)| (i as u32 + 1, t as u32));
 
         let in_exon = exon_info.is_some();
         let in_intron = intron_info.is_some();
@@ -274,7 +283,10 @@ impl ConsequencePredictor {
 
         // Only add extended splice consequences if not already a donor/acceptor
         let is_essential_splice = consequences.iter().any(|c| {
-            matches!(c, Consequence::SpliceDonorVariant | Consequence::SpliceAcceptorVariant)
+            matches!(
+                c,
+                Consequence::SpliceDonorVariant | Consequence::SpliceAcceptorVariant
+            )
         });
 
         if !is_essential_splice {
@@ -290,10 +302,10 @@ impl ConsequencePredictor {
             }
             // VEP excludes splice_region_variant when a more specific splice term is present:
             // splice_donor_region_variant or splice_donor_5th_base_variant
-            if !is_donor_5th && !is_donor_region
-                && splice::is_splice_region(transcript, var_start) {
-                    consequences.push(Consequence::SpliceRegionVariant);
-                }
+            if !is_donor_5th && !is_donor_region && splice::is_splice_region(transcript, var_start)
+            {
+                consequences.push(Consequence::SpliceRegionVariant);
+            }
         }
 
         // 5. Coding vs non-coding transcript
@@ -315,7 +327,8 @@ impl ConsequencePredictor {
                 protein_end = Some(Transcript::cds_to_protein(cds_e));
             }
 
-            let in_coding_region = self.is_in_coding_region(var_start, var_end, coding_start, coding_end);
+            let in_coding_region =
+                self.is_in_coding_region(var_start, var_end, coding_start, coding_end);
             let in_5_utr = self.is_in_5_utr(var_start, var_end, transcript);
             let in_3_utr = self.is_in_3_utr(var_start, var_end, transcript);
 
@@ -374,7 +387,10 @@ impl ConsequencePredictor {
         // PVS1 decision-tree inputs (Abou Tayoun 2018). Both are properties of
         // the transcript and the position, so they are derived here where the
         // exon structure is in hand rather than re-derived downstream.
-        let protein_length = transcript.is_coding().then(|| transcript.peptide_length()).flatten();
+        let protein_length = transcript
+            .is_coding()
+            .then(|| transcript.peptide_length())
+            .flatten();
         let escapes_nmd = if transcript.is_coding() {
             cdna_start.and_then(|p| transcript.escapes_nmd(p))
         } else {
@@ -385,11 +401,16 @@ impl ConsequencePredictor {
             allele: alt_allele.clone(),
             consequences,
             impact,
-            cdna_start, cdna_end,
-            cds_start, cds_end,
-            protein_start, protein_end,
-            amino_acids, codons,
-            exon: exon_info, intron: intron_info,
+            cdna_start,
+            cdna_end,
+            cds_start,
+            cds_end,
+            protein_start,
+            protein_end,
+            amino_acids,
+            codons,
+            exon: exon_info,
+            intron: intron_info,
             distance,
             protein_length,
             escapes_nmd,
@@ -449,7 +470,11 @@ impl ConsequencePredictor {
 
             // Try to compute amino acids and codons from translateable_seq
             let (aa_pair, codon_pair) = self.compute_indel_amino_acids(
-                transcript, cds_pos, ref_allele, alt_allele, is_frameshift,
+                transcript,
+                cds_pos,
+                ref_allele,
+                alt_allele,
+                is_frameshift,
             );
 
             return Some((consequence, aa_pair, codon_pair));
@@ -597,7 +622,11 @@ impl ConsequencePredictor {
             return (None, None);
         }
 
-        let ref_codon = [seq_bytes[codon_start], seq_bytes[codon_start + 1], seq_bytes[codon_start + 2]];
+        let ref_codon = [
+            seq_bytes[codon_start],
+            seq_bytes[codon_start + 1],
+            seq_bytes[codon_start + 2],
+        ];
         let ref_aa = self.codon_table_for(transcript).translate(&ref_codon);
         let ref_aa_str = String::from(ref_aa as char);
 
@@ -665,7 +694,8 @@ impl ConsequencePredictor {
                     }
                     _ => {}
                 }
-                original_codon.iter()
+                original_codon
+                    .iter()
                     .map(|&b| (b as char).to_ascii_lowercase())
                     .collect()
             };
@@ -679,7 +709,10 @@ impl ConsequencePredictor {
                     if transcript.strand == Strand::Reverse {
                         bases = bases.iter().map(|&b| complement(b)).collect();
                     }
-                    bases.iter().map(|&b| (b as char).to_ascii_uppercase()).collect::<String>()
+                    bases
+                        .iter()
+                        .map(|&b| (b as char).to_ascii_uppercase())
+                        .collect::<String>()
                 } else {
                     alt_codon_display
                 };
@@ -707,12 +740,19 @@ impl ConsequencePredictor {
                         // Deletion starts at codon boundary: VEP shows deleted AAs vs "-"
                         let ref_end = (codon_start + del_codons * 3).min(seq_bytes.len());
                         let ref_region = &seq_bytes[codon_start..ref_end];
-                        let ref_aas: String = ref_region.chunks(3)
+                        let ref_aas: String = ref_region
+                            .chunks(3)
                             .filter(|c| c.len() == 3)
-                            .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
+                            .map(|c| {
+                                self.codon_table_for(transcript)
+                                    .translate(&[c[0], c[1], c[2]])
+                                    as char
+                            })
                             .collect();
-                        let ref_codons: String = ref_region.iter()
-                            .map(|&b| (b as char).to_uppercase().next().unwrap()).collect();
+                        let ref_codons: String = ref_region
+                            .iter()
+                            .map(|&b| (b as char).to_uppercase().next().unwrap())
+                            .collect();
                         let aa_pair = Some((ref_aas, "-".to_string()));
                         let codon_pair = Some((ref_codons, "-".to_string()));
                         return (aa_pair, codon_pair);
@@ -721,21 +761,37 @@ impl ConsequencePredictor {
                         let n_ref_codons = del_codons + 1;
                         let ref_end = (codon_start + n_ref_codons * 3).min(seq_bytes.len());
                         let ref_region = &seq_bytes[codon_start..ref_end];
-                        let ref_aas: String = ref_region.chunks(3)
+                        let ref_aas: String = ref_region
+                            .chunks(3)
                             .filter(|c| c.len() == 3)
-                            .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
+                            .map(|c| {
+                                self.codon_table_for(transcript)
+                                    .translate(&[c[0], c[1], c[2]])
+                                    as char
+                            })
                             .collect();
                         let alt_codon_end = (codon_start + 3).min(alt_seq.len());
                         let alt_region = &alt_seq[codon_start..alt_codon_end];
                         let alt_aas: String = if alt_region.len() == 3 {
-                            String::from(self.codon_table_for(transcript).translate(&[alt_region[0], alt_region[1], alt_region[2]]) as char)
+                            String::from(self.codon_table_for(transcript).translate(&[
+                                alt_region[0],
+                                alt_region[1],
+                                alt_region[2],
+                            ]) as char)
                         } else {
                             "-".to_string()
                         };
-                        let ref_codons: String = ref_region.iter()
-                            .map(|&b| (b as char).to_uppercase().next().unwrap()).collect();
-                        let alt_codons: String = if alt_aas == "-" { "-".to_string() } else {
-                            alt_region.iter().map(|&b| (b as char).to_uppercase().next().unwrap()).collect()
+                        let ref_codons: String = ref_region
+                            .iter()
+                            .map(|&b| (b as char).to_uppercase().next().unwrap())
+                            .collect();
+                        let alt_codons: String = if alt_aas == "-" {
+                            "-".to_string()
+                        } else {
+                            alt_region
+                                .iter()
+                                .map(|&b| (b as char).to_uppercase().next().unwrap())
+                                .collect()
                         };
                         let aa_pair = Some((ref_aas, alt_aas));
                         let codon_pair = Some((ref_codons, alt_codons));
@@ -762,16 +818,22 @@ impl ConsequencePredictor {
                     }
 
                     // Ref: the single codon at the insertion point
-                    let ref_codon_str: String = ref_codon.iter()
-                        .map(|&b| (b as char).to_lowercase().next().unwrap()).collect();
+                    let ref_codon_str: String = ref_codon
+                        .iter()
+                        .map(|&b| (b as char).to_lowercase().next().unwrap())
+                        .collect();
 
                     // Alt: translate codons spanning the insertion
                     let ins_codons = (bases.len() / 3) + 1;
                     let alt_end = (codon_start + ins_codons * 3).min(alt_seq.len());
                     let alt_region = &alt_seq[codon_start..alt_end];
-                    let alt_aas: String = alt_region.chunks(3)
+                    let alt_aas: String = alt_region
+                        .chunks(3)
                         .filter(|c| c.len() == 3)
-                        .map(|c| self.codon_table_for(transcript).translate(&[c[0], c[1], c[2]]) as char)
+                        .map(|c| {
+                            self.codon_table_for(transcript)
+                                .translate(&[c[0], c[1], c[2]]) as char
+                        })
                         .collect();
 
                     // Build alt codon string: original bases lowercase, inserted uppercase
@@ -784,7 +846,9 @@ impl ConsequencePredictor {
                     for (i, &b) in alt_region.iter().enumerate() {
                         let is_original = if i < ins_offset_in_codon {
                             true
-                        } else { i >= ins_offset_in_codon + bases.len() };
+                        } else {
+                            i >= ins_offset_in_codon + bases.len()
+                        };
                         if is_original {
                             alt_codon_display.push((b as char).to_lowercase().next().unwrap());
                         } else {
@@ -802,7 +866,12 @@ impl ConsequencePredictor {
         }
     }
 
-    fn distance_to_transcript(&self, var_start: u64, var_end: u64, transcript: &Transcript) -> Option<i64> {
+    fn distance_to_transcript(
+        &self,
+        var_start: u64,
+        var_end: u64,
+        transcript: &Transcript,
+    ) -> Option<i64> {
         // For insertions (end < start), use start for distance calculation
         // since start represents the actual insertion position
         let effective_start = var_start.min(var_end);
@@ -816,7 +885,13 @@ impl ConsequencePredictor {
         }
     }
 
-    fn is_in_coding_region(&self, var_start: u64, var_end: u64, coding_start: u64, coding_end: u64) -> bool {
+    fn is_in_coding_region(
+        &self,
+        var_start: u64,
+        var_end: u64,
+        coding_start: u64,
+        coding_end: u64,
+    ) -> bool {
         var_start <= coding_end && var_end >= coding_start
     }
 
@@ -906,9 +981,33 @@ mod tests {
             end: 5000,
             strand: Strand::Forward,
             exons: vec![
-                Exon { stable_id: "E1".into(), start: 1000, end: 1200, strand: Strand::Forward, phase: -1, end_phase: 0, rank: 1 },
-                Exon { stable_id: "E2".into(), start: 2000, end: 2300, strand: Strand::Forward, phase: 0, end_phase: 1, rank: 2 },
-                Exon { stable_id: "E3".into(), start: 4000, end: 5000, strand: Strand::Forward, phase: 1, end_phase: -1, rank: 3 },
+                Exon {
+                    stable_id: "E1".into(),
+                    start: 1000,
+                    end: 1200,
+                    strand: Strand::Forward,
+                    phase: -1,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "E2".into(),
+                    start: 2000,
+                    end: 2300,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 1,
+                    rank: 2,
+                },
+                Exon {
+                    stable_id: "E3".into(),
+                    start: 4000,
+                    end: 5000,
+                    strand: Strand::Forward,
+                    phase: 1,
+                    end_phase: -1,
+                    rank: 3,
+                },
             ],
             translation: Some(Translation {
                 stable_id: "ENSP00000001".into(),
@@ -927,12 +1026,21 @@ mod tests {
             translateable_seq: Some(translateable),
             peptide: None,
             canonical: true,
-            mane_select: None, mane_plus_clinical: None,
-            tsl: Some(1), appris: None, ccds: None,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: Some(1),
+            appris: None,
+            ccds: None,
             protein_id: Some("ENSP00000001".into()),
             protein_version: None,
-            swissprot: vec![], trembl: vec![], uniparc: vec![],
-            refseq_id: None, source: None, gencode_primary: false, flags: vec![], codon_table_start_phase: 0,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
         }
     }
 
@@ -943,28 +1051,63 @@ mod tests {
             gene: Gene {
                 stable_id: "ENSG_NC".into(),
                 symbol: Some("NCRNA1".into()),
-                symbol_source: None, hgnc_id: None,
+                symbol_source: None,
+                hgnc_id: None,
                 biotype: "lncRNA".into(),
                 chromosome: "chr1".into(),
-                start: 10000, end: 12000,
+                start: 10000,
+                end: 12000,
                 strand: Strand::Forward,
             },
             biotype: "lncRNA".into(),
             chromosome: "chr1".into(),
-            start: 10000, end: 12000,
+            start: 10000,
+            end: 12000,
             strand: Strand::Forward,
             exons: vec![
-                Exon { stable_id: "E1".into(), start: 10000, end: 10500, strand: Strand::Forward, phase: -1, end_phase: -1, rank: 1 },
-                Exon { stable_id: "E2".into(), start: 11500, end: 12000, strand: Strand::Forward, phase: -1, end_phase: -1, rank: 2 },
+                Exon {
+                    stable_id: "E1".into(),
+                    start: 10000,
+                    end: 10500,
+                    strand: Strand::Forward,
+                    phase: -1,
+                    end_phase: -1,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "E2".into(),
+                    start: 11500,
+                    end: 12000,
+                    strand: Strand::Forward,
+                    phase: -1,
+                    end_phase: -1,
+                    rank: 2,
+                },
             ],
             translation: None,
-            cdna_coding_start: None, cdna_coding_end: None,
-            coding_region_start: None, coding_region_end: None,
-            spliced_seq: None, translateable_seq: None, peptide: None,
-            canonical: false, mane_select: None, mane_plus_clinical: None,
-            tsl: None, appris: None, ccds: None, protein_id: None, protein_version: None,
-            swissprot: vec![], trembl: vec![], uniparc: vec![],
-            refseq_id: None, source: None, gencode_primary: false, flags: vec![], codon_table_start_phase: 0,
+            cdna_coding_start: None,
+            cdna_coding_end: None,
+            coding_region_start: None,
+            coding_region_end: None,
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: false,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: None,
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
         }
     }
 
@@ -973,12 +1116,20 @@ mod tests {
         let predictor = ConsequencePredictor::default();
         let tr = make_coding_transcript();
         let pos = GenomicPosition::new("chr1", 500, 500, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         assert_eq!(result.transcript_consequences.len(), 1);
         let tc = &result.transcript_consequences[0];
         assert_eq!(tc.allele_consequences.len(), 1);
-        assert!(tc.allele_consequences[0].consequences.contains(&Consequence::UpstreamGeneVariant));
+        assert!(tc.allele_consequences[0]
+            .consequences
+            .contains(&Consequence::UpstreamGeneVariant));
         assert_eq!(tc.allele_consequences[0].distance, Some(500));
     }
 
@@ -987,10 +1138,18 @@ mod tests {
         let predictor = ConsequencePredictor::default();
         let tr = make_coding_transcript();
         let pos = GenomicPosition::new("chr1", 5500, 5500, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
-        assert!(ac.consequences.contains(&Consequence::DownstreamGeneVariant));
+        assert!(ac
+            .consequences
+            .contains(&Consequence::DownstreamGeneVariant));
         assert_eq!(ac.distance, Some(500));
     }
 
@@ -1000,7 +1159,13 @@ mod tests {
         let tr = make_coding_transcript();
         // Very far away
         let pos = GenomicPosition::new("chr1", 100000, 100000, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(ac.consequences.contains(&Consequence::IntergenicVariant));
@@ -1012,7 +1177,13 @@ mod tests {
         let tr = make_coding_transcript();
         // Position 1020 is in exon1 (1000-1200), before CDS start (1050)
         let pos = GenomicPosition::new("chr1", 1020, 1020, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(ac.consequences.contains(&Consequence::FivePrimeUtrVariant));
@@ -1024,7 +1195,13 @@ mod tests {
         let tr = make_coding_transcript();
         // Position 4600 is in exon3 (4000-5000), after CDS end (4500)
         let pos = GenomicPosition::new("chr1", 4600, 4600, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(ac.consequences.contains(&Consequence::ThreePrimeUtrVariant));
@@ -1036,7 +1213,13 @@ mod tests {
         let tr = make_coding_transcript();
         // Position 1500 is in intron1 (1201-1999), away from splice sites
         let pos = GenomicPosition::new("chr1", 1500, 1500, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(ac.consequences.contains(&Consequence::IntronVariant));
@@ -1048,7 +1231,13 @@ mod tests {
         let tr = make_coding_transcript();
         // Position 1201 is first base of intron1 → splice donor
         let pos = GenomicPosition::new("chr1", 1201, 1201, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("G"), &[Allele::from_str("A")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("G"),
+            &[Allele::from_str("A")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(ac.consequences.contains(&Consequence::SpliceDonorVariant));
@@ -1061,10 +1250,18 @@ mod tests {
         let tr = make_coding_transcript();
         // Position 1999 is last base of intron1 → splice acceptor
         let pos = GenomicPosition::new("chr1", 1999, 1999, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("G"), &[Allele::from_str("A")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("G"),
+            &[Allele::from_str("A")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
-        assert!(ac.consequences.contains(&Consequence::SpliceAcceptorVariant));
+        assert!(ac
+            .consequences
+            .contains(&Consequence::SpliceAcceptorVariant));
         assert_eq!(ac.impact, Impact::High);
     }
 
@@ -1091,7 +1288,8 @@ mod tests {
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(
             ac.consequences.contains(&Consequence::SynonymousVariant),
-            "Expected synonymous, got: {:?}", ac.consequences
+            "Expected synonymous, got: {:?}",
+            ac.consequences
         );
         assert_eq!(ac.impact, Impact::Low);
     }
@@ -1114,7 +1312,8 @@ mod tests {
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(
             ac.consequences.contains(&Consequence::MissenseVariant),
-            "Expected missense, got: {:?}", ac.consequences
+            "Expected missense, got: {:?}",
+            ac.consequences
         );
         assert_eq!(ac.impact, Impact::Moderate);
     }
@@ -1171,7 +1370,8 @@ mod tests {
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(
             ac.consequences.contains(&Consequence::FrameshiftVariant),
-            "Expected frameshift, got: {:?}", ac.consequences
+            "Expected frameshift, got: {:?}",
+            ac.consequences
         );
         assert_eq!(ac.impact, Impact::High);
     }
@@ -1193,7 +1393,8 @@ mod tests {
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(
             ac.consequences.contains(&Consequence::InframeDeletion),
-            "Expected inframe_deletion, got: {:?}", ac.consequences
+            "Expected inframe_deletion, got: {:?}",
+            ac.consequences
         );
         assert_eq!(ac.impact, Impact::Moderate);
     }
@@ -1203,10 +1404,18 @@ mod tests {
         let predictor = ConsequencePredictor::default();
         let tr = make_noncoding_transcript();
         let pos = GenomicPosition::new("chr1", 10100, 10100, Strand::Forward);
-        let result = predictor.predict(&pos, &Allele::from_str("A"), &[Allele::from_str("G")], &[&tr], None);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("A"),
+            &[Allele::from_str("G")],
+            &[&tr],
+            None,
+        );
 
         let ac = &result.transcript_consequences[0].allele_consequences[0];
-        assert!(ac.consequences.contains(&Consequence::NonCodingTranscriptExonVariant));
+        assert!(ac
+            .consequences
+            .contains(&Consequence::NonCodingTranscriptExonVariant));
     }
 
     #[test]
@@ -1227,7 +1436,8 @@ mod tests {
         let ac = &result.transcript_consequences[0].allele_consequences[0];
         assert!(
             ac.consequences.contains(&Consequence::StartLost),
-            "Expected start_lost, got: {:?}", ac.consequences
+            "Expected start_lost, got: {:?}",
+            ac.consequences
         );
     }
 
@@ -1249,9 +1459,13 @@ mod tests {
 
         assert_eq!(result.transcript_consequences.len(), 2);
         // tr1: intron variant
-        assert!(result.transcript_consequences[0].allele_consequences[0].consequences.contains(&Consequence::IntronVariant));
+        assert!(result.transcript_consequences[0].allele_consequences[0]
+            .consequences
+            .contains(&Consequence::IntronVariant));
         // tr2: 8500bp away (>5000), so intergenic
-        assert!(result.transcript_consequences[1].allele_consequences[0].consequences.contains(&Consequence::IntergenicVariant));
+        assert!(result.transcript_consequences[1].allele_consequences[0]
+            .consequences
+            .contains(&Consequence::IntergenicVariant));
     }
 
     #[test]

--- a/crates/fastvep-consequence/src/splice.rs
+++ b/crates/fastvep-consequence/src/splice.rs
@@ -20,44 +20,44 @@ use fastvep_genome::Transcript;
 
 /// Check if a genomic position is in a splice donor site (first 2 intronic bases at 5' of intron).
 pub fn is_splice_donor(transcript: &Transcript, genomic_pos: u64) -> bool {
-    for_each_intron_boundary(transcript, |donor_start, donor_end, _acc_start, _acc_end| {
-        genomic_pos >= donor_start && genomic_pos <= donor_end
-    })
+    for_each_intron_boundary(
+        transcript,
+        |donor_start, donor_end, _acc_start, _acc_end| {
+            genomic_pos >= donor_start && genomic_pos <= donor_end
+        },
+    )
 }
 
 /// Check if a genomic position is in a splice acceptor site (last 2 intronic bases at 3' of intron).
 pub fn is_splice_acceptor(transcript: &Transcript, genomic_pos: u64) -> bool {
-    for_each_intron_boundary(transcript, |_donor_start, _donor_end, acc_start, acc_end| {
-        genomic_pos >= acc_start && genomic_pos <= acc_end
-    })
+    for_each_intron_boundary(
+        transcript,
+        |_donor_start, _donor_end, acc_start, acc_end| {
+            genomic_pos >= acc_start && genomic_pos <= acc_end
+        },
+    )
 }
 
 /// Check if position is the 5th base of the donor site.
 pub fn is_splice_donor_5th_base(transcript: &Transcript, genomic_pos: u64) -> bool {
-    for_each_intron_boundary_extended(
-        transcript,
-        |intron_start, intron_end, is_donor_at_start| {
-            if is_donor_at_start {
-                genomic_pos == intron_start + 4
-            } else {
-                genomic_pos == intron_end - 4
-            }
-        },
-    )
+    for_each_intron_boundary_extended(transcript, |intron_start, intron_end, is_donor_at_start| {
+        if is_donor_at_start {
+            genomic_pos == intron_start + 4
+        } else {
+            genomic_pos == intron_end - 4
+        }
+    })
 }
 
 /// Check if position is in the splice donor region (positions 3-6 of intron).
 pub fn is_splice_donor_region(transcript: &Transcript, genomic_pos: u64) -> bool {
-    for_each_intron_boundary_extended(
-        transcript,
-        |intron_start, intron_end, is_donor_at_start| {
-            if is_donor_at_start {
-                genomic_pos >= intron_start + 2 && genomic_pos <= intron_start + 5
-            } else {
-                genomic_pos >= intron_end - 5 && genomic_pos <= intron_end - 2
-            }
-        },
-    )
+    for_each_intron_boundary_extended(transcript, |intron_start, intron_end, is_donor_at_start| {
+        if is_donor_at_start {
+            genomic_pos >= intron_start + 2 && genomic_pos <= intron_start + 5
+        } else {
+            genomic_pos >= intron_end - 5 && genomic_pos <= intron_end - 2
+        }
+    })
 }
 
 /// Check if position is in the splice polypyrimidine tract (3-17 bases from acceptor).
@@ -66,21 +66,22 @@ pub fn is_splice_donor_region(transcript: &Transcript, genomic_pos: u64) -> bool
 /// (i.e., 3 to 17 bases from the 3' end of the intron), matching the Ensembl definition
 /// of acceptor -3 to acceptor -17.
 pub fn is_splice_polypyrimidine_tract(transcript: &Transcript, genomic_pos: u64) -> bool {
-    for_each_intron_boundary_extended(
-        transcript,
-        |intron_start, intron_end, is_donor_at_start| {
-            // Polypyrimidine tract is near the acceptor end
-            if is_donor_at_start {
-                // Acceptor is at intron_end
-                let acc_region_start = if intron_end >= 16 { intron_end - 16 } else { intron_start };
-                genomic_pos >= acc_region_start && genomic_pos <= intron_end.saturating_sub(2)
+    for_each_intron_boundary_extended(transcript, |intron_start, intron_end, is_donor_at_start| {
+        // Polypyrimidine tract is near the acceptor end
+        if is_donor_at_start {
+            // Acceptor is at intron_end
+            let acc_region_start = if intron_end >= 16 {
+                intron_end - 16
             } else {
-                // Acceptor is at intron_start
-                let acc_region_end = (intron_start + 16).min(intron_end);
-                genomic_pos >= intron_start + 2 && genomic_pos <= acc_region_end
-            }
-        },
-    )
+                intron_start
+            };
+            genomic_pos >= acc_region_start && genomic_pos <= intron_end.saturating_sub(2)
+        } else {
+            // Acceptor is at intron_start
+            let acc_region_end = (intron_start + 16).min(intron_end);
+            genomic_pos >= intron_start + 2 && genomic_pos <= acc_region_end
+        }
+    })
 }
 
 /// Check if position is in a splice region (3-8 bases into intron from either end,
@@ -150,7 +151,11 @@ pub fn is_splice_region(transcript: &Transcript, genomic_pos: u64) -> bool {
         match transcript.strand {
             Strand::Forward => {
                 // Donor exon end
-                let region_start = if donor_exon.end >= 2 { donor_exon.end - 2 } else { donor_exon.start };
+                let region_start = if donor_exon.end >= 2 {
+                    donor_exon.end - 2
+                } else {
+                    donor_exon.start
+                };
                 if genomic_pos >= region_start && genomic_pos <= donor_exon.end {
                     return true;
                 }
@@ -167,7 +172,11 @@ pub fn is_splice_region(transcript: &Transcript, genomic_pos: u64) -> bool {
                     return true;
                 }
                 // Acceptor exon end (higher genomic coord for reverse strand acceptor)
-                let region_start = if acceptor_exon.end >= 2 { acceptor_exon.end - 2 } else { acceptor_exon.start };
+                let region_start = if acceptor_exon.end >= 2 {
+                    acceptor_exon.end - 2
+                } else {
+                    acceptor_exon.start
+                };
                 if genomic_pos >= region_start && genomic_pos <= acceptor_exon.end {
                     return true;
                 }
@@ -212,11 +221,19 @@ where
             Strand::Forward => (
                 intron_start,
                 (intron_start + 1).min(intron_end),
-                if intron_end >= 1 { intron_end - 1 } else { intron_start },
+                if intron_end >= 1 {
+                    intron_end - 1
+                } else {
+                    intron_start
+                },
                 intron_end,
             ),
             Strand::Reverse => (
-                if intron_end >= 1 { intron_end - 1 } else { intron_start },
+                if intron_end >= 1 {
+                    intron_end - 1
+                } else {
+                    intron_start
+                },
                 intron_end,
                 intron_start,
                 (intron_start + 1).min(intron_end),
@@ -299,19 +316,57 @@ mod tests {
             end: 2300,
             strand: Strand::Forward,
             exons: vec![
-                Exon { stable_id: "E1".into(), start: 1000, end: 1200, strand: Strand::Forward, phase: 0, end_phase: 0, rank: 1 },
-                Exon { stable_id: "E2".into(), start: 2000, end: 2300, strand: Strand::Forward, phase: 0, end_phase: 0, rank: 2 },
+                Exon {
+                    stable_id: "E1".into(),
+                    start: 1000,
+                    end: 1200,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "E2".into(),
+                    start: 2000,
+                    end: 2300,
+                    strand: Strand::Forward,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 2,
+                },
             ],
-            translation: Some(Translation { stable_id: "P1".into(), genomic_start: 1000, genomic_end: 2300, start_exon_rank: 1, start_exon_offset: 0, end_exon_rank: 2, end_exon_offset: 300 }),
+            translation: Some(Translation {
+                stable_id: "P1".into(),
+                genomic_start: 1000,
+                genomic_end: 2300,
+                start_exon_rank: 1,
+                start_exon_offset: 0,
+                end_exon_rank: 2,
+                end_exon_offset: 300,
+            }),
             cdna_coding_start: Some(1),
             cdna_coding_end: Some(502),
             coding_region_start: Some(1000),
             coding_region_end: Some(2300),
-            spliced_seq: None, translateable_seq: None, peptide: None,
-            canonical: false, mane_select: None, mane_plus_clinical: None,
-            tsl: None, appris: None, ccds: None, protein_id: None, protein_version: None,
-            swissprot: vec![], trembl: vec![], uniparc: vec![],
-            refseq_id: None, source: None, gencode_primary: false, flags: vec![], codon_table_start_phase: 0,
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: false,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: None,
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
         }
     }
 
@@ -363,7 +418,12 @@ mod tests {
         // Check boundaries
         for pos in 1980..=2000 {
             let in_ppt = is_splice_polypyrimidine_tract(&tr, pos);
-            eprintln!("  pos {} (dist from end = {}): ppt={}", pos, 1999u64.saturating_sub(pos), in_ppt);
+            eprintln!(
+                "  pos {} (dist from end = {}): ppt={}",
+                pos,
+                1999u64.saturating_sub(pos),
+                in_ppt
+            );
         }
 
         // Distance 17 from intron_end(1999) = 1982 = intron_end - 17
@@ -371,10 +431,22 @@ mod tests {
         // But VEP measures from exon boundary (2000):
         //   dist 17 from exon = 2000-17 = 1983 = intron_end - 16
         //   dist 3 from exon = 2000-3 = 1997 = intron_end - 2
-        assert!(is_splice_polypyrimidine_tract(&tr, 1983), "pos 1983 (dist 17 from exon) should be PPT");
-        assert!(is_splice_polypyrimidine_tract(&tr, 1997), "pos 1997 (dist 3 from exon) should be PPT");
-        assert!(!is_splice_polypyrimidine_tract(&tr, 1982), "pos 1982 (dist 18 from exon) should NOT be PPT");
-        assert!(!is_splice_polypyrimidine_tract(&tr, 1998), "pos 1998 (dist 2 from exon) should NOT be PPT - it's the acceptor site");
+        assert!(
+            is_splice_polypyrimidine_tract(&tr, 1983),
+            "pos 1983 (dist 17 from exon) should be PPT"
+        );
+        assert!(
+            is_splice_polypyrimidine_tract(&tr, 1997),
+            "pos 1997 (dist 3 from exon) should be PPT"
+        );
+        assert!(
+            !is_splice_polypyrimidine_tract(&tr, 1982),
+            "pos 1982 (dist 18 from exon) should NOT be PPT"
+        );
+        assert!(
+            !is_splice_polypyrimidine_tract(&tr, 1998),
+            "pos 1998 (dist 2 from exon) should NOT be PPT - it's the acceptor site"
+        );
     }
 
     fn make_reverse_transcript() -> Transcript {
@@ -403,19 +475,57 @@ mod tests {
             end: 2300,
             strand: Strand::Reverse,
             exons: vec![
-                Exon { stable_id: "E1".into(), start: 2000, end: 2300, strand: Strand::Reverse, phase: 0, end_phase: 0, rank: 1 },
-                Exon { stable_id: "E2".into(), start: 1000, end: 1200, strand: Strand::Reverse, phase: 0, end_phase: 0, rank: 2 },
+                Exon {
+                    stable_id: "E1".into(),
+                    start: 2000,
+                    end: 2300,
+                    strand: Strand::Reverse,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "E2".into(),
+                    start: 1000,
+                    end: 1200,
+                    strand: Strand::Reverse,
+                    phase: 0,
+                    end_phase: 0,
+                    rank: 2,
+                },
             ],
-            translation: Some(Translation { stable_id: "P1".into(), genomic_start: 1000, genomic_end: 2300, start_exon_rank: 1, start_exon_offset: 0, end_exon_rank: 2, end_exon_offset: 200 }),
+            translation: Some(Translation {
+                stable_id: "P1".into(),
+                genomic_start: 1000,
+                genomic_end: 2300,
+                start_exon_rank: 1,
+                start_exon_offset: 0,
+                end_exon_rank: 2,
+                end_exon_offset: 200,
+            }),
             cdna_coding_start: Some(1),
             cdna_coding_end: Some(502),
             coding_region_start: Some(1000),
             coding_region_end: Some(2300),
-            spliced_seq: None, translateable_seq: None, peptide: None,
-            canonical: false, mane_select: None, mane_plus_clinical: None,
-            tsl: None, appris: None, ccds: None, protein_id: None, protein_version: None,
-            swissprot: vec![], trembl: vec![], uniparc: vec![],
-            refseq_id: None, source: None, gencode_primary: false, flags: vec![], codon_table_start_phase: 0,
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: false,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: None,
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
         }
     }
 
@@ -430,16 +540,33 @@ mod tests {
 
         for pos in 1199..=1220 {
             let in_ppt = is_splice_polypyrimidine_tract(&tr, pos);
-            eprintln!("  REV pos {} (dist from intron_start=1201: {}): ppt={}", pos, pos as i64 - 1201, in_ppt);
+            eprintln!(
+                "  REV pos {} (dist from intron_start=1201: {}): ppt={}",
+                pos,
+                pos as i64 - 1201,
+                in_ppt
+            );
         }
 
         // c.X-17 = 17 bases from exon boundary = 1200+17 = 1217 = intron_start + 16
-        assert!(is_splice_polypyrimidine_tract(&tr, 1217), "pos 1217 (c.X-17, dist 16 from intron_start) should be PPT");
+        assert!(
+            is_splice_polypyrimidine_tract(&tr, 1217),
+            "pos 1217 (c.X-17, dist 16 from intron_start) should be PPT"
+        );
         // c.X-3 = 3 bases from exon boundary = 1200+3 = 1203 = intron_start + 2
-        assert!(is_splice_polypyrimidine_tract(&tr, 1203), "pos 1203 (c.X-3, dist 2 from intron_start) should be PPT");
+        assert!(
+            is_splice_polypyrimidine_tract(&tr, 1203),
+            "pos 1203 (c.X-3, dist 2 from intron_start) should be PPT"
+        );
         // c.X-18 = 18 bases = 1218 = intron_start + 17
-        assert!(!is_splice_polypyrimidine_tract(&tr, 1218), "pos 1218 (c.X-18) should NOT be PPT");
+        assert!(
+            !is_splice_polypyrimidine_tract(&tr, 1218),
+            "pos 1218 (c.X-18) should NOT be PPT"
+        );
         // c.X-2 = 2 bases = 1202 = intron_start + 1 (acceptor site)
-        assert!(!is_splice_polypyrimidine_tract(&tr, 1202), "pos 1202 (c.X-2, acceptor site) should NOT be PPT");
+        assert!(
+            !is_splice_polypyrimidine_tract(&tr, 1202),
+            "pos 1202 (c.X-2, acceptor site) should NOT be PPT"
+        );
     }
 }

--- a/crates/fastvep-consequence/src/sv_predictor.rs
+++ b/crates/fastvep-consequence/src/sv_predictor.rs
@@ -266,7 +266,9 @@ fn determine_sv_overlap_consequences(
 
 /// Check if the SV interval overlaps any exon's coding region.
 fn hits_coding_region(sv_start: u64, sv_end: u64, transcript: &Transcript) -> bool {
-    if let (Some(cds_start), Some(cds_end)) = (transcript.coding_region_start, transcript.coding_region_end) {
+    if let (Some(cds_start), Some(cds_end)) =
+        (transcript.coding_region_start, transcript.coding_region_end)
+    {
         let coding_start = cds_start.min(cds_end);
         let coding_end = cds_start.max(cds_end);
         sv_start <= coding_end && sv_end >= coding_start
@@ -374,9 +376,14 @@ mod tests {
     fn test_deletion_completely_contains_transcript() {
         let tx = make_coding_transcript(5000, 6000);
         let results = predict_sv_consequences(
-            "chr1", 4000, 7000, VariantType::CopyNumberLoss,
+            "chr1",
+            4000,
+            7000,
+            VariantType::CopyNumberLoss,
             &[Allele::Symbolic("<DEL>".into())],
-            &[&tx], 5000, 5000,
+            &[&tx],
+            5000,
+            5000,
         );
 
         assert_eq!(results.len(), 1);
@@ -388,9 +395,14 @@ mod tests {
     fn test_deletion_partial_overlap() {
         let tx = make_coding_transcript(5000, 6000);
         let results = predict_sv_consequences(
-            "chr1", 5300, 5800, VariantType::CopyNumberLoss,
+            "chr1",
+            5300,
+            5800,
+            VariantType::CopyNumberLoss,
             &[Allele::Symbolic("<DEL>".into())],
-            &[&tx], 5000, 5000,
+            &[&tx],
+            5000,
+            5000,
         );
 
         assert_eq!(results.len(), 1);
@@ -403,9 +415,14 @@ mod tests {
     fn test_duplication_completely_contains() {
         let tx = make_coding_transcript(5000, 6000);
         let results = predict_sv_consequences(
-            "chr1", 4000, 7000, VariantType::TandemDuplication,
+            "chr1",
+            4000,
+            7000,
+            VariantType::TandemDuplication,
             &[Allele::Symbolic("<DUP>".into())],
-            &[&tx], 5000, 5000,
+            &[&tx],
+            5000,
+            5000,
         );
 
         let cons = &results[0].allele_consequences[0].consequences;
@@ -416,9 +433,14 @@ mod tests {
     fn test_sv_no_overlap_upstream() {
         let tx = make_coding_transcript(10000, 11000);
         let results = predict_sv_consequences(
-            "chr1", 5000, 6000, VariantType::CopyNumberLoss,
+            "chr1",
+            5000,
+            6000,
+            VariantType::CopyNumberLoss,
             &[Allele::Symbolic("<DEL>".into())],
-            &[&tx], 5000, 5000,
+            &[&tx],
+            5000,
+            5000,
         );
 
         let cons = &results[0].allele_consequences[0].consequences;

--- a/crates/fastvep-core/src/chrom.rs
+++ b/crates/fastvep-core/src/chrom.rs
@@ -134,7 +134,9 @@ pub fn looks_like_refseq_accession(name: &str) -> bool {
 /// Accepts the common spellings of each assembly (`GRCh38`, `hg38`, `38`,
 /// `b38`, case-insensitively) and tolerates a patch-level suffix
 /// (`GRCh38.p14`), so new NCBI patches keep resolving without a code change.
-pub fn refseq_primary_accessions(assembly: &str) -> Option<&'static [(&'static str, &'static str)]> {
+pub fn refseq_primary_accessions(
+    assembly: &str,
+) -> Option<&'static [(&'static str, &'static str)]> {
     let mut a = assembly.trim().to_ascii_lowercase();
     // Drop a patch-level suffix (`grch38.p14`, `grch38.p15`, …). The primary
     // chromosome accessions are stable across patches of a given major build,
@@ -342,7 +344,11 @@ mod chrom_alias_tests {
             ("MT", "chrM"),
             ("chrMT", "chrM"),
         ] {
-            assert_eq!(map.get(query).map(String::as_str), Some(want), "query {query}");
+            assert_eq!(
+                map.get(query).map(String::as_str),
+                Some(want),
+                "query {query}"
+            );
         }
         // An absent contig resolves to nothing, so callers miss cleanly rather
         // than probing the database with a name it does not contain.
@@ -396,7 +402,15 @@ mod synonym_tests {
 
     #[test]
     fn non_refseq_names_rejected() {
-        for n in ["17", "chr17", "NC_00017", "NC_000017", "X", "", "NX_000017.11"] {
+        for n in [
+            "17",
+            "chr17",
+            "NC_00017",
+            "NC_000017",
+            "X",
+            "",
+            "NX_000017.11",
+        ] {
             assert!(!looks_like_refseq_accession(n), "{} misclassified", n);
         }
     }
@@ -429,7 +443,15 @@ mod synonym_tests {
     fn refseq_primary_accessions_cover_both_assemblies() {
         use super::refseq_primary_accessions;
 
-        for spelling in ["GRCh38", "grch38", "hg38", "38", "b38", "GRCh38.p14", "GRCh38.p15"] {
+        for spelling in [
+            "GRCh38",
+            "grch38",
+            "hg38",
+            "38",
+            "b38",
+            "GRCh38.p14",
+            "GRCh38.p15",
+        ] {
             let table = refseq_primary_accessions(spelling).expect("GRCh38 table");
             assert_eq!(table.len(), 25, "24 chromosomes + MT");
             assert!(table.contains(&("NC_000001.11", "chr1")));

--- a/crates/fastvep-core/src/consequence.rs
+++ b/crates/fastvep-core/src/consequence.rs
@@ -275,9 +275,7 @@ impl Consequence {
             "splice_region_variant" => Some(Self::SpliceRegionVariant),
             "splice_donor_5th_base_variant" => Some(Self::SpliceDonorFifthBaseVariant),
             "splice_donor_region_variant" => Some(Self::SpliceDonorRegionVariant),
-            "splice_polypyrimidine_tract_variant" => {
-                Some(Self::SplicePolypyrimidineTractVariant)
-            }
+            "splice_polypyrimidine_tract_variant" => Some(Self::SplicePolypyrimidineTractVariant),
             "incomplete_terminal_codon_variant" => Some(Self::IncompleteTerminalCodonVariant),
             "start_retained_variant" => Some(Self::StartRetainedVariant),
             "stop_retained_variant" => Some(Self::StopRetainedVariant),
@@ -394,6 +392,9 @@ mod tests {
             Consequence::MissenseVariant,
             Consequence::SynonymousVariant,
         ];
-        assert_eq!(Consequence::most_severe(&cs), Some(Consequence::MissenseVariant));
+        assert_eq!(
+            Consequence::most_severe(&cs),
+            Some(Consequence::MissenseVariant)
+        );
     }
 }

--- a/crates/fastvep-core/src/hgvs.rs
+++ b/crates/fastvep-core/src/hgvs.rs
@@ -29,7 +29,9 @@ pub fn parse_intronic_offset(hgvs_c: &str) -> Option<i64> {
             let mut val: i64 = 0;
             let mut any = false;
             while j < bytes.len() && bytes[j].is_ascii_digit() {
-                val = val.saturating_mul(10).saturating_add((bytes[j] - b'0') as i64);
+                val = val
+                    .saturating_mul(10)
+                    .saturating_add((bytes[j] - b'0') as i64);
                 any = true;
                 j += 1;
             }
@@ -65,7 +67,10 @@ mod tests {
         assert_eq!(parse_intronic_offset("c.*1411T>A"), None);
         // Canonical splice positions.
         assert_eq!(parse_intronic_offset("c.964+1G>A"), Some(1));
-        assert_eq!(parse_intronic_offset("ENST00000378156.9:c.2818-2A>."), Some(-2));
+        assert_eq!(
+            parse_intronic_offset("ENST00000378156.9:c.2818-2A>."),
+            Some(-2)
+        );
         // Deep intronic.
         assert_eq!(parse_intronic_offset("c.4001+12_4001+15del"), Some(12));
         assert_eq!(parse_intronic_offset("n.162-24414C>T"), Some(-24414));

--- a/crates/fastvep-core/src/lib.rs
+++ b/crates/fastvep-core/src/lib.rs
@@ -5,10 +5,10 @@ pub mod hgvs;
 mod position;
 
 pub use annotation_types::{GeneAnnotation, SupplementaryAnnotation};
-pub use hgvs::{is_canonical_dinucleotide_offset, parse_intronic_offset};
 pub use chrom::{
     chrom_alias_map, chrom_aliases, looks_like_refseq_accession, refseq_primary_accessions,
     ChromSynonyms,
 };
 pub use consequence::{Consequence, Impact};
+pub use hgvs::{is_canonical_dinucleotide_offset, parse_intronic_offset};
 pub use position::{Allele, GenomicPosition, Strand, VariantType};

--- a/crates/fastvep-core/src/position.rs
+++ b/crates/fastvep-core/src/position.rs
@@ -135,9 +135,7 @@ impl Allele {
         match s {
             "-" => Allele::Deletion,
             "*" => Allele::Missing,
-            _ if s.starts_with('<') && s.ends_with('>') => {
-                Allele::Symbolic(s.to_string())
-            }
+            _ if s.starts_with('<') && s.ends_with('>') => Allele::Symbolic(s.to_string()),
             _ => Allele::Sequence(s.as_bytes().to_vec()),
         }
     }
@@ -202,10 +200,7 @@ mod tests {
     fn test_allele_from_str() {
         assert_eq!(Allele::from_str("-"), Allele::Deletion);
         assert_eq!(Allele::from_str("*"), Allele::Missing);
-        assert_eq!(
-            Allele::from_str("ACGT"),
-            Allele::Sequence(b"ACGT".to_vec())
-        );
+        assert_eq!(Allele::from_str("ACGT"), Allele::Sequence(b"ACGT".to_vec()));
     }
 
     #[test]

--- a/crates/fastvep-filter/src/evaluator.rs
+++ b/crates/fastvep-filter/src/evaluator.rs
@@ -65,24 +65,18 @@ pub fn evaluate(expr: &FilterExpr, ctx: &FilterContext) -> bool {
             // The actual value might be a single value or ampersand-separated list
             // (VEP uses & to separate multiple consequences)
             let actual_parts: Vec<&str> = actual.split('&').collect();
-            actual_parts.iter().any(|a| {
-                values.iter().any(|v| a.eq_ignore_ascii_case(v))
-            })
+            actual_parts
+                .iter()
+                .any(|a| values.iter().any(|v| a.eq_ignore_ascii_case(v)))
         }
         FilterExpr::Match { field, pattern } => {
             let actual = ctx.get(field);
             // Simple glob-style matching (contains check for basic use)
             actual.contains(pattern)
         }
-        FilterExpr::And(left, right) => {
-            evaluate(left, ctx) && evaluate(right, ctx)
-        }
-        FilterExpr::Or(left, right) => {
-            evaluate(left, ctx) || evaluate(right, ctx)
-        }
-        FilterExpr::Not(inner) => {
-            !evaluate(inner, ctx)
-        }
+        FilterExpr::And(left, right) => evaluate(left, ctx) && evaluate(right, ctx),
+        FilterExpr::Or(left, right) => evaluate(left, ctx) || evaluate(right, ctx),
+        FilterExpr::Not(inner) => !evaluate(inner, ctx),
     }
 }
 
@@ -127,19 +121,35 @@ mod tests {
             field: "Consequence".into(),
             values: vec!["missense_variant".into(), "stop_gained".into()],
         };
-        assert!(evaluate(&expr, &ctx(&[("Consequence", "missense_variant&splice_region_variant")])));
-        assert!(!evaluate(&expr, &ctx(&[("Consequence", "synonymous_variant")])));
+        assert!(evaluate(
+            &expr,
+            &ctx(&[("Consequence", "missense_variant&splice_region_variant")])
+        ));
+        assert!(!evaluate(
+            &expr,
+            &ctx(&[("Consequence", "synonymous_variant")])
+        ));
     }
 
     #[test]
     fn test_and_or_not() {
         let expr = FilterExpr::And(
-            Box::new(FilterExpr::Eq { field: "IMPACT".into(), value: "HIGH".into() }),
-            Box::new(FilterExpr::Not(
-                Box::new(FilterExpr::Eq { field: "CANONICAL".into(), value: "NO".into() }),
-            )),
+            Box::new(FilterExpr::Eq {
+                field: "IMPACT".into(),
+                value: "HIGH".into(),
+            }),
+            Box::new(FilterExpr::Not(Box::new(FilterExpr::Eq {
+                field: "CANONICAL".into(),
+                value: "NO".into(),
+            }))),
         );
-        assert!(evaluate(&expr, &ctx(&[("IMPACT", "HIGH"), ("CANONICAL", "YES")])));
-        assert!(!evaluate(&expr, &ctx(&[("IMPACT", "HIGH"), ("CANONICAL", "NO")])));
+        assert!(evaluate(
+            &expr,
+            &ctx(&[("IMPACT", "HIGH"), ("CANONICAL", "YES")])
+        ));
+        assert!(!evaluate(
+            &expr,
+            &ctx(&[("IMPACT", "HIGH"), ("CANONICAL", "NO")])
+        ));
     }
 }

--- a/crates/fastvep-filter/src/lexer.rs
+++ b/crates/fastvep-filter/src/lexer.rs
@@ -4,18 +4,18 @@ use anyhow::{bail, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
-    Field(String),     // Field name (e.g., IMPACT, AF, Consequence)
-    Value(String),     // String value (e.g., HIGH, missense_variant)
-    Number(f64),       // Numeric value
+    Field(String), // Field name (e.g., IMPACT, AF, Consequence)
+    Value(String), // String value (e.g., HIGH, missense_variant)
+    Number(f64),   // Numeric value
     // Comparison operators
-    Is,                // is, =, eq
-    Ne,                // !=, ne
-    Lt,                // <
-    Gt,                // >
-    Le,                // <=
-    Ge,                // >=
-    In,                // in
-    Match,             // match, ~
+    Is,    // is, =, eq
+    Ne,    // !=, ne
+    Lt,    // <
+    Gt,    // >
+    Le,    // <=
+    Ge,    // >=
+    In,    // in
+    Match, // match, ~
     // Logical operators
     And,
     Or,
@@ -159,8 +159,14 @@ fn consume_word(chars: &mut std::iter::Peekable<std::str::Chars>) -> String {
 fn is_value_position(tokens: &[Token]) -> bool {
     matches!(
         tokens.last(),
-        Some(Token::Is) | Some(Token::Ne) | Some(Token::Lt) | Some(Token::Gt)
-            | Some(Token::Le) | Some(Token::Ge) | Some(Token::In) | Some(Token::Match)
+        Some(Token::Is)
+            | Some(Token::Ne)
+            | Some(Token::Lt)
+            | Some(Token::Gt)
+            | Some(Token::Le)
+            | Some(Token::Ge)
+            | Some(Token::In)
+            | Some(Token::Match)
     )
 }
 
@@ -171,21 +177,23 @@ mod tests {
     #[test]
     fn test_simple_tokens() {
         let tokens = tokenize("IMPACT is HIGH").unwrap();
-        assert_eq!(tokens, vec![
-            Token::Field("IMPACT".into()),
-            Token::Is,
-            Token::Value("HIGH".into()),
-        ]);
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Field("IMPACT".into()),
+                Token::Is,
+                Token::Value("HIGH".into()),
+            ]
+        );
     }
 
     #[test]
     fn test_numeric_comparison() {
         let tokens = tokenize("AF < 0.01").unwrap();
-        assert_eq!(tokens, vec![
-            Token::Field("AF".into()),
-            Token::Lt,
-            Token::Number(0.01),
-        ]);
+        assert_eq!(
+            tokens,
+            vec![Token::Field("AF".into()), Token::Lt, Token::Number(0.01),]
+        );
     }
 
     #[test]
@@ -202,6 +210,9 @@ mod tests {
         let tokens = tokenize("Consequence in missense_variant,stop_gained").unwrap();
         assert_eq!(tokens[0], Token::Field("Consequence".into()));
         assert_eq!(tokens[1], Token::In);
-        assert_eq!(tokens[2], Token::Value("missense_variant,stop_gained".into()));
+        assert_eq!(
+            tokens[2],
+            Token::Value("missense_variant,stop_gained".into())
+        );
     }
 }

--- a/crates/fastvep-filter/src/lib.rs
+++ b/crates/fastvep-filter/src/lib.rs
@@ -22,9 +22,9 @@
 //! - `match` / `~`: regex match
 //! - `and`, `or`, `not`: logical operators
 
+mod evaluator;
 mod lexer;
 mod parser;
-mod evaluator;
 
 pub use evaluator::FilterContext;
 pub use parser::FilterExpr;
@@ -99,7 +99,8 @@ mod tests {
 
     #[test]
     fn test_in_operator() {
-        let f = Filter::parse("Consequence in missense_variant,stop_gained,frameshift_variant").unwrap();
+        let f = Filter::parse("Consequence in missense_variant,stop_gained,frameshift_variant")
+            .unwrap();
         assert!(f.matches(&ctx(&[("Consequence", "missense_variant")])));
         assert!(f.matches(&ctx(&[("Consequence", "stop_gained")])));
         assert!(!f.matches(&ctx(&[("Consequence", "synonymous_variant")])));

--- a/crates/fastvep-filter/src/parser.rs
+++ b/crates/fastvep-filter/src/parser.rs
@@ -168,7 +168,9 @@ fn consume_number(tokens: &[Token], pos: &mut usize) -> Result<f64> {
     }
     let num = match &tokens[*pos] {
         Token::Number(n) => *n,
-        Token::Value(v) => v.parse::<f64>().map_err(|_| anyhow::anyhow!("Expected number, got '{}'", v))?,
+        Token::Value(v) => v
+            .parse::<f64>()
+            .map_err(|_| anyhow::anyhow!("Expected number, got '{}'", v))?,
         other => bail!("Expected number, got {:?}", other),
     };
     *pos += 1;

--- a/crates/fastvep-genome/src/codon.rs
+++ b/crates/fastvep-genome/src/codon.rs
@@ -10,50 +10,90 @@ impl CodonTable {
     pub fn standard() -> Self {
         let codons = [
             // Phe
-            (b"TTT", b'F'), (b"TTC", b'F'),
+            (b"TTT", b'F'),
+            (b"TTC", b'F'),
             // Leu
-            (b"TTA", b'L'), (b"TTG", b'L'), (b"CTT", b'L'), (b"CTC", b'L'),
-            (b"CTA", b'L'), (b"CTG", b'L'),
+            (b"TTA", b'L'),
+            (b"TTG", b'L'),
+            (b"CTT", b'L'),
+            (b"CTC", b'L'),
+            (b"CTA", b'L'),
+            (b"CTG", b'L'),
             // Ile
-            (b"ATT", b'I'), (b"ATC", b'I'), (b"ATA", b'I'),
+            (b"ATT", b'I'),
+            (b"ATC", b'I'),
+            (b"ATA", b'I'),
             // Met (start)
             (b"ATG", b'M'),
             // Val
-            (b"GTT", b'V'), (b"GTC", b'V'), (b"GTA", b'V'), (b"GTG", b'V'),
+            (b"GTT", b'V'),
+            (b"GTC", b'V'),
+            (b"GTA", b'V'),
+            (b"GTG", b'V'),
             // Ser
-            (b"TCT", b'S'), (b"TCC", b'S'), (b"TCA", b'S'), (b"TCG", b'S'),
-            (b"AGT", b'S'), (b"AGC", b'S'),
+            (b"TCT", b'S'),
+            (b"TCC", b'S'),
+            (b"TCA", b'S'),
+            (b"TCG", b'S'),
+            (b"AGT", b'S'),
+            (b"AGC", b'S'),
             // Pro
-            (b"CCT", b'P'), (b"CCC", b'P'), (b"CCA", b'P'), (b"CCG", b'P'),
+            (b"CCT", b'P'),
+            (b"CCC", b'P'),
+            (b"CCA", b'P'),
+            (b"CCG", b'P'),
             // Thr
-            (b"ACT", b'T'), (b"ACC", b'T'), (b"ACA", b'T'), (b"ACG", b'T'),
+            (b"ACT", b'T'),
+            (b"ACC", b'T'),
+            (b"ACA", b'T'),
+            (b"ACG", b'T'),
             // Ala
-            (b"GCT", b'A'), (b"GCC", b'A'), (b"GCA", b'A'), (b"GCG", b'A'),
+            (b"GCT", b'A'),
+            (b"GCC", b'A'),
+            (b"GCA", b'A'),
+            (b"GCG", b'A'),
             // Tyr
-            (b"TAT", b'Y'), (b"TAC", b'Y'),
+            (b"TAT", b'Y'),
+            (b"TAC", b'Y'),
             // Stop
-            (b"TAA", b'*'), (b"TAG", b'*'), (b"TGA", b'*'),
+            (b"TAA", b'*'),
+            (b"TAG", b'*'),
+            (b"TGA", b'*'),
             // His
-            (b"CAT", b'H'), (b"CAC", b'H'),
+            (b"CAT", b'H'),
+            (b"CAC", b'H'),
             // Gln
-            (b"CAA", b'Q'), (b"CAG", b'Q'),
+            (b"CAA", b'Q'),
+            (b"CAG", b'Q'),
             // Asn
-            (b"AAT", b'N'), (b"AAC", b'N'),
+            (b"AAT", b'N'),
+            (b"AAC", b'N'),
             // Lys
-            (b"AAA", b'K'), (b"AAG", b'K'),
+            (b"AAA", b'K'),
+            (b"AAG", b'K'),
             // Asp
-            (b"GAT", b'D'), (b"GAC", b'D'),
+            (b"GAT", b'D'),
+            (b"GAC", b'D'),
             // Glu
-            (b"GAA", b'E'), (b"GAG", b'E'),
+            (b"GAA", b'E'),
+            (b"GAG", b'E'),
             // Cys
-            (b"TGT", b'C'), (b"TGC", b'C'),
+            (b"TGT", b'C'),
+            (b"TGC", b'C'),
             // Trp
             (b"TGG", b'W'),
             // Arg
-            (b"CGT", b'R'), (b"CGC", b'R'), (b"CGA", b'R'), (b"CGG", b'R'),
-            (b"AGA", b'R'), (b"AGG", b'R'),
+            (b"CGT", b'R'),
+            (b"CGC", b'R'),
+            (b"CGA", b'R'),
+            (b"CGG", b'R'),
+            (b"AGA", b'R'),
+            (b"AGG", b'R'),
             // Gly
-            (b"GGT", b'G'), (b"GGC", b'G'), (b"GGA", b'G'), (b"GGG", b'G'),
+            (b"GGT", b'G'),
+            (b"GGC", b'G'),
+            (b"GGA", b'G'),
+            (b"GGG", b'G'),
         ];
 
         let mut table = HashMap::with_capacity(64);

--- a/crates/fastvep-genome/src/transcript.rs
+++ b/crates/fastvep-genome/src/transcript.rs
@@ -139,7 +139,8 @@ impl Transcript {
                 return Some(residues);
             }
         }
-        let cds_len = self.cdna_coding_end?.checked_sub(self.cdna_coding_start?)? + 1
+        let cds_len = self.cdna_coding_end?.checked_sub(self.cdna_coding_start?)?
+            + 1
             + self.codon_table_start_phase;
         // A complete CDS ends in a stop codon, which is not a residue.
         (cds_len / 3).checked_sub(1).filter(|n| *n > 0)
@@ -507,7 +508,11 @@ mod tests {
     fn test_peptide_length_prefers_the_translated_peptide() {
         let mut tr = make_test_transcript();
         tr.peptide = Some("MKVLA*".to_string());
-        assert_eq!(tr.peptide_length(), Some(5), "the stop codon is not a residue");
+        assert_eq!(
+            tr.peptide_length(),
+            Some(5),
+            "the stop codon is not a residue"
+        );
     }
 
     #[test]
@@ -524,9 +529,21 @@ mod tests {
         // Exons are 201 + 301 + 1001 = 1503 cDNA bases, so the final
         // exon-exon junction sits at cDNA position 502.
         let tr = make_test_transcript();
-        assert_eq!(tr.escapes_nmd(452), Some(false), "51 nt upstream of the junction decays");
-        assert_eq!(tr.escapes_nmd(453), Some(true), "50 nt upstream is the escape window");
-        assert_eq!(tr.escapes_nmd(502), Some(true), "the junction itself escapes");
+        assert_eq!(
+            tr.escapes_nmd(452),
+            Some(false),
+            "51 nt upstream of the junction decays"
+        );
+        assert_eq!(
+            tr.escapes_nmd(453),
+            Some(true),
+            "50 nt upstream is the escape window"
+        );
+        assert_eq!(
+            tr.escapes_nmd(502),
+            Some(true),
+            "the junction itself escapes"
+        );
         assert_eq!(tr.escapes_nmd(900), Some(true), "the last exon escapes");
         assert_eq!(tr.escapes_nmd(10), Some(false), "far upstream decays");
     }
@@ -610,7 +627,9 @@ mod tests {
                     // UTR: first 50 bases, CDS starts at offset 50
                     let mut seq = vec![b'N'; len];
                     // Put ATG at offset 50 (genomic 1050)
-                    seq[50] = b'A'; seq[51] = b'T'; seq[52] = b'G';
+                    seq[50] = b'A';
+                    seq[51] = b'T';
+                    seq[52] = b'G';
                     // Fill rest of CDS with GCT (Ala)
                     for (i, base) in seq.iter_mut().enumerate().skip(53) {
                         *base = b"GCT"[(i - 53) % 3];
@@ -645,15 +664,24 @@ mod tests {
 
         let ts = tr.translateable_seq.as_ref().unwrap();
         // translateable_seq should start with ATG
-        assert!(ts.starts_with("ATG"), "translateable_seq starts with: {}", &ts[..6]);
+        assert!(
+            ts.starts_with("ATG"),
+            "translateable_seq starts with: {}",
+            &ts[..6]
+        );
         // Length should be cdna_coding_end - cdna_coding_start + 1 = 952 - 51 + 1 = 902
         // Actually: cdna_coding_end = 952 in the test fixture
-        let expected_len = (tr.cdna_coding_end.unwrap() - tr.cdna_coding_start.unwrap() + 1) as usize;
+        let expected_len =
+            (tr.cdna_coding_end.unwrap() - tr.cdna_coding_start.unwrap() + 1) as usize;
         // Wait, the slice is [cs-1..ce] which is ce - (cs-1) = ce - cs + 1 items
         assert_eq!(ts.len(), expected_len);
 
         let peptide = tr.peptide.as_ref().unwrap();
         // Peptide should start with M (Met)
-        assert!(peptide.starts_with('M'), "peptide starts with: {}", &peptide[..1]);
+        assert!(
+            peptide.starts_with('M'),
+            "peptide starts with: {}",
+            &peptide[..1]
+        );
     }
 }

--- a/crates/fastvep-hgvs/src/coding.rs
+++ b/crates/fastvep-hgvs/src/coding.rs
@@ -13,7 +13,17 @@ pub fn hgvsc(
     coding_start: u64,
     coding_end: Option<u64>,
 ) -> Option<String> {
-    hgvsc_with_seq(transcript_id, cdna_start, cdna_end, ref_allele, alt_allele, coding_start, coding_end, None, 0)
+    hgvsc_with_seq(
+        transcript_id,
+        cdna_start,
+        cdna_end,
+        ref_allele,
+        alt_allele,
+        coding_start,
+        coding_end,
+        None,
+        0,
+    )
 }
 
 /// Generate HGVSc with optional 3' shifting for deletions/insertions.
@@ -42,9 +52,9 @@ pub fn hgvsc_with_seq(
     // For coding region: position = cdna - coding_start + 1 + start_phase (1-based)
     // start_phase accounts for incomplete start codons (Ensembl convention)
     let cds_pos_start = if (cdna_start as i64) < (coding_start as i64) {
-        cdna_start as i64 - coding_start as i64  // 5'UTR: no phase
+        cdna_start as i64 - coding_start as i64 // 5'UTR: no phase
     } else {
-        cdna_start as i64 - coding_start as i64 + 1 + start_phase as i64  // CDS: with phase
+        cdna_start as i64 - coding_start as i64 + 1 + start_phase as i64 // CDS: with phase
     };
     let cds_pos_end = if (cdna_end as i64) < (coding_start as i64) {
         cdna_end as i64 - coding_start as i64
@@ -77,10 +87,7 @@ pub fn hgvsc_with_seq(
         {
             format!(
                 "{}{}{}>{}",
-                prefix,
-                pos_str,
-                ref_bases[0] as char,
-                alt_bases[0] as char
+                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char
             )
         }
         // Deletion — apply HGVS 3' shifting in repetitive regions
@@ -90,8 +97,8 @@ pub fn hgvsc_with_seq(
             let (shifted_start, shifted_end) = if let Some(seq) = spliced_seq {
                 let seq_bytes = seq.as_bytes();
                 let mut s = (cdna_start - 1) as usize; // 0-based start
-                let mut e = (cdna_end - 1) as usize;   // 0-based end (inclusive)
-                // Shift right while the base at position end+1 matches base at start
+                let mut e = (cdna_end - 1) as usize; // 0-based end (inclusive)
+                                                     // Shift right while the base at position end+1 matches base at start
                 while e + 1 < seq_bytes.len()
                     && seq_bytes[e + 1].eq_ignore_ascii_case(&seq_bytes[s])
                 {
@@ -147,7 +154,7 @@ pub fn hgvsc_with_seq(
         // Insertion — normalize coordinates: ensure ins_before < ins_after
         (Allele::Deletion, Allele::Sequence(alt_bases)) => {
             let ins_before_cdna = cdna_start.min(cdna_end); // base before insertion
-            let ins_after_cdna = cdna_start.max(cdna_end);   // base after insertion
+            let ins_after_cdna = cdna_start.max(cdna_end); // base after insertion
             let ins_before_cds = cds_pos_start.min(cds_pos_end);
             let ins_after_cds = cds_pos_start.max(cds_pos_end);
 
@@ -159,7 +166,9 @@ pub fn hgvsc_with_seq(
                 // Check preceding sequence
                 let dup_before = if before_pos + 1 >= ins_len && before_pos < seq_bytes.len() {
                     let preceding = &seq_bytes[before_pos + 1 - ins_len..before_pos + 1];
-                    preceding.iter().zip(alt_bases.iter())
+                    preceding
+                        .iter()
+                        .zip(alt_bases.iter())
                         .all(|(a, b)| a.eq_ignore_ascii_case(b))
                 } else {
                     false
@@ -169,7 +178,9 @@ pub fn hgvsc_with_seq(
                     let after_pos = ins_after_cdna as usize; // 0-based index of base after insertion
                     if after_pos + ins_len <= seq_bytes.len() {
                         let following = &seq_bytes[after_pos..after_pos + ins_len];
-                        following.iter().zip(alt_bases.iter())
+                        following
+                            .iter()
+                            .zip(alt_bases.iter())
                             .all(|(a, b)| a.eq_ignore_ascii_case(b))
                     } else {
                         false
@@ -261,10 +272,15 @@ pub fn hgvsc_intronic(
     coding_end: Option<u64>,
 ) -> Option<String> {
     hgvsc_intronic_range(
-        transcript_id, nearest_exon_cdna_pos, intron_offset,
+        transcript_id,
+        nearest_exon_cdna_pos,
+        intron_offset,
         None, // end_cdna_pos
         None, // end_offset
-        ref_allele, alt_allele, coding_start, coding_end,
+        ref_allele,
+        alt_allele,
+        coding_start,
+        coding_end,
     )
 }
 
@@ -291,7 +307,11 @@ pub fn hgvsc_intronic_range(
     // For 5'UTR positions: cds_pos = cdna - coding_start (no +1, since there's no position 0;
     //   position -1 = last 5'UTR base at cdna = coding_start - 1)
     let raw_cds_pos = nearest_exon_cdna_pos as i64 - coding_start as i64 + 1;
-    let cds_pos = if raw_cds_pos <= 0 { raw_cds_pos - 1 } else { raw_cds_pos };
+    let cds_pos = if raw_cds_pos <= 0 {
+        raw_cds_pos - 1
+    } else {
+        raw_cds_pos
+    };
 
     // Build the position string with offset
     let pos_str = if cds_pos < 0 {
@@ -320,8 +340,10 @@ pub fn hgvsc_intronic_range(
         (Allele::Sequence(ref_bases), Allele::Sequence(alt_bases))
             if ref_bases.len() == 1 && alt_bases.len() == 1 =>
         {
-            format!("{}{}{}>{}",
-                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char)
+            format!(
+                "{}{}{}>{}",
+                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char
+            )
         }
         (Allele::Sequence(ref_bases), Allele::Deletion) => {
             // A single-base deletion, or one with no end offset from the
@@ -333,12 +355,18 @@ pub fn hgvsc_intronic_range(
                 let e_raw = e_cdna as i64 - coding_start as i64 + 1;
                 let e_cds = if e_raw <= 0 { e_raw - 1 } else { e_raw };
                 let end_pos_str = if e_cds < 0 {
-                    if e_offset > 0 { format!("{}+{}", e_cds, e_offset) }
-                    else { format!("{}{}", e_cds, e_offset) }
+                    if e_offset > 0 {
+                        format!("{}+{}", e_cds, e_offset)
+                    } else {
+                        format!("{}{}", e_cds, e_offset)
+                    }
                 } else if coding_end.is_some_and(|ce| e_cdna > ce) {
                     let utr = e_cdna - coding_end.unwrap();
-                    if e_offset > 0 { format!("*{}+{}", utr, e_offset) }
-                    else { format!("*{}{}", utr, e_offset) }
+                    if e_offset > 0 {
+                        format!("*{}+{}", utr, e_offset)
+                    } else {
+                        format!("*{}{}", utr, e_offset)
+                    }
                 } else if e_offset > 0 {
                     format!("{}+{}", e_cds, e_offset)
                 } else {
@@ -348,8 +376,8 @@ pub fn hgvsc_intronic_range(
                 // For same-sign offsets: smaller absolute value first (closer to exon)
                 // For positive: +4035 before +4038
                 // For negative: -2625 before -2616
-                let same_sign = (intron_offset > 0 && e_offset > 0)
-                    || (intron_offset < 0 && e_offset < 0);
+                let same_sign =
+                    (intron_offset > 0 && e_offset > 0) || (intron_offset < 0 && e_offset < 0);
                 let (start_str, end_str) = if same_sign && intron_offset >= e_offset {
                     (end_pos_str, pos_str.clone())
                 } else {
@@ -368,10 +396,18 @@ pub fn hgvsc_intronic_range(
                 let raw = cdna as i64 - coding_start as i64 + 1;
                 let cp = if raw <= 0 { raw - 1 } else { raw }; // skip position 0 for 5'UTR
                 if cp < 0 {
-                    if off > 0 { format!("{}+{}", cp, off) } else { format!("{}{}", cp, off) }
+                    if off > 0 {
+                        format!("{}+{}", cp, off)
+                    } else {
+                        format!("{}{}", cp, off)
+                    }
                 } else if coding_end.is_some_and(|ce| cdna > ce) {
                     let u = cdna - coding_end.unwrap();
-                    if off > 0 { format!("*{}+{}", u, off) } else { format!("*{}{}", u, off) }
+                    if off > 0 {
+                        format!("*{}+{}", u, off)
+                    } else {
+                        format!("*{}{}", u, off)
+                    }
                 } else if off > 0 {
                     format!("{}+{}", cp, off)
                 } else {
@@ -399,7 +435,11 @@ pub fn hgvsc_noncoding(
     alt_allele: &Allele,
 ) -> Option<String> {
     let prefix = format!("{}:n.", transcript_id);
-    let (pos_min, pos_max) = if cdna_start <= cdna_end { (cdna_start, cdna_end) } else { (cdna_end, cdna_start) };
+    let (pos_min, pos_max) = if cdna_start <= cdna_end {
+        (cdna_start, cdna_end)
+    } else {
+        (cdna_end, cdna_start)
+    };
     let pos_str = if pos_min == pos_max {
         format!("{}", pos_min)
     } else {
@@ -410,20 +450,30 @@ pub fn hgvsc_noncoding(
         (Allele::Sequence(ref_bases), Allele::Sequence(alt_bases))
             if ref_bases.len() == 1 && alt_bases.len() == 1 =>
         {
-            format!("{}{}{}>{}",
-                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char)
+            format!(
+                "{}{}{}>{}",
+                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char
+            )
         }
         (Allele::Sequence(_), Allele::Deletion) => {
             format!("{}{}del", prefix, pos_str)
         }
         (Allele::Deletion, Allele::Sequence(alt_bases)) => {
             let ins_pos = format!("{}_{}", pos_max, pos_max + 1);
-            format!("{}{}ins{}",
-                prefix, ins_pos, std::str::from_utf8(alt_bases).unwrap_or("?"))
+            format!(
+                "{}{}ins{}",
+                prefix,
+                ins_pos,
+                std::str::from_utf8(alt_bases).unwrap_or("?")
+            )
         }
         (Allele::Sequence(_), Allele::Sequence(alt_bases)) => {
-            format!("{}{}delins{}",
-                prefix, pos_str, std::str::from_utf8(alt_bases).unwrap_or("?"))
+            format!(
+                "{}{}delins{}",
+                prefix,
+                pos_str,
+                std::str::from_utf8(alt_bases).unwrap_or("?")
+            )
         }
         _ => return None,
     };
@@ -439,8 +489,13 @@ pub fn hgvsc_noncoding_intronic(
     alt_allele: &Allele,
 ) -> Option<String> {
     hgvsc_noncoding_intronic_range(
-        transcript_id, nearest_exon_cdna_pos, intron_offset,
-        None, None, ref_allele, alt_allele,
+        transcript_id,
+        nearest_exon_cdna_pos,
+        intron_offset,
+        None,
+        None,
+        ref_allele,
+        alt_allele,
     )
 }
 
@@ -465,8 +520,10 @@ pub fn hgvsc_noncoding_intronic_range(
         (Allele::Sequence(ref_bases), Allele::Sequence(alt_bases))
             if ref_bases.len() == 1 && alt_bases.len() == 1 =>
         {
-            format!("{}{}{}>{}",
-                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char)
+            format!(
+                "{}{}{}>{}",
+                prefix, pos_str, ref_bases[0] as char, alt_bases[0] as char
+            )
         }
         (Allele::Sequence(ref_bases), Allele::Deletion) => {
             // A single-base deletion, or one with no end offset from the
@@ -514,10 +571,12 @@ mod tests {
     fn test_hgvsc_snv() {
         let result = hgvsc(
             "ENST00000001",
-            151, 151,
+            151,
+            151,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Sequence(b"G".to_vec()),
-            51, None,
+            51,
+            None,
         );
         assert_eq!(result, Some("ENST00000001:c.101A>G".to_string()));
     }
@@ -526,10 +585,12 @@ mod tests {
     fn test_hgvsc_deletion() {
         let result = hgvsc(
             "ENST00000001",
-            54, 56,
+            54,
+            56,
             &Allele::Sequence(b"ACG".to_vec()),
             &Allele::Deletion,
-            51, None,
+            51,
+            None,
         );
         assert_eq!(result, Some("ENST00000001:c.4_6del".to_string()));
     }
@@ -538,10 +599,12 @@ mod tests {
     fn test_hgvsc_insertion() {
         let result = hgvsc(
             "ENST00000001",
-            54, 53,
+            54,
+            53,
             &Allele::Deletion,
             &Allele::Sequence(b"TTT".to_vec()),
-            51, None,
+            51,
+            None,
         );
         assert_eq!(result, Some("ENST00000001:c.3_4insTTT".to_string()));
     }
@@ -550,10 +613,12 @@ mod tests {
     fn test_hgvsc_5_utr() {
         let result = hgvsc(
             "ENST00000001",
-            10, 10,
+            10,
+            10,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Sequence(b"G".to_vec()),
-            51, None,
+            51,
+            None,
         );
         // 5'UTR: position = cdna - coding_start = 10 - 51 = -41
         assert_eq!(result, Some("ENST00000001:c.-41A>G".to_string()));
@@ -564,10 +629,12 @@ mod tests {
         // coding_end = 1003 in cDNA, variant at cDNA 1021
         let result = hgvsc(
             "ENST00000001",
-            1021, 1021,
+            1021,
+            1021,
             &Allele::Sequence(b"G".to_vec()),
             &Allele::Sequence(b"A".to_vec()),
-            51, Some(1003),
+            51,
+            Some(1003),
         );
         // utr_offset = 1021 - 1003 = 18
         assert_eq!(result, Some("ENST00000001:c.*18G>A".to_string()));
@@ -580,10 +647,12 @@ mod tests {
         // CDS pos = 201 - 51 + 1 = 151
         let result = hgvsc_intronic(
             "ENST00000001",
-            201, 5,
+            201,
+            5,
             &Allele::Sequence(b"G".to_vec()),
             &Allele::Sequence(b"A".to_vec()),
-            51, None,
+            51,
+            None,
         );
         assert_eq!(result, Some("ENST00000001:c.151+5G>A".to_string()));
     }
@@ -595,10 +664,12 @@ mod tests {
         // CDS pos = 202 - 51 + 1 = 152
         let result = hgvsc_intronic(
             "ENST00000001",
-            202, -3,
+            202,
+            -3,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Sequence(b"G".to_vec()),
-            51, None,
+            51,
+            None,
         );
         assert_eq!(result, Some("ENST00000001:c.152-3A>G".to_string()));
     }
@@ -611,11 +682,14 @@ mod tests {
         let seq = "AACTTTTGA";
         let result = hgvsc_with_seq(
             "ENST00000001",
-            4, 4, // cdna_start=4, cdna_end=4 (the first T in TTTT)
+            4,
+            4, // cdna_start=4, cdna_end=4 (the first T in TTTT)
             &Allele::Sequence(b"T".to_vec()),
             &Allele::Deletion,
-            1, None,
-            Some(seq), 0,
+            1,
+            None,
+            Some(seq),
+            0,
         );
         // Should shift from pos 4 to pos 7 (last T in the TTTT run)
         assert_eq!(result, Some("ENST00000001:c.7del".to_string()));
@@ -627,11 +701,14 @@ mod tests {
         let seq = "ACGTACGT";
         let result = hgvsc_with_seq(
             "ENST00000001",
-            1, 1,
+            1,
+            1,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Deletion,
-            1, None,
-            Some(seq), 0,
+            1,
+            None,
+            Some(seq),
+            0,
         );
         assert_eq!(result, Some("ENST00000001:c.1del".to_string()));
     }
@@ -640,7 +717,8 @@ mod tests {
     fn test_hgvsc_noncoding_snv() {
         let result = hgvsc_noncoding(
             "ENST00000472807.5",
-            100, 100,
+            100,
+            100,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Sequence(b"G".to_vec()),
         );

--- a/crates/fastvep-hgvs/src/genomic.rs
+++ b/crates/fastvep-hgvs/src/genomic.rs
@@ -5,7 +5,13 @@ use fastvep_core::Allele;
 /// Format: chromosome:g.positionREF>ALT (for SNVs)
 ///         chromosome:g.start_enddelREF (for deletions)
 ///         chromosome:g.pos_pos+1insALT (for insertions)
-pub fn hgvsg(chrom: &str, start: u64, end: u64, ref_allele: &Allele, alt_allele: &Allele) -> String {
+pub fn hgvsg(
+    chrom: &str,
+    start: u64,
+    end: u64,
+    ref_allele: &Allele,
+    alt_allele: &Allele,
+) -> String {
     let prefix = format!("{}:g.", chrom);
 
     match (ref_allele, alt_allele) {
@@ -15,10 +21,7 @@ pub fn hgvsg(chrom: &str, start: u64, end: u64, ref_allele: &Allele, alt_allele:
         {
             format!(
                 "{}{}{}>{}",
-                prefix,
-                start,
-                ref_bases[0] as char,
-                alt_bases[0] as char
+                prefix, start, ref_bases[0] as char, alt_bases[0] as char
             )
         }
         // Deletion
@@ -82,7 +85,9 @@ mod tests {
     #[test]
     fn test_hgvsg_snv() {
         let result = hgvsg(
-            "chr1", 12345, 12345,
+            "chr1",
+            12345,
+            12345,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Sequence(b"G".to_vec()),
         );
@@ -92,7 +97,9 @@ mod tests {
     #[test]
     fn test_hgvsg_deletion_single() {
         let result = hgvsg(
-            "chr1", 100, 100,
+            "chr1",
+            100,
+            100,
             &Allele::Sequence(b"A".to_vec()),
             &Allele::Deletion,
         );
@@ -102,7 +109,9 @@ mod tests {
     #[test]
     fn test_hgvsg_deletion_multi() {
         let result = hgvsg(
-            "chr1", 100, 102,
+            "chr1",
+            100,
+            102,
             &Allele::Sequence(b"ACG".to_vec()),
             &Allele::Deletion,
         );
@@ -112,7 +121,9 @@ mod tests {
     #[test]
     fn test_hgvsg_insertion() {
         let result = hgvsg(
-            "chr1", 101, 100, // insertion: start > end in Ensembl coords
+            "chr1",
+            101,
+            100, // insertion: start > end in Ensembl coords
             &Allele::Deletion,
             &Allele::Sequence(b"TCG".to_vec()),
         );
@@ -122,7 +133,9 @@ mod tests {
     #[test]
     fn test_hgvsg_mnv() {
         let result = hgvsg(
-            "chr1", 100, 101,
+            "chr1",
+            100,
+            101,
             &Allele::Sequence(b"AC".to_vec()),
             &Allele::Sequence(b"GT".to_vec()),
         );

--- a/crates/fastvep-hgvs/src/lib.rs
+++ b/crates/fastvep-hgvs/src/lib.rs
@@ -2,7 +2,10 @@ mod coding;
 mod genomic;
 mod protein;
 
-pub use coding::{hgvsc, hgvsc_with_seq, hgvsc_intronic, hgvsc_intronic_range, hgvsc_noncoding, hgvsc_noncoding_intronic, hgvsc_noncoding_intronic_range};
+pub use coding::{
+    hgvsc, hgvsc_intronic, hgvsc_intronic_range, hgvsc_noncoding, hgvsc_noncoding_intronic,
+    hgvsc_noncoding_intronic_range, hgvsc_with_seq,
+};
 pub use genomic::hgvsg;
 pub use protein::{hgvsp, hgvsp_frameshift, hgvsp_inframe_deletion};
 

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -29,12 +29,12 @@ pub fn hgvsp(
 
     if alt_aa == b'*' {
         // Stop gained
-        return Some(format!("{}{}{}{}",prefix, ref_aa3, protein_pos, alt_aa3));
+        return Some(format!("{}{}{}{}", prefix, ref_aa3, protein_pos, alt_aa3));
     }
 
     if ref_aa == b'*' {
         // Stop lost - extension
-        return Some(format!("{}{}{}ext*?",prefix, alt_aa3, protein_pos));
+        return Some(format!("{}{}{}ext*?", prefix, alt_aa3, protein_pos));
     }
 
     // Missense
@@ -161,7 +161,8 @@ pub fn hgvsp_frameshift(
     // If the sequence contains unresolved (X) amino acids, use Ter? to indicate uncertainty.
     let mut stop_dist = None;
     let mut hit_unresolved = false;
-    let unresolved_count = alt_peptide[first_changed_offset..].iter()
+    let unresolved_count = alt_peptide[first_changed_offset..]
+        .iter()
         .take(10)
         .filter(|&&aa| aa == b'X')
         .count();
@@ -181,13 +182,22 @@ pub fn hgvsp_frameshift(
     }
 
     if let Some(d) = stop_dist {
-        Some(format!("{}{}{}{}fsTer{}", prefix, ref_aa3, first_changed_pos, alt_aa3, d))
+        Some(format!(
+            "{}{}{}{}fsTer{}",
+            prefix, ref_aa3, first_changed_pos, alt_aa3, d
+        ))
     } else if hit_unresolved || mostly_unresolved {
         // Sequence has unresolved regions - can't determine stop position
-        Some(format!("{}{}{}{}fsTer?", prefix, ref_aa3, first_changed_pos, alt_aa3))
+        Some(format!(
+            "{}{}{}{}fsTer?",
+            prefix, ref_aa3, first_changed_pos, alt_aa3
+        ))
     } else {
         // No stop found and sequence is clean - true extension
-        Some(format!("{}{}{}{}fsTer?", prefix, ref_aa3, first_changed_pos, alt_aa3))
+        Some(format!(
+            "{}{}{}{}fsTer?",
+            prefix, ref_aa3, first_changed_pos, alt_aa3
+        ))
     }
 }
 
@@ -212,8 +222,13 @@ mod tests {
 
         let standard_result =
             hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 0, &standard);
-        let mito_result =
-            hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 0, &mitochondrial);
+        let mito_result = hgvsp_frameshift(
+            "ENSP1",
+            ref_translateable,
+            alt_translateable,
+            0,
+            &mitochondrial,
+        );
 
         // Standard table: TGA is a stop, so the new terminator is 2 codons in.
         assert_eq!(standard_result, Some("ENSP1:p.Arg1ProfsTer2".to_string()));
@@ -235,8 +250,7 @@ mod tests {
         let alt_translateable = b"CC"; // only 2 bases -- shorter than ref_start (3)
 
         let standard = CodonTable::standard();
-        let result =
-            hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 1, &standard);
+        let result = hgvsp_frameshift("ENSP1", ref_translateable, alt_translateable, 1, &standard);
         assert_eq!(result, None);
     }
 
@@ -270,7 +284,10 @@ mod tests {
     fn test_hgvsp_inframe_delins() {
         // in-frame deletion-insertion
         let r = hgvsp_inframe_deletion("ENSP00000001", 2173, "NL", "K");
-        assert_eq!(r, Some("ENSP00000001:p.Asn2173_Leu2174delinsLys".to_string()));
+        assert_eq!(
+            r,
+            Some("ENSP00000001:p.Asn2173_Leu2174delinsLys".to_string())
+        );
     }
 
     #[test]

--- a/crates/fastvep-io/src/geneset.rs
+++ b/crates/fastvep-io/src/geneset.rs
@@ -45,8 +45,8 @@ impl GeneSet {
     /// from spreadsheets work directly.
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
-        let file = File::open(path)
-            .with_context(|| format!("Opening gene list: {}", path.display()))?;
+        let file =
+            File::open(path).with_context(|| format!("Opening gene list: {}", path.display()))?;
         let reader = BufReader::new(file);
         let mut members = HashSet::new();
         for line in reader.lines() {

--- a/crates/fastvep-io/src/output.rs
+++ b/crates/fastvep-io/src/output.rs
@@ -44,7 +44,9 @@ fn format_csq_entry_into(
             "Allele" => escape_csq_str(&aa.allele.to_string(), buf),
             "Consequence" => {
                 for (j, c) in aa.consequences.iter().enumerate() {
-                    if j > 0 { buf.push('&'); }
+                    if j > 0 {
+                        buf.push('&');
+                    }
                     buf.push_str(c.so_term());
                 }
             }
@@ -88,7 +90,9 @@ fn format_csq_entry_into(
             }
             "Existing_variation" => {
                 for (j, ev) in aa.existing_variation.iter().enumerate() {
-                    if j > 0 { buf.push('&'); }
+                    if j > 0 {
+                        buf.push('&');
+                    }
                     escape_csq_str(ev, buf);
                 }
             }
@@ -109,14 +113,22 @@ fn format_csq_entry_into(
                     let _ = write!(buf, "{}", d);
                 }
             }
-            "STRAND" => { let _ = write!(buf, "{}", tv.strand.as_int()); }
+            "STRAND" => {
+                let _ = write!(buf, "{}", tv.strand.as_int());
+            }
             "FLAGS" => {
                 for (j, f) in tv.flags.iter().enumerate() {
-                    if j > 0 { buf.push('&'); }
+                    if j > 0 {
+                        buf.push('&');
+                    }
                     buf.push_str(f);
                 }
             }
-            "CANONICAL" => { if tv.canonical { buf.push_str("YES"); } }
+            "CANONICAL" => {
+                if tv.canonical {
+                    buf.push_str("YES");
+                }
+            }
             "SYMBOL_SOURCE" => escape_csq_str(tv.symbol_source.as_deref().unwrap_or_default(), buf),
             "HGNC_ID" => escape_csq_str(tv.hgnc_id.as_deref().unwrap_or_default(), buf),
             "MANE" => {
@@ -127,17 +139,28 @@ fn format_csq_entry_into(
                 }
             }
             "MANE_SELECT" => escape_csq_str(tv.mane_select.as_deref().unwrap_or_default(), buf),
-            "MANE_PLUS_CLINICAL" => escape_csq_str(tv.mane_plus_clinical.as_deref().unwrap_or_default(), buf),
-            "TSL" => { if let Some(t) = tv.tsl { let _ = write!(buf, "{}", t); } }
+            "MANE_PLUS_CLINICAL" => {
+                escape_csq_str(tv.mane_plus_clinical.as_deref().unwrap_or_default(), buf)
+            }
+            "TSL" => {
+                if let Some(t) = tv.tsl {
+                    let _ = write!(buf, "{}", t);
+                }
+            }
             "APPRIS" => escape_csq_str(tv.appris.as_deref().unwrap_or_default(), buf),
             "CCDS" => escape_csq_str(tv.ccds.as_deref().unwrap_or_default(), buf),
-            "GENCODE_PRIMARY" => { if tv.gencode_primary { buf.push_str("YES"); } }
+            "GENCODE_PRIMARY" => {
+                if tv.gencode_primary {
+                    buf.push_str("YES");
+                }
+            }
             "ENSP" => escape_csq_str(tv.protein_id.as_deref().unwrap_or_default(), buf),
             "SIFT" => escape_csq_str(aa.sift.as_deref().unwrap_or_default(), buf),
             "PolyPhen" => escape_csq_str(aa.polyphen.as_deref().unwrap_or_default(), buf),
             "AF" => {
                 if let Some(f) = vf.existing_variants.iter().find_map(|kv| {
-                    kv.frequencies.get("gnomAD")
+                    kv.frequencies
+                        .get("gnomAD")
                         .or_else(|| kv.frequencies.get("gnomADe"))
                         .or_else(|| kv.frequencies.get("minor_allele_freq"))
                 }) {
@@ -145,19 +168,35 @@ fn format_csq_entry_into(
                 }
             }
             "CLIN_SIG" => {
-                if let Some(cs) = vf.existing_variants.iter()
+                if let Some(cs) = vf
+                    .existing_variants
+                    .iter()
                     .find_map(|kv| kv.clinical_significance.as_deref())
                 {
                     escape_csq_str(cs, buf);
                 }
             }
-            "SOMATIC" => { if vf.existing_variants.iter().any(|kv| kv.somatic) { buf.push('1'); } }
-            "PHENO" => { if vf.existing_variants.iter().any(|kv| kv.phenotype_or_disease) { buf.push('1'); } }
+            "SOMATIC" => {
+                if vf.existing_variants.iter().any(|kv| kv.somatic) {
+                    buf.push('1');
+                }
+            }
+            "PHENO" => {
+                if vf
+                    .existing_variants
+                    .iter()
+                    .any(|kv| kv.phenotype_or_disease)
+                {
+                    buf.push('1');
+                }
+            }
             "PUBMED" => {
                 let mut first_pub = true;
                 for kv in &vf.existing_variants {
                     for p in &kv.pubmed {
-                        if !first_pub { buf.push('&'); }
+                        if !first_pub {
+                            buf.push('&');
+                        }
                         first_pub = false;
                         buf.push_str(p);
                     }
@@ -183,7 +222,9 @@ fn format_csq_entry_into(
                         for c in criteria {
                             if c.get("met").and_then(|v| v.as_bool()).unwrap_or(false) {
                                 if let Some(code) = c.get("code").and_then(|v| v.as_str()) {
-                                    if !first { buf.push('&'); }
+                                    if !first {
+                                        buf.push('&');
+                                    }
                                     first = false;
                                     buf.push_str(code);
                                 }
@@ -222,8 +263,12 @@ fn escape_csq_value(value: &str) -> String {
 
 fn write_position_range(pos: Option<(u64, u64)>, buf: &mut String) {
     match pos {
-        Some((start, end)) if start == end => { let _ = write!(buf, "{}", start); }
-        Some((start, end)) => { let _ = write!(buf, "{}-{}", start, end); }
+        Some((start, end)) if start == end => {
+            let _ = write!(buf, "{}", start);
+        }
+        Some((start, end)) => {
+            let _ = write!(buf, "{}-{}", start, end);
+        }
         None => {}
     }
 }
@@ -363,7 +408,11 @@ const ONEKG_FIELDS: &[(&str, &str)] = &[
     ("EUR_AF", "eurAf"),
     ("SAS_AF", "sasAf"),
 ];
-const TOPMED_FIELDS: &[(&str, &str)] = &[("ALL_AF", "allAf"), ("ALL_AC", "allAc"), ("ALL_AN", "allAn")];
+const TOPMED_FIELDS: &[(&str, &str)] = &[
+    ("ALL_AF", "allAf"),
+    ("ALL_AC", "allAc"),
+    ("ALL_AN", "allAn"),
+];
 const MITOMAP_FIELDS: &[(&str, &str)] = &[("DISEASE", "disease"), ("STATUS", "status")];
 const SCORE_FIELDS: &[(&str, &str)] = &[("SCORE", "")];
 const SCORE_OBJECT_FIELDS: &[(&str, &str)] = &[("SCORE", "score")];
@@ -604,7 +653,11 @@ impl LoadedSupplementarySpecs {
             })
             .collect();
         let column_count = spliceai as usize + per_spec.iter().filter(|b| **b).count();
-        Self { spliceai, per_spec, column_count }
+        Self {
+            spliceai,
+            per_spec,
+            column_count,
+        }
     }
 
     /// Number of extra tab columns this lookup will produce (including
@@ -777,7 +830,11 @@ fn format_spliceai_projection(vf: &VariationFeature) -> Option<String> {
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_spliceai_entry(allele: &str, json_str: &str) -> Option<String> {
@@ -837,7 +894,11 @@ fn format_allele_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> 
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 /// `GeneIndex::annotate_gene` returns either a single JSON object for a gene
@@ -868,7 +929,11 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
             parts.push(escape_vcf_subfield(&ga.gene_symbol));
             if let Some(obj) = object.as_object() {
                 for (_, json_key) in spec.fields {
-                    parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+                    parts.push(
+                        obj.get(*json_key)
+                            .map(json_value_to_vcf)
+                            .unwrap_or_default(),
+                    );
                 }
             }
             let value = parts.join("|");
@@ -877,7 +942,11 @@ fn format_gene_projection(vf: &VariationFeature, spec: &VcfProjectionSpec) -> Op
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_spliceai_for_allele(vf: &VariationFeature, aa: &AlleleAnnotation) -> Option<String> {
@@ -894,7 +963,11 @@ fn format_spliceai_for_allele(vf: &VariationFeature, aa: &AlleleAnnotation) -> O
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_allele_projection_for_aa(
@@ -928,7 +1001,11 @@ fn format_allele_projection_for_aa(
         };
         let entries = match spec.kind {
             VcfProjectionKind::AlleleScalar => {
-                vec![format!("{}|{}", escape_vcf_subfield(&allele), json_value_to_vcf(&parsed))]
+                vec![format!(
+                    "{}|{}",
+                    escape_vcf_subfield(&allele),
+                    json_value_to_vcf(&parsed)
+                )]
             }
             _ => format_object_projection_entries(&allele, &parsed, spec.fields),
         };
@@ -938,7 +1015,11 @@ fn format_allele_projection_for_aa(
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_gene_projection_for_tv(
@@ -970,7 +1051,11 @@ fn format_gene_projection_for_tv(
             parts.push(escape_vcf_subfield(&ga.gene_symbol));
             if let Some(obj) = object.as_object() {
                 for (_, json_key) in spec.fields {
-                    parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+                    parts.push(
+                        obj.get(*json_key)
+                            .map(json_value_to_vcf)
+                            .unwrap_or_default(),
+                    );
                 }
             }
             let value = parts.join("|");
@@ -979,7 +1064,11 @@ fn format_gene_projection_for_tv(
             }
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_clinvar_protein_projection_for_tv(
@@ -1013,7 +1102,11 @@ fn format_clinvar_protein_projection_for_tv(
             values.push(value);
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 /// Pull every `proteinVariants[*]` entry out of a ClinVar-protein JSON
@@ -1030,7 +1123,9 @@ fn collect_clinvar_protein_variants(parsed: &Value) -> String {
             let ref_aa = v.get("refAa").map(json_leaf_to_string)?;
             let alt_aa = v.get("altAa").map(json_leaf_to_string)?;
             let sig = v.get("sig").map(json_leaf_to_string).unwrap_or_default();
-            Some(escape_vcf_subfield(&format!("{pos}:{ref_aa}>{alt_aa}:{sig}")))
+            Some(escape_vcf_subfield(&format!(
+                "{pos}:{ref_aa}>{alt_aa}:{sig}"
+            )))
         })
         .collect::<Vec<_>>()
         .join("&")
@@ -1058,7 +1153,11 @@ fn format_clinvar_protein_projection(
             values.push(value);
         }
     }
-    if values.is_empty() { None } else { Some(values.join(",")) }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
 }
 
 fn format_object_projection_entries(
@@ -1080,7 +1179,11 @@ fn format_object_projection_entries(
                 if json_key.is_empty() {
                     parts.push(json_value_to_vcf(value));
                 } else {
-                    parts.push(obj.get(*json_key).map(json_value_to_vcf).unwrap_or_default());
+                    parts.push(
+                        obj.get(*json_key)
+                            .map(json_value_to_vcf)
+                            .unwrap_or_default(),
+                    );
                 }
             }
             Some(parts.join("|"))
@@ -1229,7 +1332,9 @@ pub fn format_tab_line_with(
                     parts.push(r.clone());
                 }
                 if extra_count > 0 {
-                    parts.extend(format_supplementary_tab_columns_for_allele(vf, tv, aa, specs));
+                    parts.extend(format_supplementary_tab_columns_for_allele(
+                        vf, tv, aa, specs,
+                    ));
                 }
                 if let Some(cls) = opts.qc_class {
                     parts.push(cls.to_string());
@@ -1280,7 +1385,10 @@ pub fn format_tab_line_with(
                 .join(",");
 
             let impact_str = aa.impact.as_str().to_string();
-            let distance_str = aa.distance.map(|d| d.to_string()).unwrap_or("-".to_string());
+            let distance_str = aa
+                .distance
+                .map(|d| d.to_string())
+                .unwrap_or("-".to_string());
             let strand_str = format!("{}", tv.strand.as_int());
             let flags_str = if tv.canonical { "canonical" } else { "-" };
 
@@ -1321,7 +1429,9 @@ pub fn format_tab_line_with(
             parts.push(flags_str.to_string());
 
             if extra_count > 0 {
-                parts.extend(format_supplementary_tab_columns_for_allele(vf, tv, aa, specs));
+                parts.extend(format_supplementary_tab_columns_for_allele(
+                    vf, tv, aa, specs,
+                ));
             }
 
             if let Some(cls) = opts.qc_class {
@@ -1376,13 +1486,22 @@ pub fn format_json(vf: &VariationFeature, sa_only: bool) -> serde_json::Value {
         "seq_region_name".into(),
         serde_json::Value::String(vf.position.chromosome.clone()),
     );
-    obj.insert("start".into(), serde_json::Value::Number(vf.position.start.into()));
-    obj.insert("end".into(), serde_json::Value::Number(vf.position.end.into()));
+    obj.insert(
+        "start".into(),
+        serde_json::Value::Number(vf.position.start.into()),
+    );
+    obj.insert(
+        "end".into(),
+        serde_json::Value::Number(vf.position.end.into()),
+    );
     obj.insert(
         "allele_string".into(),
         serde_json::Value::String(vf.allele_string.clone()),
     );
-    obj.insert("strand".into(), serde_json::Value::Number(vf.position.strand.as_int().into()));
+    obj.insert(
+        "strand".into(),
+        serde_json::Value::Number(vf.position.strand.as_int().into()),
+    );
 
     if sa_only {
         let alleles: Vec<serde_json::Value> = vf
@@ -1491,7 +1610,10 @@ pub fn format_json(vf: &VariationFeature, sa_only: bool) -> serde_json::Value {
                     tc.insert("mane_select".into(), serde_json::Value::String(ms.clone()));
                 }
                 if let Some(ref mpc) = tv.mane_plus_clinical {
-                    tc.insert("mane_plus_clinical".into(), serde_json::Value::String(mpc.clone()));
+                    tc.insert(
+                        "mane_plus_clinical".into(),
+                        serde_json::Value::String(mpc.clone()),
+                    );
                 }
                 if let Some(t) = tv.tsl {
                     tc.insert("tsl".into(), serde_json::Value::Number(t.into()));
@@ -1503,7 +1625,10 @@ pub fn format_json(vf: &VariationFeature, sa_only: bool) -> serde_json::Value {
                     tc.insert("ccds".into(), serde_json::Value::String(c.clone()));
                 }
                 if tv.gencode_primary {
-                    tc.insert("gencode_primary".into(), serde_json::Value::Number(1.into()));
+                    tc.insert(
+                        "gencode_primary".into(),
+                        serde_json::Value::Number(1.into()),
+                    );
                 }
                 if let Some(ref pid) = tv.protein_id {
                     tc.insert("protein_id".into(), serde_json::Value::String(pid.clone()));
@@ -1521,20 +1646,28 @@ pub fn format_json(vf: &VariationFeature, sa_only: bool) -> serde_json::Value {
                     tc.insert("protein_end".into(), serde_json::Value::Number(e.into()));
                 }
                 if let Some(ref aas) = aa.amino_acids {
-                    tc.insert("amino_acids".into(),
-                        serde_json::Value::String(format!("{}/{}", aas.0, aas.1)));
+                    tc.insert(
+                        "amino_acids".into(),
+                        serde_json::Value::String(format!("{}/{}", aas.0, aas.1)),
+                    );
                 }
                 if let Some(ref cdns) = aa.codons {
-                    tc.insert("codons".into(),
-                        serde_json::Value::String(format!("{}/{}", cdns.0, cdns.1)));
+                    tc.insert(
+                        "codons".into(),
+                        serde_json::Value::String(format!("{}/{}", cdns.0, cdns.1)),
+                    );
                 }
                 if let Some((n, t)) = aa.exon {
-                    tc.insert("exon".into(),
-                        serde_json::Value::String(format!("{}/{}", n, t)));
+                    tc.insert(
+                        "exon".into(),
+                        serde_json::Value::String(format!("{}/{}", n, t)),
+                    );
                 }
                 if let Some((n, t)) = aa.intron {
-                    tc.insert("intron".into(),
-                        serde_json::Value::String(format!("{}/{}", n, t)));
+                    tc.insert(
+                        "intron".into(),
+                        serde_json::Value::String(format!("{}/{}", n, t)),
+                    );
                 }
                 if let Some(ref h) = aa.hgvsg {
                     tc.insert("hgvsg".into(), serde_json::Value::String(h.clone()));
@@ -1619,9 +1752,18 @@ pub fn format_nirvana_json(vf: &VariationFeature) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
 
     // Position section
-    obj.insert("chromosome".into(), serde_json::Value::String(vf.position.chromosome.clone()));
-    obj.insert("position".into(), serde_json::Value::Number(vf.position.start.into()));
-    obj.insert("end".into(), serde_json::Value::Number(vf.position.end.into()));
+    obj.insert(
+        "chromosome".into(),
+        serde_json::Value::String(vf.position.chromosome.clone()),
+    );
+    obj.insert(
+        "position".into(),
+        serde_json::Value::Number(vf.position.start.into()),
+    );
+    obj.insert(
+        "end".into(),
+        serde_json::Value::Number(vf.position.end.into()),
+    );
 
     let ref_str = vf.ref_allele.to_string();
     obj.insert("refAllele".into(), serde_json::Value::String(ref_str));
@@ -1634,7 +1776,10 @@ pub fn format_nirvana_json(vf: &VariationFeature) -> serde_json::Value {
     obj.insert("altAlleles".into(), serde_json::Value::Array(alt_strs));
 
     if vf.variant_type != fastvep_core::VariantType::Unknown {
-        obj.insert("variantType".into(), serde_json::Value::String(format!("{:?}", vf.variant_type)));
+        obj.insert(
+            "variantType".into(),
+            serde_json::Value::String(format!("{:?}", vf.variant_type)),
+        );
     }
 
     // Variants section: one per alt allele with all transcript consequences
@@ -1642,7 +1787,10 @@ pub fn format_nirvana_json(vf: &VariationFeature) -> serde_json::Value {
     for alt in &vf.alt_alleles {
         let alt_str = alt.to_string();
         let mut var_obj = serde_json::Map::new();
-        var_obj.insert("altAllele".into(), serde_json::Value::String(alt_str.clone()));
+        var_obj.insert(
+            "altAllele".into(),
+            serde_json::Value::String(alt_str.clone()),
+        );
 
         // Collect transcript consequences for this allele
         let mut transcripts = Vec::new();
@@ -1650,27 +1798,73 @@ pub fn format_nirvana_json(vf: &VariationFeature) -> serde_json::Value {
             for aa in &tv.allele_annotations {
                 if aa.allele.to_string() == alt_str {
                     let mut tc = serde_json::Map::new();
-                    tc.insert("transcriptId".into(), serde_json::Value::String(tv.transcript_id.to_string()));
-                    tc.insert("geneId".into(), serde_json::Value::String(tv.gene_id.to_string()));
+                    tc.insert(
+                        "transcriptId".into(),
+                        serde_json::Value::String(tv.transcript_id.to_string()),
+                    );
+                    tc.insert(
+                        "geneId".into(),
+                        serde_json::Value::String(tv.gene_id.to_string()),
+                    );
                     if let Some(ref sym) = tv.gene_symbol {
-                        tc.insert("geneSymbol".into(), serde_json::Value::String(sym.to_string()));
+                        tc.insert(
+                            "geneSymbol".into(),
+                            serde_json::Value::String(sym.to_string()),
+                        );
                     }
-                    tc.insert("biotype".into(), serde_json::Value::String(tv.biotype.to_string()));
-                    tc.insert("consequences".into(), serde_json::Value::Array(
-                        aa.consequences.iter().map(|c| serde_json::Value::String(c.so_term().to_string())).collect()
-                    ));
-                    tc.insert("impact".into(), serde_json::Value::String(aa.impact.as_str().to_string()));
-                    if tv.canonical { tc.insert("isCanonical".into(), serde_json::Value::Bool(true)); }
-                    if let Some(ref ms) = tv.mane_select { tc.insert("maneSelect".into(), serde_json::Value::String(ms.clone())); }
-                    if let Some(ref mpc) = tv.mane_plus_clinical { tc.insert("manePlusClinical".into(), serde_json::Value::String(mpc.clone())); }
-                    if let Some(t) = tv.tsl { tc.insert("tsl".into(), serde_json::Value::Number(t.into())); }
-                    if let Some(ref a) = tv.appris { tc.insert("appris".into(), serde_json::Value::String(a.clone())); }
-                    if let Some(ref c) = tv.ccds { tc.insert("ccds".into(), serde_json::Value::String(c.clone())); }
-                    if tv.gencode_primary { tc.insert("isGencodePrimary".into(), serde_json::Value::Bool(true)); }
-                    if let Some(ref pid) = tv.protein_id { tc.insert("proteinId".into(), serde_json::Value::String(pid.clone())); }
-                    if let Some(ref h) = aa.hgvsg { tc.insert("hgvsg".into(), serde_json::Value::String(h.clone())); }
-                    if let Some(ref h) = aa.hgvsc { tc.insert("hgvsc".into(), serde_json::Value::String(h.clone())); }
-                    if let Some(ref h) = aa.hgvsp { tc.insert("hgvsp".into(), serde_json::Value::String(h.clone())); }
+                    tc.insert(
+                        "biotype".into(),
+                        serde_json::Value::String(tv.biotype.to_string()),
+                    );
+                    tc.insert(
+                        "consequences".into(),
+                        serde_json::Value::Array(
+                            aa.consequences
+                                .iter()
+                                .map(|c| serde_json::Value::String(c.so_term().to_string()))
+                                .collect(),
+                        ),
+                    );
+                    tc.insert(
+                        "impact".into(),
+                        serde_json::Value::String(aa.impact.as_str().to_string()),
+                    );
+                    if tv.canonical {
+                        tc.insert("isCanonical".into(), serde_json::Value::Bool(true));
+                    }
+                    if let Some(ref ms) = tv.mane_select {
+                        tc.insert("maneSelect".into(), serde_json::Value::String(ms.clone()));
+                    }
+                    if let Some(ref mpc) = tv.mane_plus_clinical {
+                        tc.insert(
+                            "manePlusClinical".into(),
+                            serde_json::Value::String(mpc.clone()),
+                        );
+                    }
+                    if let Some(t) = tv.tsl {
+                        tc.insert("tsl".into(), serde_json::Value::Number(t.into()));
+                    }
+                    if let Some(ref a) = tv.appris {
+                        tc.insert("appris".into(), serde_json::Value::String(a.clone()));
+                    }
+                    if let Some(ref c) = tv.ccds {
+                        tc.insert("ccds".into(), serde_json::Value::String(c.clone()));
+                    }
+                    if tv.gencode_primary {
+                        tc.insert("isGencodePrimary".into(), serde_json::Value::Bool(true));
+                    }
+                    if let Some(ref pid) = tv.protein_id {
+                        tc.insert("proteinId".into(), serde_json::Value::String(pid.clone()));
+                    }
+                    if let Some(ref h) = aa.hgvsg {
+                        tc.insert("hgvsg".into(), serde_json::Value::String(h.clone()));
+                    }
+                    if let Some(ref h) = aa.hgvsc {
+                        tc.insert("hgvsc".into(), serde_json::Value::String(h.clone()));
+                    }
+                    if let Some(ref h) = aa.hgvsp {
+                        tc.insert("hgvsp".into(), serde_json::Value::String(h.clone()));
+                    }
 
                     // Per-allele supplementary annotations
                     for (key, json_str) in &aa.supplementary {
@@ -1871,7 +2065,10 @@ mod tests {
             "FV_GNOMAD_GENE",
             "FV_CLINVAR_PROTEIN",
         ] {
-            assert!(ids.contains(&expected), "missing projection {expected}: {projections:?}");
+            assert!(
+                ids.contains(&expected),
+                "missing projection {expected}: {projections:?}"
+            );
         }
 
         let info = projections
@@ -1879,9 +2076,18 @@ mod tests {
             .map(|(id, value)| format!("{id}={value}"))
             .collect::<Vec<_>>()
             .join(";");
-        assert!(!info.contains('{'), "VCF INFO must not contain JSON objects: {info}");
-        assert!(!info.contains('}'), "VCF INFO must not contain JSON objects: {info}");
-        assert!(!info.contains('"'), "VCF INFO must not contain JSON quotes: {info}");
+        assert!(
+            !info.contains('{'),
+            "VCF INFO must not contain JSON objects: {info}"
+        );
+        assert!(
+            !info.contains('}'),
+            "VCF INFO must not contain JSON objects: {info}"
+        );
+        assert!(
+            !info.contains('"'),
+            "VCF INFO must not contain JSON quotes: {info}"
+        );
         assert!(info.contains("SpliceAI=G|GENE%7C1|0.01|0.00|0.85|0.00|5|-28|2|-13"));
         assert!(info.contains("FV_CLINVAR=G|Pathogenic&Likely_pathogenic|criteria_provided%2C_multiple_submitters%2C_no_conflicts|Breast%2Ccancer&Ovarian%7Ccancer|SNV|SO%3A0001483"));
         assert!(info.contains("FV_PHYLOP=G|3.14"));
@@ -1895,11 +2101,8 @@ mod tests {
     fn vcf_info_replaces_existing_fastvep_owned_fields() {
         let vf = projection_test_variant();
         let csq = "G|missense_variant|MODERATE";
-        let info = format_vcf_info_fields(
-            "DP=12;CSQ=old;SpliceAI=old;FV_CLINVAR=old;KEEP=1",
-            &vf,
-            csq,
-        );
+        let info =
+            format_vcf_info_fields("DP=12;CSQ=old;SpliceAI=old;FV_CLINVAR=old;KEEP=1", &vf, csq);
 
         assert!(info.contains("DP=12"));
         assert!(info.contains("KEEP=1"));
@@ -1931,7 +2134,11 @@ mod tests {
     }
 
     fn all_supplementary_gene_keys() -> Vec<String> {
-        vec!["omim".into(), "gnomad_genes".into(), "clinvar_protein".into()]
+        vec![
+            "omim".into(),
+            "gnomad_genes".into(),
+            "clinvar_protein".into(),
+        ]
     }
 
     #[test]
@@ -1961,7 +2168,10 @@ mod tests {
             "FV_GNOMAD_GENE",
             "FV_CLINVAR_PROTEIN",
         ] {
-            assert!(cols.contains(&expected), "missing column {expected}: {cols:?}");
+            assert!(
+                cols.contains(&expected),
+                "missing column {expected}: {cols:?}"
+            );
         }
     }
 
@@ -1997,13 +2207,14 @@ mod tests {
         );
 
         let vcf_projections: std::collections::HashMap<String, String> =
-            format_supplementary_vcf_info(&vf)
-                .into_iter()
-                .collect();
+            format_supplementary_vcf_info(&vf).into_iter().collect();
 
         for (i, info_id) in extra_cols.iter().enumerate() {
             let tab_value = cols[17 + i];
-            let expected = vcf_projections.get(*info_id).cloned().unwrap_or_else(|| "-".into());
+            let expected = vcf_projections
+                .get(*info_id)
+                .cloned()
+                .unwrap_or_else(|| "-".into());
             assert_eq!(
                 tab_value, expected,
                 "tab column {info_id} should equal VCF INFO value"
@@ -2012,7 +2223,10 @@ mod tests {
 
         assert!(!row.contains('{'), "tab row must not contain JSON: {row}");
         assert!(!row.contains('}'), "tab row must not contain JSON: {row}");
-        assert!(!row.contains('"'), "tab row must not contain JSON quotes: {row}");
+        assert!(
+            !row.contains('"'),
+            "tab row must not contain JSON quotes: {row}"
+        );
     }
 
     #[test]
@@ -2025,10 +2239,8 @@ mod tests {
         }
         vf.gene_annotations.clear();
 
-        let specs = LoadedSupplementarySpecs::new(
-            &["clinvar".to_string(), "dbnsfp".to_string()],
-            &[],
-        );
+        let specs =
+            LoadedSupplementarySpecs::new(&["clinvar".to_string(), "dbnsfp".to_string()], &[]);
         let lines = format_tab_line(&vf, &specs, false);
         let cols: Vec<&str> = lines[0].split('\t').collect();
         assert_eq!(cols.len(), 17 + 2);
@@ -2062,9 +2274,17 @@ mod tests {
         let specs = LoadedSupplementarySpecs::new(&sa_keys, &gene_keys);
 
         let lines = format_tab_line(&vf, &specs, false);
-        assert_eq!(lines.len(), 1, "single alt allele yields one intergenic row");
+        assert_eq!(
+            lines.len(),
+            1,
+            "single alt allele yields one intergenic row"
+        );
         let cols: Vec<&str> = lines[0].split('\t').collect();
-        assert_eq!(cols.len(), 17 + 3, "intergenic row must include FV_* columns");
+        assert_eq!(
+            cols.len(),
+            17 + 3,
+            "intergenic row must include FV_* columns"
+        );
         assert_eq!(cols[6], "intergenic_variant");
         // All FV_* columns should be `-` for an intergenic row.
         for tail in &cols[17..] {
@@ -2113,12 +2333,20 @@ mod tests {
         let lines = format_tab_line(&vf, &specs, false);
         assert_eq!(lines.len(), 2);
         assert!(
-            lines[0].split('\t').next_back().unwrap().starts_with("G|Pathogenic|"),
+            lines[0]
+                .split('\t')
+                .next_back()
+                .unwrap()
+                .starts_with("G|Pathogenic|"),
             "first row should carry the ALT-G clinvar value: {}",
             lines[0]
         );
         assert!(
-            lines[1].split('\t').next_back().unwrap().starts_with("T|Benign|"),
+            lines[1]
+                .split('\t')
+                .next_back()
+                .unwrap()
+                .starts_with("T|Benign|"),
             "second row should carry the ALT-T clinvar value: {}",
             lines[1]
         );
@@ -2224,10 +2452,8 @@ mod tests {
             }
         }
         vf.gene_annotations.clear();
-        let specs = LoadedSupplementarySpecs::new(
-            &["clinvar".to_string(), "dbnsfp".to_string()],
-            &[],
-        );
+        let specs =
+            LoadedSupplementarySpecs::new(&["clinvar".to_string(), "dbnsfp".to_string()], &[]);
         let lines = format_tab_line(&vf, &specs, false);
         let row = &lines[0];
         assert!(!row.contains('{'), "malformed JSON must not leak: {row}");

--- a/crates/fastvep-io/src/qc.rs
+++ b/crates/fastvep-io/src/qc.rs
@@ -316,8 +316,14 @@ mod tests {
             max_fs = 60.0
             "#,
         );
-        assert_eq!(rules.classify(&InfoView::new("FS=30.0", None), "PASS"), "GOOD");
-        assert_eq!(rules.classify(&InfoView::new("FS=65.0", None), "PASS"), "FAIL_QC");
+        assert_eq!(
+            rules.classify(&InfoView::new("FS=30.0", None), "PASS"),
+            "GOOD"
+        );
+        assert_eq!(
+            rules.classify(&InfoView::new("FS=65.0", None), "PASS"),
+            "FAIL_QC"
+        );
     }
 
     #[test]
@@ -330,7 +336,10 @@ mod tests {
             "#,
         );
         // No DP in INFO → cannot prove threshold passed.
-        assert_eq!(rules.classify(&InfoView::new("AF=0.5", None), "PASS"), "FAIL_QC");
+        assert_eq!(
+            rules.classify(&InfoView::new("AF=0.5", None), "PASS"),
+            "FAIL_QC"
+        );
     }
 
     #[test]

--- a/crates/fastvep-io/src/sample.rs
+++ b/crates/fastvep-io/src/sample.rs
@@ -29,7 +29,9 @@ impl Genotype {
     /// Returns true if homozygous alternate (all non-missing alleles same, > 0).
     pub fn is_hom_alt(&self) -> bool {
         let present: Vec<u32> = self.alleles.iter().filter_map(|a| *a).collect();
-        !present.is_empty() && present.iter().all(|a| *a > 0) && present.iter().min() == present.iter().max()
+        !present.is_empty()
+            && present.iter().all(|a| *a > 0)
+            && present.iter().min() == present.iter().max()
     }
 
     /// Returns true if all alleles are missing.
@@ -39,11 +41,17 @@ impl Genotype {
 
     /// Short string representation: "het", "hom_ref", "hom_alt", "missing".
     pub fn class(&self) -> &'static str {
-        if self.is_missing() { "missing" }
-        else if self.is_hom_ref() { "hom_ref" }
-        else if self.is_hom_alt() { "hom_alt" }
-        else if self.is_het() { "het" }
-        else { "other" }
+        if self.is_missing() {
+            "missing"
+        } else if self.is_hom_ref() {
+            "hom_ref"
+        } else if self.is_hom_alt() {
+            "hom_alt"
+        } else if self.is_het() {
+            "het"
+        } else {
+            "other"
+        }
     }
 }
 
@@ -98,11 +106,7 @@ pub fn parse_samples(
             let quality = raw_fields.get("GQ").and_then(|v| v.parse().ok());
             let allele_depths = raw_fields
                 .get("AD")
-                .map(|v| {
-                    v.split(',')
-                        .filter_map(|s| s.parse().ok())
-                        .collect()
-                })
+                .map(|v| v.split(',').filter_map(|s| s.parse().ok()).collect())
                 .unwrap_or_default();
 
             SampleData {

--- a/crates/fastvep-io/src/variant.rs
+++ b/crates/fastvep-io/src/variant.rs
@@ -1,6 +1,6 @@
 use fastvep_core::{
-    Allele, Consequence, GeneAnnotation, GenomicPosition, Impact, Strand,
-    SupplementaryAnnotation, VariantType,
+    Allele, Consequence, GeneAnnotation, GenomicPosition, Impact, Strand, SupplementaryAnnotation,
+    VariantType,
 };
 use std::sync::Arc;
 
@@ -153,7 +153,10 @@ impl VariationFeature {
     pub fn is_indel(&self) -> bool {
         self.ref_allele == Allele::Deletion
             || self.alt_alleles.contains(&Allele::Deletion)
-            || self.alt_alleles.iter().any(|a| a.len() != self.ref_allele.len())
+            || self
+                .alt_alleles
+                .iter()
+                .any(|a| a.len() != self.ref_allele.len())
     }
 
     /// One `(allele_key, pos, ref, alt)` tuple per alternate allele, in

--- a/crates/fastvep-io/src/vcf.rs
+++ b/crates/fastvep-io/src/vcf.rs
@@ -121,9 +121,7 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
 
     // Check if any alt makes this an indel
     let is_indel = alt_allele_strs.iter().any(|alt| {
-        alt.starts_with('D')
-            || alt.starts_with('I')
-            || alt.len() != ref_allele_str.len()
+        alt.starts_with('D') || alt.starts_with('I') || alt.len() != ref_allele_str.len()
     });
 
     let is_non_variant = alt_str == "." || alt_str == "<NON_REF>" || alt_str == "<*>";
@@ -137,7 +135,12 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
         if alt_allele_strs.len() > 1 {
             // Multi-allelic indel: strip shared first base only if ALL non-star alleles share it
             let non_star: Vec<&str> = std::iter::once(ref_allele_str.as_str())
-                .chain(alt_allele_strs.iter().filter(|a| !a.contains('*')).map(|s| s.as_str()))
+                .chain(
+                    alt_allele_strs
+                        .iter()
+                        .filter(|a| !a.contains('*'))
+                        .map(|s| s.as_str()),
+                )
                 .collect();
 
             let all_share_first = non_star.len() > 1
@@ -200,11 +203,7 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
     let allele_string = if is_non_variant {
         ref_allele_str.clone()
     } else {
-        format!(
-            "{}/{}",
-            ref_allele_str,
-            alt_allele_strs.join("/")
-        )
+        format!("{}/{}", ref_allele_str, alt_allele_strs.join("/"))
     };
 
     // Convert to Allele enums.
@@ -219,10 +218,17 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
     let alt_alleles: Vec<Allele> = if is_non_variant {
         alt_allele_strs.iter().map(|_| Allele::Missing).collect()
     } else {
-        alt_allele_strs.iter().map(|s| Allele::from_str(s)).collect()
+        alt_allele_strs
+            .iter()
+            .map(|s| Allele::from_str(s))
+            .collect()
     };
 
-    let variation_name = if id == "." { None } else { Some(id.to_string()) };
+    let variation_name = if id == "." {
+        None
+    } else {
+        Some(id.to_string())
+    };
 
     let vcf_fields = VcfFields {
         chrom: chrom.to_string(),
@@ -239,12 +245,8 @@ pub fn parse_vcf_line(line: &str) -> Result<VariationFeature> {
     // Parse SV-related INFO fields for structural variants
     let (sv_end, sv_len, variant_type) = if has_symbolic {
         let info_map = parse_info_field(info);
-        let sv_end = info_map
-            .get("END")
-            .and_then(|v| v.parse::<u64>().ok());
-        let sv_len = info_map
-            .get("SVLEN")
-            .and_then(|v| v.parse::<i64>().ok());
+        let sv_end = info_map.get("END").and_then(|v| v.parse::<u64>().ok());
+        let sv_len = info_map.get("SVLEN").and_then(|v| v.parse::<i64>().ok());
         let svtype = info_map.get("SVTYPE").map(|s| s.as_str());
 
         let vtype = classify_sv_type(svtype, &alt_allele_strs);
@@ -311,9 +313,13 @@ fn classify_sv_type(svtype: Option<&str>, alts: &[String]) -> VariantType {
         s if s.starts_with("CN") => {
             // <CN0>, <CN1> = loss; <CN3>, <CN4> = gain
             if let Ok(cn) = s.trim_start_matches("CN").parse::<u32>() {
-                if cn < 2 { VariantType::CopyNumberLoss }
-                else if cn > 2 { VariantType::CopyNumberGain }
-                else { VariantType::CopyNumberVariation }
+                if cn < 2 {
+                    VariantType::CopyNumberLoss
+                } else if cn > 2 {
+                    VariantType::CopyNumberGain
+                } else {
+                    VariantType::CopyNumberVariation
+                }
             } else {
                 VariantType::CopyNumberVariation
             }

--- a/crates/fastvep-io/tests/vep_compat.rs
+++ b/crates/fastvep-io/tests/vep_compat.rs
@@ -227,9 +227,21 @@ fn test_vep_indel_variety() {
     // Various indel types from test_not_ordered.vcf
     let test_cases = vec![
         // (line, expected_start, expected_allele_string)
-        ("21\t30000016\trs202173120\tT\tTCA\t.\t.\t.", 30000017, "-/CA"),
-        ("21\t30000018\trs144102269\tA\tAAT\t.\t.\t.", 30000019, "-/AT"),
-        ("21\t30000020\trs35748481\tG\tGAT\t.\t.\t.", 30000021, "-/AT"),
+        (
+            "21\t30000016\trs202173120\tT\tTCA\t.\t.\t.",
+            30000017,
+            "-/CA",
+        ),
+        (
+            "21\t30000018\trs144102269\tA\tAAT\t.\t.\t.",
+            30000019,
+            "-/AT",
+        ),
+        (
+            "21\t30000020\trs35748481\tG\tGAT\t.\t.\t.",
+            30000021,
+            "-/AT",
+        ),
         ("21\t30000105\trs34988396\tC\tCC\t.\t.\t.", 30000106, "-/C"),
     ];
 
@@ -237,11 +249,13 @@ fn test_vep_indel_variety() {
         let vf = parse_vcf_line(line).unwrap();
         assert_eq!(
             vf.position.start, expected_start,
-            "Failed for: {} — got start={}", line, vf.position.start
+            "Failed for: {} — got start={}",
+            line, vf.position.start
         );
         assert_eq!(
             vf.allele_string, expected_alleles,
-            "Failed for: {} — got alleles={}", line, vf.allele_string
+            "Failed for: {} — got alleles={}",
+            line, vf.allele_string
         );
     }
 }
@@ -324,7 +338,13 @@ fn test_all_consequence_types_have_valid_so_terms() {
     for c in &all {
         let term = c.so_term();
         let parsed = Consequence::from_so_term(term);
-        assert_eq!(parsed, Some(*c), "SO term round-trip failed for {:?} ({})", c, term);
+        assert_eq!(
+            parsed,
+            Some(*c),
+            "SO term round-trip failed for {:?} ({})",
+            c,
+            term
+        );
     }
 
     // Verify strict ordering by rank
@@ -332,7 +352,10 @@ fn test_all_consequence_types_have_valid_so_terms() {
         assert!(
             all[i].rank() < all[i + 1].rank(),
             "{:?} (rank {}) should be more severe than {:?} (rank {})",
-            all[i], all[i].rank(), all[i + 1], all[i + 1].rank()
+            all[i],
+            all[i].rank(),
+            all[i + 1],
+            all[i + 1].rank()
         );
     }
 }
@@ -405,7 +428,12 @@ fn test_all_64_codons_translate() {
             for &b3 in &bases {
                 let codon = [b1, b2, b3];
                 let aa = table.translate(&codon);
-                assert_ne!(aa, b'X', "Codon {:?} should translate", std::str::from_utf8(&codon));
+                assert_ne!(
+                    aa,
+                    b'X',
+                    "Codon {:?} should translate",
+                    std::str::from_utf8(&codon)
+                );
                 count += 1;
             }
         }
@@ -631,32 +659,60 @@ fn test_csq_frameshift_codon_format() {
 #[test]
 fn test_csq_header_includes_new_fields() {
     let header = output::csq_header_line(output::DEFAULT_CSQ_FIELDS);
-    assert!(header.contains("REF_ALLELE"), "Header should include REF_ALLELE");
-    assert!(header.contains("UPLOADED_ALLELE"), "Header should include UPLOADED_ALLELE");
+    assert!(
+        header.contains("REF_ALLELE"),
+        "Header should include REF_ALLELE"
+    );
+    assert!(
+        header.contains("UPLOADED_ALLELE"),
+        "Header should include UPLOADED_ALLELE"
+    );
     assert!(header.contains("FLAGS"), "Header should include FLAGS");
-    assert!(header.contains("SYMBOL_SOURCE"), "Header should include SYMBOL_SOURCE");
+    assert!(
+        header.contains("SYMBOL_SOURCE"),
+        "Header should include SYMBOL_SOURCE"
+    );
     assert!(header.contains("HGNC_ID"), "Header should include HGNC_ID");
-    assert!(header.contains("MANE|MANE_SELECT"), "Header should include MANE fields");
+    assert!(
+        header.contains("MANE|MANE_SELECT"),
+        "Header should include MANE fields"
+    );
     assert!(header.contains("TSL"), "Header should include TSL");
     assert!(header.contains("APPRIS"), "Header should include APPRIS");
-    assert!(header.contains("TRANSCRIPTION_FACTORS"), "Header should end with TRANSCRIPTION_FACTORS");
-    assert!(header.contains("CANONICAL"), "Header should include CANONICAL");
+    assert!(
+        header.contains("TRANSCRIPTION_FACTORS"),
+        "Header should end with TRANSCRIPTION_FACTORS"
+    );
+    assert!(
+        header.contains("CANONICAL"),
+        "Header should include CANONICAL"
+    );
     assert!(header.contains("CCDS"), "Header should include CCDS");
     assert!(header.contains("ENSP"), "Header should include ENSP");
     assert!(header.contains("SOURCE"), "Header should include SOURCE");
-    assert!(header.contains("HGVS_OFFSET"), "Header should include HGVS_OFFSET");
+    assert!(
+        header.contains("HGVS_OFFSET"),
+        "Header should include HGVS_OFFSET"
+    );
 }
 
 #[test]
 fn test_csq_field_count_matches_vep() {
     // Extended field set includes all VEP fields plus CANONICAL, CCDS, ENSP, SOURCE, HGVS_OFFSET
-    assert_eq!(output::DEFAULT_CSQ_FIELDS.len(), 49, "DEFAULT_CSQ_FIELDS should have 49 fields");
+    assert_eq!(
+        output::DEFAULT_CSQ_FIELDS.len(),
+        49,
+        "DEFAULT_CSQ_FIELDS should have 49 fields"
+    );
 
     // Verify formatting produces 49 pipe-delimited values
     let vf = mock_vf_missense();
     let csq = output::format_csq(&vf, output::DEFAULT_CSQ_FIELDS);
     let field_count = csq.split('|').count();
-    assert_eq!(field_count, 49, "CSQ output should have 49 pipe-delimited fields");
+    assert_eq!(
+        field_count, 49,
+        "CSQ output should have 49 pipe-delimited fields"
+    );
 }
 
 #[test]
@@ -671,64 +727,75 @@ fn test_csq_missense_full_42_field_match() {
 
     // VEP expected values (all 49 fields)
     let expected: Vec<&str> = vec![
-        "C",                                  // 0:  Allele
-        "missense_variant",                   // 1:  Consequence
-        "MODERATE",                           // 2:  IMPACT
-        "OR4F5",                              // 3:  SYMBOL
-        "ENSG00000186092",                    // 4:  Gene
-        "Transcript",                         // 5:  Feature_type
-        "ENST00000641515.2",                  // 6:  Feature
-        "protein_coding",                     // 7:  BIOTYPE
-        "2/3",                                // 8:  EXON
-        "",                                   // 9:  INTRON
-        "",                                   // 10: HGVSc
-        "",                                   // 11: HGVSp
-        "64",                                 // 12: cDNA_position
-        "4",                                  // 13: CDS_position
-        "2",                                  // 14: Protein_position
-        "K/Q",                                // 15: Amino_acids
-        "Aag/Cag",                            // 16: Codons
-        "",                                   // 17: Existing_variation
-        "A",                                  // 18: REF_ALLELE
-        "A/C",                                // 19: UPLOADED_ALLELE
-        "",                                   // 20: DISTANCE
-        "1",                                  // 21: STRAND
-        "",                                   // 22: FLAGS
-        "",                                   // 23: CANONICAL
-        "HGNC",                               // 24: SYMBOL_SOURCE
-        "HGNC:14825",                         // 25: HGNC_ID
-        "MANE_Select",                        // 26: MANE
-        "NM_001005484.2",                     // 27: MANE_SELECT
-        "",                                   // 28: MANE_PLUS_CLINICAL
-        "",                                   // 29: TSL
-        "P1",                                 // 30: APPRIS
-        "",                                   // 31: CCDS
-        "",                                   // 32: ENSP
-        "",                                   // 33: SOURCE
-        "",                                   // 34: HGVS_OFFSET
-        "tolerated_low_confidence(0.06)",     // 35: SIFT
-        "benign(0)",                          // 36: PolyPhen
-        "",                                   // 37: AF
-        "",                                   // 38: CLIN_SIG
-        "",                                   // 39: SOMATIC
-        "",                                   // 40: PHENO
-        "",                                   // 41: PUBMED
-        "",                                   // 42: MOTIF_NAME
-        "",                                   // 43: MOTIF_POS
-        "",                                   // 44: HIGH_INF_POS
-        "",                                   // 45: MOTIF_SCORE_CHANGE
-        "",                                   // 46: TRANSCRIPTION_FACTORS
-        "",                                   // 47: ACMG (empty when --acmg not run)
-        "",                                   // 48: ACMG_CRITERIA
+        "C",                              // 0:  Allele
+        "missense_variant",               // 1:  Consequence
+        "MODERATE",                       // 2:  IMPACT
+        "OR4F5",                          // 3:  SYMBOL
+        "ENSG00000186092",                // 4:  Gene
+        "Transcript",                     // 5:  Feature_type
+        "ENST00000641515.2",              // 6:  Feature
+        "protein_coding",                 // 7:  BIOTYPE
+        "2/3",                            // 8:  EXON
+        "",                               // 9:  INTRON
+        "",                               // 10: HGVSc
+        "",                               // 11: HGVSp
+        "64",                             // 12: cDNA_position
+        "4",                              // 13: CDS_position
+        "2",                              // 14: Protein_position
+        "K/Q",                            // 15: Amino_acids
+        "Aag/Cag",                        // 16: Codons
+        "",                               // 17: Existing_variation
+        "A",                              // 18: REF_ALLELE
+        "A/C",                            // 19: UPLOADED_ALLELE
+        "",                               // 20: DISTANCE
+        "1",                              // 21: STRAND
+        "",                               // 22: FLAGS
+        "",                               // 23: CANONICAL
+        "HGNC",                           // 24: SYMBOL_SOURCE
+        "HGNC:14825",                     // 25: HGNC_ID
+        "MANE_Select",                    // 26: MANE
+        "NM_001005484.2",                 // 27: MANE_SELECT
+        "",                               // 28: MANE_PLUS_CLINICAL
+        "",                               // 29: TSL
+        "P1",                             // 30: APPRIS
+        "",                               // 31: CCDS
+        "",                               // 32: ENSP
+        "",                               // 33: SOURCE
+        "",                               // 34: HGVS_OFFSET
+        "tolerated_low_confidence(0.06)", // 35: SIFT
+        "benign(0)",                      // 36: PolyPhen
+        "",                               // 37: AF
+        "",                               // 38: CLIN_SIG
+        "",                               // 39: SOMATIC
+        "",                               // 40: PHENO
+        "",                               // 41: PUBMED
+        "",                               // 42: MOTIF_NAME
+        "",                               // 43: MOTIF_POS
+        "",                               // 44: HIGH_INF_POS
+        "",                               // 45: MOTIF_SCORE_CHANGE
+        "",                               // 46: TRANSCRIPTION_FACTORS
+        "",                               // 47: ACMG (empty when --acmg not run)
+        "",                               // 48: ACMG_CRITERIA
     ];
 
-    assert_eq!(fields.len(), expected.len(),
-        "Field count mismatch: got {}, expected {}", fields.len(), expected.len());
+    assert_eq!(
+        fields.len(),
+        expected.len(),
+        "Field count mismatch: got {}, expected {}",
+        fields.len(),
+        expected.len()
+    );
 
     for (i, (got, exp)) in fields.iter().zip(expected.iter()).enumerate() {
-        assert_eq!(got, exp,
+        assert_eq!(
+            got,
+            exp,
             "Field {} ({}) mismatch: got {:?}, expected {:?}",
-            i, output::DEFAULT_CSQ_FIELDS[i], got, exp);
+            i,
+            output::DEFAULT_CSQ_FIELDS[i],
+            got,
+            exp
+        );
     }
 }
 
@@ -804,64 +871,75 @@ fn test_csq_frameshift_full_42_field_match() {
     // -|frameshift_variant|HIGH|CHL1|ENSG00000134121|Transcript|ENST00000421198.5|
     // protein_coding|3/5||||258|5|2|E/X|gAg/gg||A|A/-||1|cds_end_NF|HGNC|HGNC:1939||||4|||||||||||||
     let expected: Vec<&str> = vec![
-        "-",                    // 0:  Allele
-        "frameshift_variant",   // 1:  Consequence
-        "HIGH",                 // 2:  IMPACT
-        "CHL1",                 // 3:  SYMBOL
-        "ENSG00000134121",      // 4:  Gene
-        "Transcript",           // 5:  Feature_type
-        "ENST00000421198.5",    // 6:  Feature
-        "protein_coding",       // 7:  BIOTYPE
-        "3/5",                  // 8:  EXON
-        "",                     // 9:  INTRON
-        "",                     // 10: HGVSc
-        "",                     // 11: HGVSp
-        "258",                  // 12: cDNA_position
-        "5",                    // 13: CDS_position
-        "2",                    // 14: Protein_position
-        "E/X",                  // 15: Amino_acids
-        "gAg/gg",               // 16: Codons
-        "",                     // 17: Existing_variation
-        "A",                    // 18: REF_ALLELE
-        "A/-",                  // 19: UPLOADED_ALLELE
-        "",                     // 20: DISTANCE
-        "1",                    // 21: STRAND
-        "cds_end_NF",           // 22: FLAGS
-        "",                     // 23: CANONICAL
-        "HGNC",                 // 24: SYMBOL_SOURCE
-        "HGNC:1939",            // 25: HGNC_ID
-        "",                     // 26: MANE
-        "",                     // 27: MANE_SELECT
-        "",                     // 28: MANE_PLUS_CLINICAL
-        "4",                    // 29: TSL
-        "",                     // 30: APPRIS
-        "",                     // 31: CCDS
-        "",                     // 32: ENSP
-        "",                     // 33: SOURCE
-        "",                     // 34: HGVS_OFFSET
-        "",                     // 35: SIFT
-        "",                     // 36: PolyPhen
-        "",                     // 37: AF
-        "",                     // 38: CLIN_SIG
-        "",                     // 39: SOMATIC
-        "",                     // 40: PHENO
-        "",                     // 41: PUBMED
-        "",                     // 42: MOTIF_NAME
-        "",                     // 43: MOTIF_POS
-        "",                     // 44: HIGH_INF_POS
-        "",                     // 45: MOTIF_SCORE_CHANGE
-        "",                     // 46: TRANSCRIPTION_FACTORS
-        "",                     // 47: ACMG
-        "",                     // 48: ACMG_CRITERIA
+        "-",                  // 0:  Allele
+        "frameshift_variant", // 1:  Consequence
+        "HIGH",               // 2:  IMPACT
+        "CHL1",               // 3:  SYMBOL
+        "ENSG00000134121",    // 4:  Gene
+        "Transcript",         // 5:  Feature_type
+        "ENST00000421198.5",  // 6:  Feature
+        "protein_coding",     // 7:  BIOTYPE
+        "3/5",                // 8:  EXON
+        "",                   // 9:  INTRON
+        "",                   // 10: HGVSc
+        "",                   // 11: HGVSp
+        "258",                // 12: cDNA_position
+        "5",                  // 13: CDS_position
+        "2",                  // 14: Protein_position
+        "E/X",                // 15: Amino_acids
+        "gAg/gg",             // 16: Codons
+        "",                   // 17: Existing_variation
+        "A",                  // 18: REF_ALLELE
+        "A/-",                // 19: UPLOADED_ALLELE
+        "",                   // 20: DISTANCE
+        "1",                  // 21: STRAND
+        "cds_end_NF",         // 22: FLAGS
+        "",                   // 23: CANONICAL
+        "HGNC",               // 24: SYMBOL_SOURCE
+        "HGNC:1939",          // 25: HGNC_ID
+        "",                   // 26: MANE
+        "",                   // 27: MANE_SELECT
+        "",                   // 28: MANE_PLUS_CLINICAL
+        "4",                  // 29: TSL
+        "",                   // 30: APPRIS
+        "",                   // 31: CCDS
+        "",                   // 32: ENSP
+        "",                   // 33: SOURCE
+        "",                   // 34: HGVS_OFFSET
+        "",                   // 35: SIFT
+        "",                   // 36: PolyPhen
+        "",                   // 37: AF
+        "",                   // 38: CLIN_SIG
+        "",                   // 39: SOMATIC
+        "",                   // 40: PHENO
+        "",                   // 41: PUBMED
+        "",                   // 42: MOTIF_NAME
+        "",                   // 43: MOTIF_POS
+        "",                   // 44: HIGH_INF_POS
+        "",                   // 45: MOTIF_SCORE_CHANGE
+        "",                   // 46: TRANSCRIPTION_FACTORS
+        "",                   // 47: ACMG
+        "",                   // 48: ACMG_CRITERIA
     ];
 
-    assert_eq!(fields.len(), expected.len(),
-        "Field count mismatch: got {}, expected {}", fields.len(), expected.len());
+    assert_eq!(
+        fields.len(),
+        expected.len(),
+        "Field count mismatch: got {}, expected {}",
+        fields.len(),
+        expected.len()
+    );
 
     for (i, (got, exp)) in fields.iter().zip(expected.iter()).enumerate() {
-        assert_eq!(got, exp,
+        assert_eq!(
+            got,
+            exp,
             "Field {} ({}) mismatch: got {:?}, expected {:?}",
-            i, output::DEFAULT_CSQ_FIELDS[i], got, exp);
+            i,
+            output::DEFAULT_CSQ_FIELDS[i],
+            got,
+            exp
+        );
     }
 }
 
@@ -950,11 +1028,11 @@ fn test_csq_downstream_variant_match() {
     assert_eq!(fields[24], "HGNC");
     assert_eq!(fields[25], "HGNC:31276");
     // All annotation fields should be empty for downstream variant
-    assert_eq!(fields[8], "");   // EXON
-    assert_eq!(fields[12], "");  // cDNA_position
-    assert_eq!(fields[13], "");  // CDS_position
-    assert_eq!(fields[15], "");  // Amino_acids
-    assert_eq!(fields[16], "");  // Codons
+    assert_eq!(fields[8], ""); // EXON
+    assert_eq!(fields[12], ""); // cDNA_position
+    assert_eq!(fields[13], ""); // CDS_position
+    assert_eq!(fields[15], ""); // Amino_acids
+    assert_eq!(fields[16], ""); // Codons
 }
 
 #[test]
@@ -1035,15 +1113,15 @@ fn test_csq_intron_variant_match() {
     assert_eq!(fields[2], "MODIFIER");
     assert_eq!(fields[3], "ACP1");
     assert_eq!(fields[7], "protein_coding");
-    assert_eq!(fields[8], "");     // EXON empty for intron
-    assert_eq!(fields[9], "1/5");  // INTRON
+    assert_eq!(fields[8], ""); // EXON empty for intron
+    assert_eq!(fields[9], "1/5"); // INTRON
     assert_eq!(fields[18], "C");
     assert_eq!(fields[19], "C/T");
     assert_eq!(fields[21], "1");
-    assert_eq!(fields[24], "HGNC");     // SYMBOL_SOURCE (shifted +1)
+    assert_eq!(fields[24], "HGNC"); // SYMBOL_SOURCE (shifted +1)
     assert_eq!(fields[25], "HGNC:122");
     assert_eq!(fields[26], "MANE_Select");
     assert_eq!(fields[27], "NM_004300.4");
-    assert_eq!(fields[29], "1");   // TSL (shifted +1)
-    assert_eq!(fields[30], "P3");  // APPRIS (shifted +1)
+    assert_eq!(fields[29], "1"); // TSL (shifted +1)
+    assert_eq!(fields[30], "P3"); // APPRIS (shifted +1)
 }

--- a/crates/fastvep-sa/examples/bench_shapes.rs
+++ b/crates/fastvep-sa/examples/bench_shapes.rs
@@ -65,7 +65,10 @@ const HUMAN_CHROMS: &[(u16, &str, u32)] = &[
 ];
 
 fn env_usize(name: &str, default: usize) -> usize {
-    env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 
 fn chrom_list() -> Vec<String> {
@@ -96,7 +99,11 @@ fn build_sites(n_records: usize) -> Vec<Site> {
         let step = (*length as u64 / share as u64).max(1);
         for j in 0..share {
             let pos = (1 + j as u64 * step).min(*length as u64) as u32;
-            sites.push(Site { chrom_idx: *chrom_idx, chrom: name, position: pos });
+            sites.push(Site {
+                chrom_idx: *chrom_idx,
+                chrom: name,
+                position: pos,
+            });
         }
     }
     sites
@@ -137,9 +144,15 @@ impl Numeric {
     }
 }
 impl Shape for Numeric {
-    fn name(&self) -> &'static str { "numeric   (gnomAD: AF+AN+AC)" }
-    fn json_key(&self) -> &'static str { "gnomad" }
-    fn v2_fields(&self) -> Vec<Field> { self.fields.clone() }
+    fn name(&self) -> &'static str {
+        "numeric   (gnomAD: AF+AN+AC)"
+    }
+    fn json_key(&self) -> &'static str {
+        "gnomad"
+    }
+    fn v2_fields(&self) -> Vec<Field> {
+        self.fields.clone()
+    }
     fn v1_json(&self, s: &Site) -> String {
         let af = ((s.position as u64 % 100_000) as f64) / 1_000_000.0;
         let an = 150_000i64;
@@ -180,19 +193,31 @@ impl Score {
     }
 }
 impl Shape for Score {
-    fn name(&self) -> &'static str { "score     (AlphaMissense: score+class)" }
-    fn json_key(&self) -> &'static str { "alphaMissense" }
-    fn v2_fields(&self) -> Vec<Field> { self.fields.clone() }
+    fn name(&self) -> &'static str {
+        "score     (AlphaMissense: score+class)"
+    }
+    fn json_key(&self) -> &'static str {
+        "alphaMissense"
+    }
+    fn v2_fields(&self) -> Vec<Field> {
+        self.fields.clone()
+    }
     fn v2_string_tables(&self) -> Vec<(usize, Vec<String>)> {
         vec![(1, AM_CLASSES.iter().map(|s| s.to_string()).collect())]
     }
     fn v1_json(&self, s: &Site) -> String {
         let score = Self::score_of(s);
         let class = AM_CLASSES[Self::class_of(s) as usize];
-        format!(r#"{{"amPathogenicity":{:.6e},"amClass":"{}"}}"#, score, class)
+        format!(
+            r#"{{"amPathogenicity":{:.6e},"amClass":"{}"}}"#,
+            score, class
+        )
     }
     fn v2_values(&self, s: &Site) -> Vec<u32> {
-        vec![self.fields[0].encode_float(Self::score_of(s)), Self::class_of(s)]
+        vec![
+            self.fields[0].encode_float(Self::score_of(s)),
+            Self::class_of(s),
+        ]
     }
 }
 
@@ -202,20 +227,37 @@ struct IdString {
 }
 impl IdString {
     fn new() -> Self {
-        Self { fields: vec![blob_field("dbsnp")] }
+        Self {
+            fields: vec![blob_field("dbsnp")],
+        }
     }
     fn blob(s: &Site) -> String {
         // One opaque, near-unique identifier per variant, as dbSNP carries.
-        format!(r#"{{"rsId":"rs{}"}}"#, (s.chrom_idx as u64) * 1_000_000_000 + s.position as u64)
+        format!(
+            r#"{{"rsId":"rs{}"}}"#,
+            (s.chrom_idx as u64) * 1_000_000_000 + s.position as u64
+        )
     }
 }
 impl Shape for IdString {
-    fn name(&self) -> &'static str { "id_string (dbSNP: rsID blob)" }
-    fn json_key(&self) -> &'static str { "dbsnp" }
-    fn v2_fields(&self) -> Vec<Field> { self.fields.clone() }
-    fn v1_json(&self, s: &Site) -> String { Self::blob(s) }
-    fn v2_values(&self, _s: &Site) -> Vec<u32> { Vec::new() }
-    fn v2_blob(&self, s: &Site) -> Option<String> { Some(Self::blob(s)) }
+    fn name(&self) -> &'static str {
+        "id_string (dbSNP: rsID blob)"
+    }
+    fn json_key(&self) -> &'static str {
+        "dbsnp"
+    }
+    fn v2_fields(&self) -> Vec<Field> {
+        self.fields.clone()
+    }
+    fn v1_json(&self, s: &Site) -> String {
+        Self::blob(s)
+    }
+    fn v2_values(&self, _s: &Site) -> Vec<u32> {
+        Vec::new()
+    }
+    fn v2_blob(&self, s: &Site) -> Option<String> {
+        Some(Self::blob(s))
+    }
 }
 
 // --- array_blob (ClinVar-like) ---------------------------------------------
@@ -224,7 +266,9 @@ struct ArrayBlob {
 }
 impl ArrayBlob {
     fn new() -> Self {
-        Self { fields: vec![blob_field("clinvar")] }
+        Self {
+            fields: vec![blob_field("clinvar")],
+        }
     }
     fn blob(s: &Site) -> String {
         // A multi-field record with arrays, as ClinVar carries.
@@ -243,41 +287,75 @@ impl ArrayBlob {
     }
 }
 impl Shape for ArrayBlob {
-    fn name(&self) -> &'static str { "array_blob(ClinVar: sig array + fields)" }
-    fn json_key(&self) -> &'static str { "clinvar" }
-    fn is_array(&self) -> bool { true }
-    fn v2_fields(&self) -> Vec<Field> { self.fields.clone() }
-    fn v1_json(&self, s: &Site) -> String { Self::blob(s) }
-    fn v2_values(&self, _s: &Site) -> Vec<u32> { Vec::new() }
-    fn v2_blob(&self, s: &Site) -> Option<String> { Some(Self::blob(s)) }
+    fn name(&self) -> &'static str {
+        "array_blob(ClinVar: sig array + fields)"
+    }
+    fn json_key(&self) -> &'static str {
+        "clinvar"
+    }
+    fn is_array(&self) -> bool {
+        true
+    }
+    fn v2_fields(&self) -> Vec<Field> {
+        self.fields.clone()
+    }
+    fn v1_json(&self, s: &Site) -> String {
+        Self::blob(s)
+    }
+    fn v2_values(&self, _s: &Site) -> Vec<u32> {
+        Vec::new()
+    }
+    fn v2_blob(&self, s: &Site) -> Option<String> {
+        Some(Self::blob(s))
+    }
 }
 
 fn float_field(field: &str, alias: &str, multiplier: u32) -> Field {
     Field {
-        field: field.into(), alias: alias.into(), ftype: FieldType::Float,
-        multiplier, zigzag: false, missing_value: u32::MAX,
-        missing_string: ".".into(), description: String::new(),
+        field: field.into(),
+        alias: alias.into(),
+        ftype: FieldType::Float,
+        multiplier,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
     }
 }
 fn int_field(field: &str, alias: &str) -> Field {
     Field {
-        field: field.into(), alias: alias.into(), ftype: FieldType::Integer,
-        multiplier: 1, zigzag: false, missing_value: u32::MAX,
-        missing_string: ".".into(), description: String::new(),
+        field: field.into(),
+        alias: alias.into(),
+        ftype: FieldType::Integer,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
     }
 }
 fn categorical_field(field: &str, alias: &str) -> Field {
     Field {
-        field: field.into(), alias: alias.into(), ftype: FieldType::Categorical,
-        multiplier: 1, zigzag: false, missing_value: u32::MAX,
-        missing_string: ".".into(), description: String::new(),
+        field: field.into(),
+        alias: alias.into(),
+        ftype: FieldType::Categorical,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
     }
 }
 fn blob_field(alias: &str) -> Field {
     Field {
-        field: alias.into(), alias: alias.into(), ftype: FieldType::JsonBlob,
-        multiplier: 1, zigzag: false, missing_value: u32::MAX,
-        missing_string: ".".into(), description: String::new(),
+        field: alias.into(),
+        alias: alias.into(),
+        ftype: FieldType::JsonBlob,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
     }
 }
 
@@ -292,7 +370,11 @@ fn build_v1(path: &Path, sites: &[Site], shape: &dyn Shape) -> Result<u64> {
             json: shape.v1_json(s),
         })
         .collect();
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
 
     let header = IndexHeader {
         schema_version: SCHEMA_VERSION,
@@ -375,7 +457,11 @@ fn score_text(score: f64) -> String {
 /// would flatter v2's compression and overstate the size win.
 fn positional_score(pos: u32) -> f64 {
     let phase = (pos % 2000) as f64 / 2000.0; // 0..1
-    let tri = if phase < 0.5 { phase * 2.0 } else { 2.0 - phase * 2.0 }; // 0..1..0
+    let tri = if phase < 0.5 {
+        phase * 2.0
+    } else {
+        2.0 - phase * 2.0
+    }; // 0..1..0
     let base = tri * 10.0 - 4.0;
     // Knuth multiplicative hash → deterministic per-position jitter in ~[-0.5, 0.5].
     let h = pos.wrapping_mul(2_654_435_761);
@@ -422,7 +508,9 @@ fn bench_positional(n_records: usize) -> Result<()> {
     let mut w = SaWriter::new(header);
     w.write_to_files(&v1_base, v1_records.into_iter(), &chrom_list())?;
     let v1_size = std::fs::metadata(v1_base.with_extension("osa"))?.len()
-        + std::fs::metadata(v1_base.with_extension("osa.idx")).map(|m| m.len()).unwrap_or(0);
+        + std::fs::metadata(v1_base.with_extension("osa.idx"))
+            .map(|m| m.len())
+            .unwrap_or(0);
 
     // --- v2 .osa2 (positional metadata, whole-record blob = bare number) ---
     let mut v2_records: Vec<Osa2Record> = Vec::with_capacity(n_records);
@@ -488,7 +576,10 @@ fn main() -> Result<()> {
         Box::new(ArrayBlob::new()),
     ];
 
-    println!("{:<40} {:>12} {:>12} {:>10}", "shape", "v1 MB", "v2 MB", "v2/v1");
+    println!(
+        "{:<40} {:>12} {:>12} {:>10}",
+        "shape", "v1 MB", "v2 MB", "v2/v1"
+    );
     println!("{}", "-".repeat(76));
 
     for shape in &shapes {
@@ -510,7 +601,11 @@ fn main() -> Result<()> {
         let got_v2 = v2_reader
             .annotate_position(sample.chrom, sample.position as u64, "A", "G")?
             .is_some();
-        let flag = if got_v1 != got_v2 { "  !! data mismatch" } else { "" };
+        let flag = if got_v1 != got_v2 {
+            "  !! data mismatch"
+        } else {
+            ""
+        };
 
         println!(
             "{:<40} {:>12.1} {:>12.1} {:>9.2}x{}",

--- a/crates/fastvep-sa/examples/bench_v1_vs_v2.rs
+++ b/crates/fastvep-sa/examples/bench_v1_vs_v2.rs
@@ -56,11 +56,17 @@ const HUMAN_CHROMS: &[(u16, &str, u32)] = &[
 ];
 
 fn env_usize(name: &str, default: usize) -> usize {
-    env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 
 fn env_f64(name: &str, default: f64) -> f64 {
-    env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 
 fn chrom_map() -> Vec<String> {
@@ -128,7 +134,11 @@ fn build_v1(path: &Path, sites: &[SiteData]) -> Result<u64> {
             ),
         })
         .collect();
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
 
     let header = IndexHeader {
         schema_version: SCHEMA_VERSION,
@@ -149,19 +159,34 @@ fn build_v1(path: &Path, sites: &[SiteData]) -> Result<u64> {
 fn v2_fields() -> Vec<Field> {
     vec![
         Field {
-            field: "AF".into(), alias: "allAf".into(), ftype: FieldType::Float,
-            multiplier: 1_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Global allele frequency".into(),
+            field: "AF".into(),
+            alias: "allAf".into(),
+            ftype: FieldType::Float,
+            multiplier: 1_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Global allele frequency".into(),
         },
         Field {
-            field: "AN".into(), alias: "allAn".into(), ftype: FieldType::Integer,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Total allele number".into(),
+            field: "AN".into(),
+            alias: "allAn".into(),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Total allele number".into(),
         },
         Field {
-            field: "AC".into(), alias: "allAc".into(), ftype: FieldType::Integer,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Allele count".into(),
+            field: "AC".into(),
+            alias: "allAc".into(),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Allele count".into(),
         },
     ]
 }
@@ -206,7 +231,11 @@ fn build_v2(path: &Path, sites: &[SiteData]) -> Result<u64> {
 /// Sorted query positions across the genome, mimicking a normal VCF input.
 /// `hit_rate` controls how many land on an annotated site vs. a definite miss
 /// (offset by +1 bp, which no synthetic record occupies given the spacing).
-fn build_workload(sites: &[SiteData], n_variants: usize, hit_rate: f64) -> Vec<(&'static str, u64)> {
+fn build_workload(
+    sites: &[SiteData],
+    n_variants: usize,
+    hit_rate: f64,
+) -> Vec<(&'static str, u64)> {
     if sites.is_empty() {
         return Vec::new();
     }
@@ -220,7 +249,11 @@ fn build_workload(sites: &[SiteData], n_variants: usize, hit_rate: f64) -> Vec<(
         // Deterministic hit/miss split: first `hit_rate` share of each 100
         // queries hit, the rest are shifted to a guaranteed-empty position.
         let is_hit = ((n % 100) as f64) < hit_rate * 100.0;
-        let pos = if is_hit { s.position as u64 } else { s.position as u64 + 1 };
+        let pos = if is_hit {
+            s.position as u64
+        } else {
+            s.position as u64 + 1
+        };
         out.push((s.chrom, pos));
         i += stride;
         n += 1;
@@ -239,7 +272,8 @@ fn run_workload(
     let mut hits = 0u64;
     let mut total = 0u64;
     for chunk in workload.chunks(batch_size) {
-        let mut by_chrom: std::collections::HashMap<&str, Vec<u64>> = std::collections::HashMap::new();
+        let mut by_chrom: std::collections::HashMap<&str, Vec<u64>> =
+            std::collections::HashMap::new();
         for (chrom, pos) in chunk {
             by_chrom.entry(chrom).or_default().push(*pos);
         }
@@ -280,7 +314,11 @@ fn main() -> Result<()> {
     println!("Generating {} synthetic sites...", n_records);
     let sites = build_sites(n_records);
     let workload = build_workload(&sites, n_variants, hit_rate);
-    println!("  {} sites, {} query positions\n", sites.len(), workload.len());
+    println!(
+        "  {} sites, {} query positions\n",
+        sites.len(),
+        workload.len()
+    );
 
     // --- Build ---
     let v1_base = base.with_extension("v1");
@@ -312,11 +350,17 @@ fn main() -> Result<()> {
     println!("QUERY (preload + per-(transcript,allele))");
     println!(
         "  v1 (.osa) : {:.2}s  {:.0} q/s  ({} hits / {} queries)",
-        v1_t, v1_total as f64 / v1_t, v1_hits, v1_total
+        v1_t,
+        v1_total as f64 / v1_t,
+        v1_hits,
+        v1_total
     );
     println!(
         "  v2 (.osa2): {:.2}s  {:.0} q/s  ({} hits / {} queries)",
-        v2_t, v2_total as f64 / v2_t, v2_hits, v2_total
+        v2_t,
+        v2_total as f64 / v2_t,
+        v2_hits,
+        v2_total
     );
     println!("  -> v2 query throughput is {:.2}x v1\n", v1_t / v2_t);
 
@@ -327,7 +371,10 @@ fn main() -> Result<()> {
             v1_hits, v2_hits
         );
     } else {
-        println!("OK: both formats returned {} hits (equivalent lookups)", v1_hits);
+        println!(
+            "OK: both formats returned {} hits (equivalent lookups)",
+            v1_hits
+        );
     }
 
     Ok(())

--- a/crates/fastvep-sa/examples/probe_sa.rs
+++ b/crates/fastvep-sa/examples/probe_sa.rs
@@ -10,7 +10,10 @@ use std::fs::File;
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
-    let path: PathBuf = env::args().nth(1).expect("usage: probe_sa <file.osa>").into();
+    let path: PathBuf = env::args()
+        .nth(1)
+        .expect("usage: probe_sa <file.osa>")
+        .into();
     let idx_path = path.with_extension("osa.idx");
     let mut f = File::open(&idx_path)?;
     let idx = SaIndex::read_from(&mut f)?;
@@ -33,10 +36,14 @@ fn main() -> Result<()> {
             let entries = SaBlock::decompress(data)?;
             total_comp += comp_len as u64;
             // raw bytes: u32 + 3 strings' data
-            let raw: usize = entries.iter().map(|e| 4 + e.ref_allele.len() + e.alt_allele.len() + e.json.len()).sum();
+            let raw: usize = entries
+                .iter()
+                .map(|e| 4 + e.ref_allele.len() + e.alt_allele.len() + e.json.len())
+                .sum();
             total_decomp += raw as u64;
             // struct overhead: Vec header (24) + per-entry (size_of::<BlockEntry>() = ~76)
-            let overhead = 24 + entries.len() * std::mem::size_of::<fastvep_sa::block::BlockEntry>();
+            let overhead =
+                24 + entries.len() * std::mem::size_of::<fastvep_sa::block::BlockEntry>();
             decomp_struct_overhead += overhead as u64;
             let block_inmem = raw + overhead;
             max_decomp = max_decomp.max(block_inmem);
@@ -44,11 +51,23 @@ fn main() -> Result<()> {
     }
     println!("blocks: {}", count);
     println!("avg compressed: {} KB", total_comp / count / 1024);
-    println!("avg raw bytes (strings only): {} KB", total_decomp / count / 1024);
-    println!("avg struct overhead: {} KB", decomp_struct_overhead / count / 1024);
+    println!(
+        "avg raw bytes (strings only): {} KB",
+        total_decomp / count / 1024
+    );
+    println!(
+        "avg struct overhead: {} KB",
+        decomp_struct_overhead / count / 1024
+    );
     println!("total compressed: {} MB", total_comp / (1024 * 1024));
-    println!("total decompressed (strings+overhead): {} MB", (total_decomp + decomp_struct_overhead) / (1024 * 1024));
+    println!(
+        "total decompressed (strings+overhead): {} MB",
+        (total_decomp + decomp_struct_overhead) / (1024 * 1024)
+    );
     println!("max single in-mem block: {} MB", max_decomp / (1024 * 1024));
-    println!("with cap=4: max footprint ≈ {} MB", (max_decomp * 4) / (1024 * 1024));
+    println!(
+        "with cap=4: max footprint ≈ {} MB",
+        (max_decomp * 4) / (1024 * 1024)
+    );
     Ok(())
 }

--- a/crates/fastvep-sa/src/block.rs
+++ b/crates/fastvep-sa/src/block.rs
@@ -40,7 +40,8 @@ impl SaBlock {
 
     /// Try to add an entry. Returns `false` if the block is full (entry not added).
     pub fn add(&mut self, entry: BlockEntry) -> bool {
-        let entry_size = 4 + 2 + entry.ref_allele.len() + 2 + entry.alt_allele.len() + 4 + entry.json.len();
+        let entry_size =
+            4 + 2 + entry.ref_allele.len() + 2 + entry.alt_allele.len() + 4 + entry.json.len();
         if !self.entries.is_empty() && self.uncompressed_size + entry_size > self.max_size {
             return false;
         }

--- a/crates/fastvep-sa/src/chunk.rs
+++ b/crates/fastvep-sa/src/chunk.rs
@@ -70,7 +70,10 @@ impl Chunk {
             idx: 0,
             sequence,
         };
-        self.longs.binary_search(&query).ok().map(|i| self.longs[i].idx as usize)
+        self.longs
+            .binary_search(&query)
+            .ok()
+            .map(|i| self.longs[i].idx as usize)
     }
 
     /// Look up a variant whose alleles are not 2-bit packable. Returns the index
@@ -144,7 +147,8 @@ impl Chunk {
                 continue; // Skip missing values in output
             }
 
-            let val_str = crate::fields::format_value(field, stored, strings.get(fi).map(|v| v.as_slice()));
+            let val_str =
+                crate::fields::format_value(field, stored, strings.get(fi).map(|v| v.as_slice()));
             if val_str != "null" {
                 parts.push(format!("\"{}\":{}", field.alias, val_str));
             }
@@ -231,19 +235,34 @@ mod tests {
         // after a JsonBlob field. Verify the trailing Integer is emitted.
         let fields = vec![
             Field {
-                field: "AF".into(), alias: "af".into(), ftype: FieldType::Float,
-                multiplier: 1_000_000, zigzag: false, missing_value: u32::MAX,
-                missing_string: ".".into(), description: String::new(),
+                field: "AF".into(),
+                alias: "af".into(),
+                ftype: FieldType::Float,
+                multiplier: 1_000_000,
+                zigzag: false,
+                missing_value: u32::MAX,
+                missing_string: ".".into(),
+                description: String::new(),
             },
             Field {
-                field: "blob".into(), alias: "blob".into(), ftype: FieldType::JsonBlob,
-                multiplier: 1, zigzag: false, missing_value: u32::MAX,
-                missing_string: ".".into(), description: String::new(),
+                field: "blob".into(),
+                alias: "blob".into(),
+                ftype: FieldType::JsonBlob,
+                multiplier: 1,
+                zigzag: false,
+                missing_value: u32::MAX,
+                missing_string: ".".into(),
+                description: String::new(),
             },
             Field {
-                field: "AC".into(), alias: "ac".into(), ftype: FieldType::Integer,
-                multiplier: 1, zigzag: false, missing_value: u32::MAX,
-                missing_string: ".".into(), description: String::new(),
+                field: "AC".into(),
+                alias: "ac".into(),
+                ftype: FieldType::Integer,
+                multiplier: 1,
+                zigzag: false,
+                missing_value: u32::MAX,
+                missing_string: ".".into(),
+                description: String::new(),
             },
         ];
 
@@ -256,7 +275,11 @@ mod tests {
         let json = chunk.reconstruct_json(0, &fields, &[]);
         assert!(json.contains("\"af\":"), "missing af in: {}", json);
         assert!(json.contains("\"ac\":42"), "missing ac in: {}", json);
-        assert!(json.contains("\"blob\":{\"k\":1}"), "missing blob in: {}", json);
+        assert!(
+            json.contains("\"blob\":{\"k\":1}"),
+            "missing blob in: {}",
+            json
+        );
     }
 
     #[test]
@@ -265,9 +288,14 @@ mod tests {
         // the complete record object; reconstruct_json must return it verbatim
         // (not nested under a key), so v2 reproduces the v1 JSON exactly.
         let fields = vec![Field {
-            field: String::new(), alias: String::new(), ftype: FieldType::JsonBlob,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: String::new(),
+            alias: String::new(),
+            ftype: FieldType::JsonBlob,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         }];
         let mut chunk = Chunk::empty();
         chunk.var32s = vec![var32::encode(100, b"A", b"G").unwrap()];
@@ -282,22 +310,32 @@ mod tests {
     fn test_chunk_reconstruct_json() {
         let fields = vec![
             Field {
-                field: "AF".into(), alias: "allAf".into(), ftype: FieldType::Float,
-                multiplier: 1_000_000, zigzag: false, missing_value: u32::MAX,
-                missing_string: ".".into(), description: String::new(),
+                field: "AF".into(),
+                alias: "allAf".into(),
+                ftype: FieldType::Float,
+                multiplier: 1_000_000,
+                zigzag: false,
+                missing_value: u32::MAX,
+                missing_string: ".".into(),
+                description: String::new(),
             },
             Field {
-                field: "AC".into(), alias: "allAc".into(), ftype: FieldType::Integer,
-                multiplier: 1, zigzag: false, missing_value: u32::MAX,
-                missing_string: ".".into(), description: String::new(),
+                field: "AC".into(),
+                alias: "allAc".into(),
+                ftype: FieldType::Integer,
+                multiplier: 1,
+                zigzag: false,
+                missing_value: u32::MAX,
+                missing_string: ".".into(),
+                description: String::new(),
             },
         ];
 
         let mut chunk = Chunk::empty();
         chunk.var32s = vec![var32::encode(100, b"A", b"G").unwrap()];
         chunk.values = vec![
-            vec![1234],   // AF * 1_000_000 = 0.001234
-            vec![42],     // AC = 42
+            vec![1234], // AF * 1_000_000 = 0.001234
+            vec![42],   // AC = 42
         ];
 
         let json = chunk.reconstruct_json(0, &fields, &[]);

--- a/crates/fastvep-sa/src/custom.rs
+++ b/crates/fastvep-sa/src/custom.rs
@@ -127,8 +127,7 @@ pub fn parse_custom_vcf<R: BufRead>(
             }
             // `serde_json::to_string` on a `Map<String, Value>` produces
             // a well-formed JSON object string.
-            let json = serde_json::to_string(&obj)
-                .unwrap_or_else(|_| "{}".to_string());
+            let json = serde_json::to_string(&obj).unwrap_or_else(|_| "{}".to_string());
 
             records.push(AnnotationRecord {
                 chrom_idx,
@@ -140,7 +139,11 @@ pub fn parse_custom_vcf<R: BufRead>(
         }
     }
 
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -284,7 +287,11 @@ fn parse_info(info: &str) -> BTreeMap<String, String> {
 }
 
 fn normalize_chrom(chrom: &str) -> String {
-    if chrom.starts_with("chr") { chrom.to_string() } else { format!("chr{}", chrom) }
+    if chrom.starts_with("chr") {
+        chrom.to_string()
+    } else {
+        format!("chr{}", chrom)
+    }
 }
 
 #[cfg(test)]
@@ -303,10 +310,7 @@ mod tests {
         assert!(recs[0].json.contains("MY_SCORE"));
 
         // Specific fields
-        let recs = parse_custom_vcf(
-            vcf.as_bytes(), &m, "test",
-            &["MY_SCORE".to_string()],
-        ).unwrap();
+        let recs = parse_custom_vcf(vcf.as_bytes(), &m, "test", &["MY_SCORE".to_string()]).unwrap();
         assert!(recs[0].json.contains("MY_SCORE"));
         assert!(!recs[0].json.contains("MY_FLAG"));
     }
@@ -422,7 +426,10 @@ mod tests {
         let recs = parse_custom_vcf(vcf.as_bytes(), &m, "t", &[]).unwrap();
         assert_eq!(recs.len(), 1);
         let val: serde_json::Value = serde_json::from_str(&recs[0].json).unwrap();
-        assert_eq!(val["CAT"], "foo,bar", "biallelic 2-value field must stay intact");
+        assert_eq!(
+            val["CAT"], "foo,bar",
+            "biallelic 2-value field must stay intact"
+        );
     }
 
     #[test]

--- a/crates/fastvep-sa/src/fields.rs
+++ b/crates/fastvep-sa/src/fields.rs
@@ -48,9 +48,15 @@ pub struct Field {
     pub description: String,
 }
 
-fn default_multiplier() -> u32 { 1 }
-fn default_missing() -> u32 { u32::MAX }
-fn default_missing_string() -> String { ".".into() }
+fn default_multiplier() -> u32 {
+    1
+}
+fn default_missing() -> u32 {
+    u32::MAX
+}
+fn default_missing_string() -> String {
+    ".".into()
+}
 
 impl Field {
     /// Encode a float value as a u32 using this field's multiplier.
@@ -109,7 +115,11 @@ impl Field {
             stored as f64
         };
         let m = self.multiplier as f64;
-        if m == 0.0 { raw } else { raw / m }
+        if m == 0.0 {
+            raw
+        } else {
+            raw / m
+        }
     }
 
     /// Encode an integer value, optionally with zigzag.
@@ -166,8 +176,11 @@ pub fn format_value(field: &Field, stored: u32, strings: Option<&[String]>) -> S
     match field.ftype {
         FieldType::Float => {
             let val = field.decode_float(stored);
-            if val.abs() < 1e-10 { "0".into() }
-            else { format!("{:.6e}", val) }
+            if val.abs() < 1e-10 {
+                "0".into()
+            } else {
+                format!("{:.6e}", val)
+            }
         }
         FieldType::Integer => {
             let val = field.decode_int(stored);
@@ -186,7 +199,11 @@ pub fn format_value(field: &Field, stored: u32, strings: Option<&[String]>) -> S
             }
         }
         FieldType::Flag => {
-            if stored != 0 { "true".into() } else { "false".into() }
+            if stored != 0 {
+                "true".into()
+            } else {
+                "false".into()
+            }
         }
         FieldType::JsonBlob => {
             // JsonBlob values are stored separately, not in u32 arrays
@@ -202,9 +219,14 @@ mod tests {
     #[test]
     fn test_float_round_trip() {
         let field = Field {
-            field: "AF".into(), alias: "af".into(), ftype: FieldType::Float,
-            multiplier: 2_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "AF".into(),
+            alias: "af".into(),
+            ftype: FieldType::Float,
+            multiplier: 2_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         let original = 0.001234;
         let stored = field.encode_float(original);
@@ -215,9 +237,14 @@ mod tests {
     #[test]
     fn test_zigzag_float() {
         let field = Field {
-            field: "score".into(), alias: "score".into(), ftype: FieldType::Float,
-            multiplier: 10_000, zigzag: true, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "score".into(),
+            alias: "score".into(),
+            ftype: FieldType::Float,
+            multiplier: 10_000,
+            zigzag: true,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         let original = -2.5;
         let stored = field.encode_float(original);
@@ -228,9 +255,14 @@ mod tests {
     #[test]
     fn test_missing_value() {
         let field = Field {
-            field: "AF".into(), alias: "af".into(), ftype: FieldType::Float,
-            multiplier: 2_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "AF".into(),
+            alias: "af".into(),
+            ftype: FieldType::Float,
+            multiplier: 2_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         assert!(field.decode_float(u32::MAX).is_nan());
         assert_eq!(format_value(&field, u32::MAX, None), "null");
@@ -239,9 +271,14 @@ mod tests {
     #[test]
     fn test_encode_nan_and_inf_become_missing() {
         let field = Field {
-            field: "AF".into(), alias: "af".into(), ftype: FieldType::Float,
-            multiplier: 2_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "AF".into(),
+            alias: "af".into(),
+            ftype: FieldType::Float,
+            multiplier: 2_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         assert_eq!(field.encode_float(f64::NAN), u32::MAX);
         assert_eq!(field.encode_float(f64::INFINITY), u32::MAX);
@@ -255,9 +292,14 @@ mod tests {
         // containing a quote or backslash must not break out of the emitted
         // JSON string.
         let field = Field {
-            field: "cat".into(), alias: "cat".into(), ftype: FieldType::Categorical,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "cat".into(),
+            alias: "cat".into(),
+            ftype: FieldType::Categorical,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         let strings = vec!["evil\"quote\\backslash".to_string()];
         let json_fragment = format_value(&field, 0, Some(&strings));
@@ -275,21 +317,35 @@ mod tests {
         // Without bounds, value * multiplier may saturate to u32::MAX and
         // collide with the default missing sentinel.
         let field = Field {
-            field: "x".into(), alias: "x".into(), ftype: FieldType::Float,
-            multiplier: 2_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "x".into(),
+            alias: "x".into(),
+            ftype: FieldType::Float,
+            multiplier: 2_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         let encoded = field.encode_float(1e30);
-        assert_ne!(encoded, u32::MAX, "saturation must not collide with missing");
+        assert_ne!(
+            encoded,
+            u32::MAX,
+            "saturation must not collide with missing"
+        );
         assert!(encoded < u32::MAX);
     }
 
     #[test]
     fn test_encode_int_negative_without_zigzag_treated_missing() {
         let field = Field {
-            field: "n".into(), alias: "n".into(), ftype: FieldType::Integer,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "n".into(),
+            alias: "n".into(),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         assert_eq!(field.encode_int(-5), u32::MAX);
         assert_eq!(field.encode_int(0), 0);
@@ -299,9 +355,14 @@ mod tests {
     #[test]
     fn test_categorical() {
         let field = Field {
-            field: "sig".into(), alias: "sig".into(), ftype: FieldType::Categorical,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: String::new(),
+            field: "sig".into(),
+            alias: "sig".into(),
+            ftype: FieldType::Categorical,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: String::new(),
         };
         let strings = vec!["Benign".to_string(), "Pathogenic".to_string()];
         assert_eq!(format_value(&field, 0, Some(&strings)), "\"Benign\"");

--- a/crates/fastvep-sa/src/index.rs
+++ b/crates/fastvep-sa/src/index.rs
@@ -226,24 +226,33 @@ mod tests {
         };
 
         let mut index = SaIndex::new(header);
-        index.add_block("chr1", BlockRef {
-            start_pos: 100,
-            end_pos: 500,
-            file_offset: 0,
-            compressed_len: 1024,
-        });
-        index.add_block("chr1", BlockRef {
-            start_pos: 501,
-            end_pos: 1000,
-            file_offset: 1024,
-            compressed_len: 2048,
-        });
-        index.add_block("chr2", BlockRef {
-            start_pos: 1,
-            end_pos: 300,
-            file_offset: 3072,
-            compressed_len: 512,
-        });
+        index.add_block(
+            "chr1",
+            BlockRef {
+                start_pos: 100,
+                end_pos: 500,
+                file_offset: 0,
+                compressed_len: 1024,
+            },
+        );
+        index.add_block(
+            "chr1",
+            BlockRef {
+                start_pos: 501,
+                end_pos: 1000,
+                file_offset: 1024,
+                compressed_len: 2048,
+            },
+        );
+        index.add_block(
+            "chr2",
+            BlockRef {
+                start_pos: 1,
+                end_pos: 300,
+                file_offset: 3072,
+                compressed_len: 512,
+            },
+        );
 
         // Serialize and deserialize
         let mut buf = Vec::new();
@@ -286,7 +295,12 @@ mod tests {
         let mut chromosomes: HashMap<String, Vec<BlockRef>> = HashMap::new();
         chromosomes.insert(
             "1".into(),
-            vec![BlockRef { start_pos: 100, end_pos: 500, file_offset: 0, compressed_len: 16 }],
+            vec![BlockRef {
+                start_pos: 100,
+                end_pos: 500,
+                file_offset: 0,
+                compressed_len: 16,
+            }],
         );
         let legacy = (test_header(), chromosomes);
 
@@ -312,7 +326,12 @@ mod tests {
         let mut index = SaIndex::new(test_header());
         index.add_block(
             "chr1",
-            BlockRef { start_pos: 1, end_pos: 9, file_offset: 0, compressed_len: 4 },
+            BlockRef {
+                start_pos: 1,
+                end_pos: 9,
+                file_offset: 0,
+                compressed_len: 4,
+            },
         );
 
         let mut actual = Vec::new();
@@ -334,7 +353,12 @@ mod tests {
         let mut index = SaIndex::new(test_header());
         index.add_block(
             "chrM",
-            BlockRef { start_pos: 1, end_pos: 100, file_offset: 0, compressed_len: 4 },
+            BlockRef {
+                start_pos: 1,
+                end_pos: 100,
+                file_offset: 0,
+                compressed_len: 4,
+            },
         );
         for alias in ["chrM", "M", "MT", "chrMT"] {
             assert!(
@@ -360,18 +384,24 @@ mod tests {
         };
 
         let mut index = SaIndex::new(header);
-        index.add_block("chr1", BlockRef {
-            start_pos: 100,
-            end_pos: 500,
-            file_offset: 0,
-            compressed_len: 100,
-        });
-        index.add_block("chr1", BlockRef {
-            start_pos: 501,
-            end_pos: 1000,
-            file_offset: 100,
-            compressed_len: 200,
-        });
+        index.add_block(
+            "chr1",
+            BlockRef {
+                start_pos: 100,
+                end_pos: 500,
+                file_offset: 0,
+                compressed_len: 100,
+            },
+        );
+        index.add_block(
+            "chr1",
+            BlockRef {
+                start_pos: 501,
+                end_pos: 1000,
+                file_offset: 100,
+                compressed_len: 200,
+            },
+        );
 
         // Position in first block
         let blocks = index.find_blocks("chr1", 250);

--- a/crates/fastvep-sa/src/interval.rs
+++ b/crates/fastvep-sa/src/interval.rs
@@ -197,7 +197,12 @@ impl IntervalIndex {
     ///
     /// `chrom` may be given in any accepted spelling; it is resolved against the
     /// index's own contig set via [`resolve_chrom`](Self::resolve_chrom).
-    pub fn find_overlapping(&self, chrom: &str, query_start: u32, query_end: u32) -> Vec<OverlapResult> {
+    pub fn find_overlapping(
+        &self,
+        chrom: &str,
+        query_start: u32,
+        query_end: u32,
+    ) -> Vec<OverlapResult> {
         let Some(chrom) = self.resolve_chrom(chrom) else {
             return Vec::new();
         };
@@ -318,10 +323,7 @@ impl OsiReader {
         let metadata = SaMetadata {
             name: index.header.name.clone(),
             version: index.header.version.clone(),
-            description: format!(
-                "Interval annotation database from {}",
-                path.display()
-            ),
+            description: format!("Interval annotation database from {}", path.display()),
             assembly: index.header.assembly.clone(),
             json_key: index.header.json_key.clone(),
             // Intervals are inherently positional — overlap doesn't care
@@ -435,8 +437,18 @@ mod tests {
         };
         let mut index = IntervalIndex::new(header);
         // Intentionally out of order:
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 500, end: 700, json: "{\"id\":\"B\"}".into() });
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 100, end: 200, json: "{\"id\":\"A\"}".into() });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 500,
+            end: 700,
+            json: "{\"id\":\"B\"}".into(),
+        });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 100,
+            end: 200,
+            json: "{\"id\":\"A\"}".into(),
+        });
         // Skip index.sort() so the on-disk layout is unsorted.
 
         let mut buf = Vec::new();
@@ -556,11 +568,7 @@ mod tests {
 
     /// Reference implementation: the pre-optimization full scan. Any
     /// divergence between this and `find_overlapping` is a correctness bug.
-    fn brute_force(
-        intervals: &[StoredInterval],
-        query_start: u32,
-        query_end: u32,
-    ) -> Vec<String> {
+    fn brute_force(intervals: &[StoredInterval], query_start: u32, query_end: u32) -> Vec<String> {
         intervals
             .iter()
             .filter(|iv| iv.start <= query_end && iv.end >= query_start)
@@ -597,7 +605,7 @@ mod tests {
         for i in 0..600u32 {
             let start = (next_rand(&mut state) % 10_000) as u32;
             let len = match i % 7 {
-                0 => 0,                                      // point interval
+                0 => 0,                                              // point interval
                 1 => 5_000 + (next_rand(&mut state) % 4_000) as u32, // long reacher
                 _ => (next_rand(&mut state) % 50) as u32,
             };
@@ -631,7 +639,13 @@ mod tests {
                 .into_iter()
                 .map(|h| h.json)
                 .collect();
-            assert_eq!(got, brute_force(&intervals, a, b), "range {}..{} diverged", a, b);
+            assert_eq!(
+                got,
+                brute_force(&intervals, a, b),
+                "range {}..{} diverged",
+                a,
+                b
+            );
         }
     }
 
@@ -661,7 +675,11 @@ mod tests {
             hi,
             hi - lo
         );
-        assert!(lo > 99_000, "lower bound should skip the whole prefix, got {}", lo);
+        assert!(
+            lo > 99_000,
+            "lower bound should skip the whole prefix, got {}",
+            lo
+        );
 
         // And it still finds the right interval.
         let hits = index.find_overlapping("chr1", 999_000, 999_000);
@@ -675,12 +693,31 @@ mod tests {
         // window must widen to the whole prefix rather than silently trusting
         // a stale array and missing overlaps.
         let mut index = IntervalIndex::new(test_header());
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 10, end: 20, json: "{\"id\":\"a\"}".into() });
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 30, end: 40, json: "{\"id\":\"b\"}".into() });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 10,
+            end: 20,
+            json: "{\"id\":\"a\"}".into(),
+        });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 30,
+            end: 40,
+            json: "{\"id\":\"b\"}".into(),
+        });
         index.sort();
-        assert_eq!(index.candidate_window("chr1", 35, 35).0, 1, "maxima should bound a fresh index");
+        assert_eq!(
+            index.candidate_window("chr1", 35, 35).0,
+            1,
+            "maxima should bound a fresh index"
+        );
 
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 50, end: 60, json: "{\"id\":\"c\"}".into() });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 50,
+            end: 60,
+            json: "{\"id\":\"c\"}".into(),
+        });
         assert_eq!(
             index.candidate_window("chr1", 35, 35).0,
             0,
@@ -702,8 +739,16 @@ mod tests {
         intervals.insert(
             "chr1".into(),
             vec![
-                StoredInterval { start: 100, end: 200, json: "{\"id\":\"a\"}".into() },
-                StoredInterval { start: 150, end: 400, json: "{\"id\":\"b\"}".into() },
+                StoredInterval {
+                    start: 100,
+                    end: 200,
+                    json: "{\"id\":\"a\"}".into(),
+                },
+                StoredInterval {
+                    start: 150,
+                    end: 400,
+                    json: "{\"id\":\"b\"}".into(),
+                },
             ],
         );
         let legacy = (test_header(), intervals);
@@ -731,8 +776,18 @@ mod tests {
         // The alias map replaced a per-query `chrom_aliases` call; the accepted
         // spellings must be exactly the same set as before.
         let mut index = IntervalIndex::new(test_header());
-        index.add(IntervalRecord { chrom: "chrM".into(), start: 100, end: 200, json: "{}".into() });
-        index.add(IntervalRecord { chrom: "1".into(), start: 10, end: 20, json: "{}".into() });
+        index.add(IntervalRecord {
+            chrom: "chrM".into(),
+            start: 100,
+            end: 200,
+            json: "{}".into(),
+        });
+        index.add(IntervalRecord {
+            chrom: "1".into(),
+            start: 10,
+            end: 20,
+            json: "{}".into(),
+        });
         index.sort();
 
         for alias in ["chrM", "M", "MT", "chrMT"] {
@@ -756,7 +811,12 @@ mod tests {
         // but never sorted still resolves spellings (it falls back to the wide
         // scan window, which `candidate_window`'s own test covers).
         let mut index = IntervalIndex::new(test_header());
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 10, end: 20, json: "{}".into() });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 10,
+            end: 20,
+            json: "{}".into(),
+        });
         assert_eq!(index.resolve_chrom("1"), Some("chr1"));
         assert_eq!(index.find_overlapping("1", 15, 15).len(), 1);
     }
@@ -766,7 +826,12 @@ mod tests {
         // Guards the on-disk format explicitly: the bytes `write_to` emits must
         // equal magic + version + len + bincode((header, intervals)).
         let mut index = IntervalIndex::new(test_header());
-        index.add(IntervalRecord { chrom: "chr1".into(), start: 5, end: 9, json: "{}".into() });
+        index.add(IntervalRecord {
+            chrom: "chr1".into(),
+            start: 5,
+            end: 9,
+            json: "{}".into(),
+        });
         index.sort();
 
         let mut actual = Vec::new();

--- a/crates/fastvep-sa/src/kmer16.rs
+++ b/crates/fastvep-sa/src/kmer16.rs
@@ -252,8 +252,16 @@ mod tests {
 
     #[test]
     fn test_equality_ignores_idx() {
-        let a = LongVariant { position: 100, idx: 0, sequence: encode_var(b"ACGTAC", b"T").unwrap() };
-        let b = LongVariant { position: 100, idx: 999, sequence: encode_var(b"ACGTAC", b"T").unwrap() };
+        let a = LongVariant {
+            position: 100,
+            idx: 0,
+            sequence: encode_var(b"ACGTAC", b"T").unwrap(),
+        };
+        let b = LongVariant {
+            position: 100,
+            idx: 999,
+            sequence: encode_var(b"ACGTAC", b"T").unwrap(),
+        };
         assert_eq!(a, b); // idx is ignored in PartialEq
     }
 

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -72,9 +72,7 @@ fn chunk_bytes(c: &Chunk) -> usize {
     let others: usize = c
         .others
         .iter()
-        .map(|o| {
-            std::mem::size_of::<OtherVariant>() + o.ref_allele.len() + o.alt_allele.len()
-        })
+        .map(|o| std::mem::size_of::<OtherVariant>() + o.ref_allele.len() + o.alt_allele.len())
         .sum();
     let vals: usize = c
         .values
@@ -264,14 +262,13 @@ impl Osa2Reader {
         };
 
         let metadata: Osa2Metadata = {
-            let buf = read_prelude("fastsa/metadata.json")?
-                .context("Missing fastsa/metadata.json")?;
+            let buf =
+                read_prelude("fastsa/metadata.json")?.context("Missing fastsa/metadata.json")?;
             serde_json::from_slice(&buf)?
         };
 
         let fields: Vec<Field> = {
-            let buf =
-                read_prelude("fastsa/config.json")?.context("Missing fastsa/config.json")?;
+            let buf = read_prelude("fastsa/config.json")?.context("Missing fastsa/config.json")?;
             serde_json::from_slice(&buf)?
         };
 

--- a/crates/fastvep-sa/src/sources/alphamissense.rs
+++ b/crates/fastvep-sa/src/sources/alphamissense.rs
@@ -273,7 +273,8 @@ impl<R: BufRead> Iterator for AlphaMissenseV2Iter<'_, R> {
             };
             let values = vec![
                 self.fields[SCORE_FIELD].encode_float(row.score),
-                row.class_idx.unwrap_or(self.fields[CLASS_FIELD].missing_value),
+                row.class_idx
+                    .unwrap_or(self.fields[CLASS_FIELD].missing_value),
             ];
             return Some(Ok(Osa2Record {
                 chrom,
@@ -297,7 +298,11 @@ pub fn parse_alphamissense<R: BufRead>(
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> =
         iter_alphamissense_tsv(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -333,10 +338,26 @@ chr1\t69095\tT\tC\thg38\tQ8NH21\tENST00000335137.4\tF2L\t0.4500\tambiguous
     fn v1_json_carries_score_and_class() {
         let recs = parse_alphamissense(SAMPLE.as_bytes(), &chrom_map()).unwrap();
         // Score is emitted in scientific notation (shared float formatting).
-        assert!(recs[0].json.contains("\"amPathogenicity\":"), "{}", recs[0].json);
-        assert!(recs[0].json.contains("\"amClass\":\"likely_benign\""), "{}", recs[0].json);
-        assert!(recs[1].json.contains("\"amClass\":\"likely_pathogenic\""), "{}", recs[1].json);
-        assert!(recs[2].json.contains("\"amClass\":\"ambiguous\""), "{}", recs[2].json);
+        assert!(
+            recs[0].json.contains("\"amPathogenicity\":"),
+            "{}",
+            recs[0].json
+        );
+        assert!(
+            recs[0].json.contains("\"amClass\":\"likely_benign\""),
+            "{}",
+            recs[0].json
+        );
+        assert!(
+            recs[1].json.contains("\"amClass\":\"likely_pathogenic\""),
+            "{}",
+            recs[1].json
+        );
+        assert!(
+            recs[2].json.contains("\"amClass\":\"ambiguous\""),
+            "{}",
+            recs[2].json
+        );
     }
 
     #[test]
@@ -347,7 +368,10 @@ chr1\t69095\tT\tC\thg38\tQ8NH21\tENST00000335137.4\tF2L\t0.4500\tambiguous
             .unwrap();
         assert_eq!(recs.len(), 3);
         let fields = alphamissense_osa2_fields();
-        assert_eq!(recs[0].values[SCORE_FIELD], fields[SCORE_FIELD].encode_float(0.2937));
+        assert_eq!(
+            recs[0].values[SCORE_FIELD],
+            fields[SCORE_FIELD].encode_float(0.2937)
+        );
         assert_eq!(recs[0].values[CLASS_FIELD], 0); // likely_benign
         assert_eq!(recs[1].values[CLASS_FIELD], 2); // likely_pathogenic
         assert_eq!(recs[2].values[CLASS_FIELD], 1); // ambiguous
@@ -368,10 +392,7 @@ chr1\t69095\tT\tC\thg38\tQ8NH21\tENST00000335137.4\tF2L\t0.4500\tambiguous
         for (r1, r2) in v1.iter().zip(v2.iter()) {
             let score = format_value(&fields[SCORE_FIELD], r2.values[SCORE_FIELD], None);
             let class = format_value(&fields[CLASS_FIELD], r2.values[CLASS_FIELD], Some(&table));
-            let expected = format!(
-                "{{\"amPathogenicity\":{},\"amClass\":{}}}",
-                score, class
-            );
+            let expected = format!("{{\"amPathogenicity\":{},\"amClass\":{}}}", score, class);
             assert_eq!(r1.json, expected);
         }
     }

--- a/crates/fastvep-sa/src/sources/clinvar.rs
+++ b/crates/fastvep-sa/src/sources/clinvar.rs
@@ -74,12 +74,12 @@ pub fn parse_clinvar_vcf<R: BufRead>(
         let clndn = info_map.get("CLNDN").cloned().unwrap_or_default();
         let clnacc = info_map.get("CLNVC").cloned(); // variant class
         let clnid = info_map.get("CLNVCSO").cloned(); // SO accession
-        // ClinVar-distributed population allele frequencies (ExAC / 1000G / ESP).
-        // Used as a frequency backstop by PM2 when gnomAD has no record. Reject
-        // non-finite values: `f64::from_str` accepts "inf"/"nan", whose Display
-        // form is invalid JSON and would poison the entire record's JSON string
-        // (silently dropping its ClinVar annotation). Real ClinVar AFs are
-        // always finite decimals, so this only guards against malformed input.
+                                                      // ClinVar-distributed population allele frequencies (ExAC / 1000G / ESP).
+                                                      // Used as a frequency backstop by PM2 when gnomAD has no record. Reject
+                                                      // non-finite values: `f64::from_str` accepts "inf"/"nan", whose Display
+                                                      // form is invalid JSON and would poison the entire record's JSON string
+                                                      // (silently dropping its ClinVar annotation). Real ClinVar AFs are
+                                                      // always finite decimals, so this only guards against malformed input.
         let parse_af = |k: &str| {
             info_map
                 .get(k)
@@ -118,7 +118,11 @@ pub fn parse_clinvar_vcf<R: BufRead>(
     }
 
     // Sort by (chrom_idx, position) as required by SaWriter
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
 
     Ok(records)
 }
@@ -145,10 +149,7 @@ fn build_clinvar_json(
     }
 
     if !clnrevstat.is_empty() {
-        parts.push(format!(
-            "\"reviewStatus\":\"{}\"",
-            escape_json(clnrevstat)
-        ));
+        parts.push(format!("\"reviewStatus\":\"{}\"", escape_json(clnrevstat)));
     }
 
     if !clndn.is_empty() && clndn != "not_provided" {

--- a/crates/fastvep-sa/src/sources/clinvar_protein.rs
+++ b/crates/fastvep-sa/src/sources/clinvar_protein.rs
@@ -163,17 +163,28 @@ fn serialize_gene_record(
 
     let mut unique: Vec<_> = unique.into_iter().collect();
     unique.sort_by(|((pos_a, ref_a, alt_a), _), ((pos_b, ref_b, alt_b), _)| {
-        pos_a.cmp(pos_b).then(ref_a.cmp(ref_b)).then(alt_a.cmp(alt_b))
+        pos_a
+            .cmp(pos_b)
+            .then(ref_a.cmp(ref_b))
+            .then(alt_a.cmp(alt_b))
     });
 
     let variant_jsons: Vec<String> = unique
         .iter()
         .map(|((pos, ref_aa, alt_aa), (sig, cdnas))| {
             let n = cdnas.len().max(1);
-            let n_field = if n > 1 { format!(r#","n":{}"#, n) } else { String::new() };
+            let n_field = if n > 1 {
+                format!(r#","n":{}"#, n)
+            } else {
+                String::new()
+            };
             format!(
                 r#"{{"pos":{},"refAa":"{}","altAa":"{}","sig":"{}"{}}}"#,
-                pos, escape_json(ref_aa), escape_json(alt_aa), escape_json(sig), n_field
+                pos,
+                escape_json(ref_aa),
+                escape_json(alt_aa),
+                escape_json(sig),
+                n_field
             )
         })
         .collect();
@@ -355,15 +366,24 @@ where
 ///    feed the protein index; genomic splice positions are not, so only rows on
 ///    the requested build feed the splice index
 ///  - `PositionVCF`, `ReferenceAlleleVCF`, `AlternateAlleleVCF` - splice index only
-fn parse_variant_summary_inner<I>(header: String, lines: I, assembly: &str) -> Result<Vec<GeneRecord>>
+fn parse_variant_summary_inner<I>(
+    header: String,
+    lines: I,
+    assembly: &str,
+) -> Result<Vec<GeneRecord>>
 where
     I: Iterator<Item = std::io::Result<String>>,
 {
     let header_fields: Vec<&str> = header.trim_start_matches('#').split('\t').collect();
-    let find = |needle: &str| header_fields.iter().position(|f| f.eq_ignore_ascii_case(needle));
+    let find = |needle: &str| {
+        header_fields
+            .iter()
+            .position(|f| f.eq_ignore_ascii_case(needle))
+    };
     let i_name = find("Name").context("variant_summary missing Name column")?;
     let i_gene = find("GeneSymbol").context("variant_summary missing GeneSymbol column")?;
-    let i_sig = find("ClinicalSignificance").context("variant_summary missing ClinicalSignificance column")?;
+    let i_sig = find("ClinicalSignificance")
+        .context("variant_summary missing ClinicalSignificance column")?;
 
     // The four columns the splice index needs. All optional: a `variant_summary`
     // predating any of them still builds a usable protein index, and the splice
@@ -405,7 +425,10 @@ where
         // dropped by the `p.` check below.
         if let Some(sv) = parse_splice_variant(name, sig_clean, &cols, splice_cols, assembly) {
             for g in gene.split(';').map(str::trim).filter(|g| !g.is_empty()) {
-                gene_splice.entry(g.to_string()).or_default().push(sv.clone());
+                gene_splice
+                    .entry(g.to_string())
+                    .or_default()
+                    .push(sv.clone());
             }
         }
 
@@ -440,7 +463,12 @@ where
     // Union of both key sets: a gene can have canonical splice variants and no
     // classified missense (or the reverse), and either way it needs a record.
     let mut genes: Vec<String> = gene_variants.keys().cloned().collect();
-    genes.extend(gene_splice.keys().filter(|g| !gene_variants.contains_key(*g)).cloned());
+    genes.extend(
+        gene_splice
+            .keys()
+            .filter(|g| !gene_variants.contains_key(*g))
+            .cloned(),
+    );
     genes.sort();
 
     let empty_protein: Vec<ProteinVariant> = Vec::new();
@@ -449,9 +477,12 @@ where
         .into_iter()
         .map(|gene| {
             let protein = gene_variants.get(&gene).unwrap_or(&empty_protein);
-            let splice = splice_cols
-                .is_some()
-                .then(|| (assembly, gene_splice.get(&gene).unwrap_or(&empty_splice).as_slice()));
+            let splice = splice_cols.is_some().then(|| {
+                (
+                    assembly,
+                    gene_splice.get(&gene).unwrap_or(&empty_splice).as_slice(),
+                )
+            });
             serialize_gene_record(gene.clone(), protein, splice)
         })
         .collect();
@@ -555,7 +586,10 @@ fn parse_protein_hgvs(hgvs: &str) -> Option<(u64, String, String)> {
         let first = p_str.chars().next()?;
         if first.is_ascii_uppercase() {
             // Extract digits
-            let digits: String = p_str[1..].chars().take_while(|c| c.is_ascii_digit()).collect();
+            let digits: String = p_str[1..]
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
             if let Ok(pos) = digits.parse::<u64>() {
                 let rest = &p_str[1 + digits.len()..];
                 if let Some(alt_aa) = rest.chars().next() {
@@ -573,11 +607,29 @@ fn parse_protein_hgvs(hgvs: &str) -> Option<(u64, String, String)> {
 /// Parse three-letter amino acid protein change like "Arg175His"
 fn parse_three_letter_protein(s: &str) -> Option<(u64, String, String)> {
     let aa_map: HashMap<&str, &str> = [
-        ("Ala", "A"), ("Arg", "R"), ("Asn", "N"), ("Asp", "D"), ("Cys", "C"),
-        ("Gln", "Q"), ("Glu", "E"), ("Gly", "G"), ("His", "H"), ("Ile", "I"),
-        ("Leu", "L"), ("Lys", "K"), ("Met", "M"), ("Phe", "F"), ("Pro", "P"),
-        ("Ser", "S"), ("Thr", "T"), ("Trp", "W"), ("Tyr", "Y"), ("Val", "V"),
-        ("Sec", "U"), ("Pyl", "O"), ("Ter", "*"),
+        ("Ala", "A"),
+        ("Arg", "R"),
+        ("Asn", "N"),
+        ("Asp", "D"),
+        ("Cys", "C"),
+        ("Gln", "Q"),
+        ("Glu", "E"),
+        ("Gly", "G"),
+        ("His", "H"),
+        ("Ile", "I"),
+        ("Leu", "L"),
+        ("Lys", "K"),
+        ("Met", "M"),
+        ("Phe", "F"),
+        ("Pro", "P"),
+        ("Ser", "S"),
+        ("Thr", "T"),
+        ("Trp", "W"),
+        ("Tyr", "Y"),
+        ("Val", "V"),
+        ("Sec", "U"),
+        ("Pyl", "O"),
+        ("Ter", "*"),
     ]
     .iter()
     .copied()
@@ -721,7 +773,12 @@ mod tests {
         let header = "#AlleleID\tType\tName\tGeneID\tGeneSymbol\tHGNC_ID\tClinicalSignificance\tClinSigSimple\tLastEvaluated\tRS# (dbSNP)\tnsv/esv (dbVar)\tRCVaccession\tPhenotypeIDS\tPhenotypeList\tOrigin\tOriginSimple\tAssembly\tChromosomeAccession\tChromosome\tStart\tStop\tReferenceAllele\tAlternateAllele\tCytogenetic\tReviewStatus\tNumberSubmitters\tGuidelines\tTestedInGTR\tOtherIDs\tSubmitterCategories\tVariationID\tPositionVCF\tReferenceAlleleVCF\tAlternateAlleleVCF\tSomaticClinicalImpact\tSomaticClinicalImpactLastEvaluated\tReviewStatusClinicalImpact\tOncogenicity\tOncogenicityLastEvaluated\tReviewStatusOncogenicity";
         let mut rows = vec![header.to_string()];
         // Deliberately out of position order in the input.
-        for (variation_id, pos_aa) in [(1, "p.Arg175His"), (2, "p.Gly245Ser"), (3, "p.Cys135Tyr"), (4, "p.Arg273Cys")] {
+        for (variation_id, pos_aa) in [
+            (1, "p.Arg175His"),
+            (2, "p.Gly245Ser"),
+            (3, "p.Cys135Tyr"),
+            (4, "p.Arg273Cys"),
+        ] {
             rows.push(format!(
                 "{vid}\tsingle nucleotide variant\tNM_000546.6(TP53):c.1A>T ({pos_aa})\t7157\tTP53\tHGNC:11998\tPathogenic\t1\t-\t-\t-\tRCV000\t-\t-\tgermline\tgermline\tGRCh38\tNC_000017.11\t17\t1\t1\tG\tA\t17p13.1\tcriteria provided, multiple submitters, no conflicts\t5\t-\t-\t-\t1\t{vid}\t1\tG\tA\t-\t-\t-\t-\t-\t-",
                 vid = variation_id,
@@ -787,7 +844,11 @@ mod tests {
     fn test_index_drops_uncertain_and_conflicting_records() {
         let data = summary_rows(&[
             ("c.524G>A", "p.Arg175His", "Uncertain significance"),
-            ("c.733G>A", "p.Gly245Ser", "Conflicting classifications of pathogenicity"),
+            (
+                "c.733G>A",
+                "p.Gly245Ser",
+                "Conflicting classifications of pathogenicity",
+            ),
         ]);
         let records = parse_clinvar_protein_vcf(data.as_bytes(), "GRCh38").unwrap();
         assert!(records.is_empty(), "got {records:?}");
@@ -810,12 +871,27 @@ mod tests {
     fn test_splice_index_records_canonical_dinucleotide_variants() {
         let data = splice_rows(&[
             ("c.376-2A>G", "Pathogenic", "GRCh38", "7676000", "A", "G"),
-            ("c.376-1G>A", "Likely pathogenic", "GRCh38", "7676001", "G", "A"),
+            (
+                "c.376-1G>A",
+                "Likely pathogenic",
+                "GRCh38",
+                "7676001",
+                "G",
+                "A",
+            ),
         ]);
         let records = parse_clinvar_protein_vcf(data.as_bytes(), "GRCh38").unwrap();
         let tp53 = &records[0];
-        assert!(tp53.json.contains(r#""spliceIndexed":true"#), "{}", tp53.json);
-        assert!(tp53.json.contains(r#""spliceAssembly":"GRCh38""#), "{}", tp53.json);
+        assert!(
+            tp53.json.contains(r#""spliceIndexed":true"#),
+            "{}",
+            tp53.json
+        );
+        assert!(
+            tp53.json.contains(r#""spliceAssembly":"GRCh38""#),
+            "{}",
+            tp53.json
+        );
         assert!(
             tp53.json
                 .contains(r#"{"pos":7676000,"ref":"A","alt":"G","off":-2,"sig":"Pathogenic"}"#),
@@ -823,8 +899,9 @@ mod tests {
             tp53.json
         );
         assert!(
-            tp53.json
-                .contains(r#"{"pos":7676001,"ref":"G","alt":"A","off":-1,"sig":"Likely_pathogenic"}"#),
+            tp53.json.contains(
+                r#"{"pos":7676001,"ref":"G","alt":"A","off":-1,"sig":"Likely_pathogenic"}"#
+            ),
             "{}",
             tp53.json
         );
@@ -868,8 +945,16 @@ mod tests {
 ";
         let records = parse_clinvar_protein_vcf(data.as_bytes(), "GRCh38").unwrap();
         assert_eq!(records.len(), 1);
-        assert!(!records[0].json.contains("spliceIndexed"), "{}", records[0].json);
-        assert!(!records[0].json.contains("splicePositions"), "{}", records[0].json);
+        assert!(
+            !records[0].json.contains("spliceIndexed"),
+            "{}",
+            records[0].json
+        );
+        assert!(
+            !records[0].json.contains("splicePositions"),
+            "{}",
+            records[0].json
+        );
     }
 
     #[test]
@@ -880,8 +965,16 @@ mod tests {
         let data = splice_rows(&[("c.376-2A>G", "Pathogenic", "GRCh38", "7676000", "A", "G")]);
         let records = parse_clinvar_protein_vcf(data.as_bytes(), "GRCh38").unwrap();
         assert_eq!(records.len(), 1);
-        assert!(records[0].json.contains(r#""proteinVariants":[]"#), "{}", records[0].json);
-        assert!(records[0].json.contains(r#""pos":7676000"#), "{}", records[0].json);
+        assert!(
+            records[0].json.contains(r#""proteinVariants":[]"#),
+            "{}",
+            records[0].json
+        );
+        assert!(
+            records[0].json.contains(r#""pos":7676000"#),
+            "{}",
+            records[0].json
+        );
     }
 
     #[test]
@@ -900,7 +993,10 @@ mod tests {
             json.find(r#""pos":7676020"#).unwrap(),
             json.find(r#""pos":7676030"#).unwrap(),
         );
-        assert!(a < b && b < c, "splicePositions must be sorted by position: {json}");
+        assert!(
+            a < b && b < c,
+            "splicePositions must be sorted by position: {json}"
+        );
     }
 
     #[test]
@@ -910,21 +1006,40 @@ mod tests {
         // to survive the dedup regardless of row order.
         for rows in [
             [
-                ("c.376-2A>G", "Likely pathogenic", "GRCh38", "7676000", "A", "G"),
+                (
+                    "c.376-2A>G",
+                    "Likely pathogenic",
+                    "GRCh38",
+                    "7676000",
+                    "A",
+                    "G",
+                ),
                 ("c.376-2A>G", "Pathogenic", "GRCh38", "7676000", "A", "G"),
             ],
             [
                 ("c.376-2A>G", "Pathogenic", "GRCh38", "7676000", "A", "G"),
-                ("c.376-2A>G", "Likely pathogenic", "GRCh38", "7676000", "A", "G"),
+                (
+                    "c.376-2A>G",
+                    "Likely pathogenic",
+                    "GRCh38",
+                    "7676000",
+                    "A",
+                    "G",
+                ),
             ],
         ] {
-            let records = parse_clinvar_protein_vcf(splice_rows(&rows).as_bytes(), "GRCh38").unwrap();
+            let records =
+                parse_clinvar_protein_vcf(splice_rows(&rows).as_bytes(), "GRCh38").unwrap();
             assert!(
                 records[0].json.contains(r#""off":-2,"sig":"Pathogenic""#),
                 "{}",
                 records[0].json
             );
-            assert!(!records[0].json.contains("Likely_pathogenic"), "{}", records[0].json);
+            assert!(
+                !records[0].json.contains("Likely_pathogenic"),
+                "{}",
+                records[0].json
+            );
         }
     }
 

--- a/crates/fastvep-sa/src/sources/cosmic.rs
+++ b/crates/fastvep-sa/src/sources/cosmic.rs
@@ -96,7 +96,11 @@ pub fn parse_cosmic_vcf<R: BufRead>(
         }
     }
 
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -111,7 +115,11 @@ fn parse_info(info: &str) -> HashMap<String, String> {
 }
 
 fn normalize_chrom(chrom: &str) -> String {
-    if chrom.starts_with("chr") { chrom.to_string() } else { format!("chr{}", chrom) }
+    if chrom.starts_with("chr") {
+        chrom.to_string()
+    } else {
+        format!("chr{}", chrom)
+    }
 }
 
 #[cfg(test)]

--- a/crates/fastvep-sa/src/sources/dbnsfp.rs
+++ b/crates/fastvep-sa/src/sources/dbnsfp.rs
@@ -94,7 +94,11 @@ pub fn parse_dbnsfp<R: BufRead>(
                 if let Ok(s) = score.parse::<f64>() {
                     let pred = cols.sift_pred.and_then(|i| {
                         let p = fields[i].split(';').next()?;
-                        if p == "." { None } else { Some(p) }
+                        if p == "." {
+                            None
+                        } else {
+                            Some(p)
+                        }
                     });
                     let pred_str = match pred {
                         Some("D") => "deleterious",
@@ -118,7 +122,11 @@ pub fn parse_dbnsfp<R: BufRead>(
                 if let Ok(s) = score.parse::<f64>() {
                     let pred = cols.polyphen_pred.and_then(|i| {
                         let p = fields[i].split(';').next()?;
-                        if p == "." { None } else { Some(p) }
+                        if p == "." {
+                            None
+                        } else {
+                            Some(p)
+                        }
                     });
                     let pred_str = match pred {
                         Some("D") => "probably_damaging",
@@ -148,7 +156,11 @@ pub fn parse_dbnsfp<R: BufRead>(
         });
     }
 
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -187,7 +199,15 @@ impl DbNsfpColumns {
 
     fn max_idx(&self) -> usize {
         let mut m = self.alt;
-        for i in [self.sift_score, self.sift_pred, self.polyphen_score, self.polyphen_pred].into_iter().flatten() {
+        for i in [
+            self.sift_score,
+            self.sift_pred,
+            self.polyphen_score,
+            self.polyphen_pred,
+        ]
+        .into_iter()
+        .flatten()
+        {
             m = m.max(i);
         }
         m

--- a/crates/fastvep-sa/src/sources/dbsnp.rs
+++ b/crates/fastvep-sa/src/sources/dbsnp.rs
@@ -145,7 +145,11 @@ pub fn parse_dbsnp_vcf<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> = iter_dbsnp_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -215,10 +219,18 @@ mod tests {
         assert_eq!(records.len(), 2);
 
         let c = records.iter().find(|r| r.alt_allele == "C").unwrap();
-        assert!(c.json.contains("8.000000e-2"), "C should get CAF index 1 (0.08): {}", c.json);
+        assert!(
+            c.json.contains("8.000000e-2"),
+            "C should get CAF index 1 (0.08): {}",
+            c.json
+        );
 
         let t = records.iter().find(|r| r.alt_allele == "T").unwrap();
-        assert!(t.json.contains("2.000000e-2"), "T should get CAF index 2 (0.02), not C's frequency: {}", t.json);
+        assert!(
+            t.json.contains("2.000000e-2"),
+            "T should get CAF index 2 (0.02), not C's frequency: {}",
+            t.json
+        );
     }
 
     #[test]

--- a/crates/fastvep-sa/src/sources/gnomad.rs
+++ b/crates/fastvep-sa/src/sources/gnomad.rs
@@ -28,7 +28,16 @@ use std::io::BufRead;
 /// gnomAD v2.1 codes (`oth`) and the v4.1 codes (`mid`, `remaining`); a
 /// missing key is silently skipped per VCF, so listing all is harmless.
 const POPULATIONS: &[&str] = &[
-    "afr", "amr", "asj", "eas", "fin", "mid", "nfe", "oth", "remaining", "sas",
+    "afr",
+    "amr",
+    "asj",
+    "eas",
+    "fin",
+    "mid",
+    "nfe",
+    "oth",
+    "remaining",
+    "sas",
 ];
 
 // =============================================================================
@@ -51,9 +60,21 @@ const POPULATIONS: &[&str] = &[
 /// "not PASS" bit so a reviewer reading the annotation can see *which* filter
 /// fired.
 const FILTER_FLAGS: &[(&str, &str, &str)] = &[
-    ("AC0", "filterAc0", "FILTER=AC0: allele count is zero after filtering out low-confidence genotypes"),
-    ("AS_VQSR", "filterVqsr", "FILTER=AS_VQSR: site failed allele-specific VQSR thresholds"),
-    ("InbreedingCoeff", "filterInbreeding", "FILTER=InbreedingCoeff: inbreeding coefficient < -0.3"),
+    (
+        "AC0",
+        "filterAc0",
+        "FILTER=AC0: allele count is zero after filtering out low-confidence genotypes",
+    ),
+    (
+        "AS_VQSR",
+        "filterVqsr",
+        "FILTER=AS_VQSR: site failed allele-specific VQSR thresholds",
+    ),
+    (
+        "InbreedingCoeff",
+        "filterInbreeding",
+        "FILTER=InbreedingCoeff: inbreeding coefficient < -0.3",
+    ),
 ];
 
 /// Region-quality INFO flags, as (INFO key, output alias, description).
@@ -66,8 +87,16 @@ const FILTER_FLAGS: &[(&str, &str, &str)] = &[
 /// pseudoautosomal region is an XY sample hemizygous.
 const INFO_FLAGS: &[(&str, &str, &str)] = &[
     ("lcr", "lcr", "Variant falls within a low-complexity region"),
-    ("segdup", "segdup", "Variant falls within a segmental duplication"),
-    ("non_par", "nonPar", "Sex-chromosome variant falls outside a pseudoautosomal region"),
+    (
+        "segdup",
+        "segdup",
+        "Variant falls within a segmental duplication",
+    ),
+    (
+        "non_par",
+        "nonPar",
+        "Sex-chromosome variant falls outside a pseudoautosomal region",
+    ),
 ];
 
 /// Per-allele (`Number=A`) XY-stratified counts.
@@ -89,11 +118,8 @@ const XY_ALLELE_INTS: &[(&str, &str, &str)] = &[(
 )];
 
 /// Per-site (`Number=1`) XY-stratified counts.
-const XY_SITE_INTS: &[(&str, &str, &str)] = &[(
-    "AN_XY",
-    "allAnXY",
-    "Total allele number in XY samples",
-)];
+const XY_SITE_INTS: &[(&str, &str, &str)] =
+    &[("AN_XY", "allAnXY", "Total allele number in XY samples")];
 
 /// Filtering allele frequencies (Whiffin 2017, PMID 28518168).
 ///
@@ -104,7 +130,11 @@ const XY_SITE_INTS: &[(&str, &str, &str)] = &[(
 /// absent elsewhere, and to a frequency estimated from very few alleles. Both
 /// failure modes were raised in the round-2 medical-genetics review.
 const FAF_FLOATS: &[(&str, &str, &str)] = &[
-    ("faf95", "faf95", "Filtering allele frequency (95% CI lower bound), all samples"),
+    (
+        "faf95",
+        "faf95",
+        "Filtering allele frequency (95% CI lower bound), all samples",
+    ),
     (
         "fafmax_faf95_max",
         "faf95Max",
@@ -307,7 +337,11 @@ pub fn parse_gnomad_vcf<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> = iter_gnomad_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -437,7 +471,12 @@ fn build_gnomad_json(
     allele_idx: usize,
     field_names: &FieldNames,
 ) -> String {
-    let GlobalCounts { af, an, ac, nhomalt } = counts;
+    let GlobalCounts {
+        af,
+        an,
+        ac,
+        nhomalt,
+    } = counts;
     let mut parts = Vec::new();
 
     if let Some(af_str) = af {
@@ -754,18 +793,28 @@ impl<R: BufRead> Iterator for GnomadOsa2Iter<'_, R> {
                 }
                 // Value order MUST match `gnomad_osa2_fields()`.
                 let mut values = Vec::with_capacity(self.fields.len());
-                values.push(enc_float(&self.fields[0], all_afs.get(ai).map(|s| s.as_str())));
+                values.push(enc_float(
+                    &self.fields[0],
+                    all_afs.get(ai).map(|s| s.as_str()),
+                ));
                 values.push(enc_int(&self.fields[1], an.first().map(|s| s.as_str())));
-                values.push(enc_int(&self.fields[2], all_acs.get(ai).map(|s| s.as_str())));
+                values.push(enc_int(
+                    &self.fields[2],
+                    all_acs.get(ai).map(|s| s.as_str()),
+                ));
                 values.push(enc_int(&self.fields[3], all_nh.get(ai).map(|s| s.as_str())));
                 for (pi, pop) in POPULATIONS.iter().enumerate() {
                     let key = field_names.pop_key(pop);
                     let vals = split_info_values(info_map.get(&key).map(|s| s.as_str()));
-                    values.push(enc_float(&self.fields[4 + pi], vals.get(ai).map(|s| s.as_str())));
+                    values.push(enc_float(
+                        &self.fields[4 + pi],
+                        vals.get(ai).map(|s| s.as_str()),
+                    ));
                 }
                 let ext_off = extended_offset();
-                for (ei, (_, value)) in
-                    extended_values(&info_map, filter_column, ai).into_iter().enumerate()
+                for (ei, (_, value)) in extended_values(&info_map, filter_column, ai)
+                    .into_iter()
+                    .enumerate()
                 {
                     values.push(encode_ext(&self.fields[ext_off + ei], value));
                 }
@@ -978,8 +1027,7 @@ chr1\t10001\t.\tA\tG\t.\tPASS\tAF=0.001;AN=not_a_number;AC=garbage;nhomalt=.
     #[test]
     fn test_parse_info_id_reordered_with_quoted_comma() {
         // Description quoted string contains commas — must not split inside it.
-        let line =
-            "##INFO=<Number=A,Type=Float,Description=\"AF, joint, multi-pop\",ID=AF_joint>";
+        let line = "##INFO=<Number=A,Type=Float,Description=\"AF, joint, multi-pop\",ID=AF_joint>";
         assert_eq!(parse_info_id(line), Some("AF_joint"));
     }
 
@@ -1015,7 +1063,10 @@ chr1\t10001\t.\tA\tG\t.\tPASS\tAF=0.001;AN=not_a_number;AC=garbage;nhomalt=.
         // The iterator indexes `fields[0..4]` for the global stats and
         // `fields[4 + pi]` per population, so this ordering is load-bearing.
         let fields = gnomad_osa2_fields();
-        assert_eq!(fields.len(), 4 + POPULATIONS.len() + extended_fields().len());
+        assert_eq!(
+            fields.len(),
+            4 + POPULATIONS.len() + extended_fields().len()
+        );
         assert_eq!(fields[0].alias, "allAf");
         assert_eq!(fields[1].alias, "allAn");
         assert_eq!(fields[2].alias, "allAc");
@@ -1037,8 +1088,9 @@ chr1\t10001\t.\tA\tG\t.\tPASS\tAF=0.001;AN=150000;AC=150;nhomalt=2;AF_afr=0.002;
 chr1\t20000\t.\tC\tT,A\t.\tPASS\tAF=0.01,0.005;AN=140000;AC=1400,700;nhomalt=10,3;AF_eas=0.02,0.01
 ";
         let map = chr1_map();
-        let recs: Vec<Osa2Record> =
-            iter_gnomad_osa2(vcf.as_bytes(), &map).collect::<Result<_>>().unwrap();
+        let recs: Vec<Osa2Record> = iter_gnomad_osa2(vcf.as_bytes(), &map)
+            .collect::<Result<_>>()
+            .unwrap();
         assert_eq!(recs.len(), 3); // 1 SNV + 2 from the multi-allelic site
 
         let fields = gnomad_osa2_fields();
@@ -1048,7 +1100,7 @@ chr1\t20000\t.\tC\tT,A\t.\tPASS\tAF=0.01,0.005;AN=140000;AC=1400,700;nhomalt=10,
         assert_eq!(recs[0].values[1], 150000); // AN
         assert_eq!(recs[0].values[2], 150); // AC
         assert_eq!(recs[0].values[3], 2); // nhomalt
-        // afr AF present, sas AF missing.
+                                          // afr AF present, sas AF missing.
         let afr_idx = 4 + POPULATIONS.iter().position(|p| *p == "afr").unwrap();
         let sas_idx = 4 + POPULATIONS.iter().position(|p| *p == "sas").unwrap();
         assert_eq!(recs[0].values[afr_idx], fields[afr_idx].encode_float(0.002));
@@ -1074,8 +1126,9 @@ chr1\t20000\t.\tC\tT,A\t.\tPASS\tAF=0.01,0.005;AN=140000;AC=1400,700;nhomalt=10,
 chr1\t10001\t.\tA\tG\t.\tPASS\tAF_joint=0.001;AN_joint=150000;AC_joint=150;AF_joint_nfe=0.0005
 ";
         let map = chr1_map();
-        let recs: Vec<Osa2Record> =
-            iter_gnomad_osa2(vcf.as_bytes(), &map).collect::<Result<_>>().unwrap();
+        let recs: Vec<Osa2Record> = iter_gnomad_osa2(vcf.as_bytes(), &map)
+            .collect::<Result<_>>()
+            .unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].values[0], 2000); // AF_joint 0.001 encoded
         assert_eq!(recs[0].values[1], 150000); // AN_joint
@@ -1119,7 +1172,10 @@ chr1\t600\t.\tA\tG\t.\tPASS\tAF=0.2;AN=1000;AC=200;nhomalt=20;non_par;AC_XY=37;A
         let records = parse_gnomad_vcf(CHRX_VCF.as_bytes(), &map).unwrap();
         let v: serde_json::Value = serde_json::from_str(&records[0].json).unwrap();
         assert_eq!(v.get("filterVqsr").and_then(|x| x.as_bool()), Some(true));
-        assert_eq!(v.get("filterInbreeding").and_then(|x| x.as_bool()), Some(true));
+        assert_eq!(
+            v.get("filterInbreeding").and_then(|x| x.as_bool()),
+            Some(true)
+        );
         assert_eq!(v.get("segdup").and_then(|x| x.as_bool()), Some(true));
         assert_eq!(v.get("lcr").and_then(|x| x.as_bool()), Some(true));
         // Unset flags are omitted rather than written as false.
@@ -1200,8 +1256,9 @@ chr2\t100\t.\tA\tG\t.\tPASS\tAF=0.5
 chr1\t200\t.\tA\tG\t.\tPASS\tAF=0.5
 ";
         let map = chr1_map(); // only chr1 is valid
-        let recs: Vec<Osa2Record> =
-            iter_gnomad_osa2(vcf.as_bytes(), &map).collect::<Result<_>>().unwrap();
+        let recs: Vec<Osa2Record> = iter_gnomad_osa2(vcf.as_bytes(), &map)
+            .collect::<Result<_>>()
+            .unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].chrom, "chr1");
         assert_eq!(recs[0].position, 200);

--- a/crates/fastvep-sa/src/sources/gnomad_gene.rs
+++ b/crates/fastvep-sa/src/sources/gnomad_gene.rs
@@ -140,10 +140,7 @@ impl GnomadGeneCols {
         let fields: Vec<&str> = header.split('\t').collect();
         let find = |needles: &[&str]| {
             for n in needles {
-                if let Some(i) = fields
-                    .iter()
-                    .position(|f| f.eq_ignore_ascii_case(n))
-                {
+                if let Some(i) = fields.iter().position(|f| f.eq_ignore_ascii_case(n)) {
                     return Some(i);
                 }
             }
@@ -174,7 +171,10 @@ impl GnomadGeneCols {
             self.loeuf,
             self.mis_z,
             self.syn_z,
-        ].into_iter().flatten() {
+        ]
+        .into_iter()
+        .flatten()
+        {
             m = m.max(i);
         }
         m

--- a/crates/fastvep-sa/src/sources/mitomap.rs
+++ b/crates/fastvep-sa/src/sources/mitomap.rs
@@ -37,16 +37,28 @@ pub fn parse_mitomap<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records = Vec::new();
-    let mt_idx = chrom_to_idx.get("chrM").or_else(|| chrom_to_idx.get("chrMT"));
-    let chrom_idx = match mt_idx { Some(&i) => i, None => return Ok(records) };
+    let mt_idx = chrom_to_idx
+        .get("chrM")
+        .or_else(|| chrom_to_idx.get("chrMT"));
+    let chrom_idx = match mt_idx {
+        Some(&i) => i,
+        None => return Ok(records),
+    };
 
     for line in reader.lines() {
         let line = line.context("Reading MitoMap")?;
-        if line.starts_with('#') || line.starts_with("Position") || line.is_empty() { continue; }
+        if line.starts_with('#') || line.starts_with("Position") || line.is_empty() {
+            continue;
+        }
         let fields: Vec<&str> = line.split('\t').collect();
-        if fields.len() < 4 { continue; }
+        if fields.len() < 4 {
+            continue;
+        }
 
-        let pos: u32 = match fields[0].trim().parse() { Ok(p) => p, Err(_) => continue };
+        let pos: u32 = match fields[0].trim().parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
         let ref_allele = fields[1].trim().to_string();
         let alt_allele = fields[2].trim().to_string();
         let disease = fields.get(3).unwrap_or(&"").trim();
@@ -63,8 +75,10 @@ pub fn parse_mitomap<R: BufRead>(
         }
 
         records.push(AnnotationRecord {
-            chrom_idx, position: pos,
-            ref_allele, alt_allele,
+            chrom_idx,
+            position: pos,
+            ref_allele,
+            alt_allele,
             json: format!("{{{}}}", parts.join(",")),
         });
     }

--- a/crates/fastvep-sa/src/sources/omim.rs
+++ b/crates/fastvep-sa/src/sources/omim.rs
@@ -133,8 +133,13 @@ mod tests {
         let records = parse_omim_genemap(data.as_bytes()).unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].gene_symbol, "BRCA1");
-        assert!(!records[0].json.contains("mimNumber"), "non-numeric MIM must be omitted: {}", records[0].json);
+        assert!(
+            !records[0].json.contains("mimNumber"),
+            "non-numeric MIM must be omitted: {}",
+            records[0].json
+        );
         // The emitted JSON must be parseable.
-        let _: serde_json::Value = serde_json::from_str(&records[0].json).expect("record must be valid JSON");
+        let _: serde_json::Value =
+            serde_json::from_str(&records[0].json).expect("record must be valid JSON");
     }
 }

--- a/crates/fastvep-sa/src/sources/onekg.rs
+++ b/crates/fastvep-sa/src/sources/onekg.rs
@@ -7,9 +7,7 @@ use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::io::BufRead;
 
-const POPS: &[&str] = &[
-    "AFR", "AMR", "EAS", "EUR", "SAS",
-];
+const POPS: &[&str] = &["AFR", "AMR", "EAS", "EUR", "SAS"];
 
 fn af_field(alias: &str, description: &str) -> Field {
     Field {
@@ -69,14 +67,24 @@ pub fn parse_onekg_vcf<R: BufRead>(
 
     for line in reader.lines() {
         let line = line.context("Reading 1000G VCF")?;
-        if line.starts_with('#') { continue; }
+        if line.starts_with('#') {
+            continue;
+        }
 
         let fields: Vec<&str> = line.splitn(9, '\t').collect();
-        if fields.len() < 8 { continue; }
+        if fields.len() < 8 {
+            continue;
+        }
 
         let chrom = normalize_chrom(fields[0]);
-        let chrom_idx = match chrom_to_idx.get(&chrom) { Some(&i) => i, None => continue };
-        let pos: u32 = match fields[1].parse() { Ok(p) => p, Err(_) => continue };
+        let chrom_idx = match chrom_to_idx.get(&chrom) {
+            Some(&i) => i,
+            None => continue,
+        };
+        let pos: u32 = match fields[1].parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
         let ref_allele = fields[3].to_string();
         let alt_field = fields[4];
         let info = fields[7];
@@ -86,7 +94,9 @@ pub fn parse_onekg_vcf<R: BufRead>(
         let all_afs = split_vals(info_map.get("AF").map(|s| s.as_str()));
 
         for (i, alt) in alts.iter().enumerate() {
-            if *alt == "." || *alt == "*" { continue; }
+            if *alt == "." || *alt == "*" {
+                continue;
+            }
 
             let mut parts = Vec::new();
             if let Some(af) = all_afs.get(i).and_then(|s| s.parse::<f64>().ok()) {
@@ -101,28 +111,45 @@ pub fn parse_onekg_vcf<R: BufRead>(
                     }
                 }
             }
-            if parts.is_empty() { continue; }
+            if parts.is_empty() {
+                continue;
+            }
             records.push(AnnotationRecord {
-                chrom_idx, position: pos,
-                ref_allele: ref_allele.clone(), alt_allele: alt.to_string(),
+                chrom_idx,
+                position: pos,
+                ref_allele: ref_allele.clone(),
+                alt_allele: alt.to_string(),
                 json: format!("{{{}}}", parts.join(",")),
             });
         }
     }
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
 fn parse_info(info: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
-    for p in info.split(';') { if let Some((k, v)) = p.split_once('=') { m.insert(k.into(), v.into()); } }
+    for p in info.split(';') {
+        if let Some((k, v)) = p.split_once('=') {
+            m.insert(k.into(), v.into());
+        }
+    }
     m
 }
 fn split_vals(v: Option<&str>) -> Vec<String> {
-    v.map(|s| s.split(',').map(|x| x.to_string()).collect()).unwrap_or_default()
+    v.map(|s| s.split(',').map(|x| x.to_string()).collect())
+        .unwrap_or_default()
 }
 fn normalize_chrom(c: &str) -> String {
-    if c.starts_with("chr") { c.to_string() } else { format!("chr{}", c) }
+    if c.starts_with("chr") {
+        c.to_string()
+    } else {
+        format!("chr{}", c)
+    }
 }
 
 #[cfg(test)]
@@ -149,9 +176,18 @@ mod tests {
         let o = crate::writer_v2::osa2_record_from_v1(&recs[0], "chr1".into(), &fields).unwrap();
 
         let idx = |alias: &str| fields.iter().position(|f| f.alias == alias).unwrap();
-        assert_eq!(o.values[idx("allAf")], fields[idx("allAf")].encode_float(0.15));
-        assert_eq!(o.values[idx("afrAf")], fields[idx("afrAf")].encode_float(0.20));
-        assert_eq!(o.values[idx("eurAf")], fields[idx("eurAf")].encode_float(0.10));
+        assert_eq!(
+            o.values[idx("allAf")],
+            fields[idx("allAf")].encode_float(0.15)
+        );
+        assert_eq!(
+            o.values[idx("afrAf")],
+            fields[idx("afrAf")].encode_float(0.20)
+        );
+        assert_eq!(
+            o.values[idx("eurAf")],
+            fields[idx("eurAf")].encode_float(0.10)
+        );
         // Populations absent from the record encode as the missing sentinel.
         assert_eq!(o.values[idx("amrAf")], u32::MAX);
         assert_eq!(o.values[idx("sasAf")], u32::MAX);

--- a/crates/fastvep-sa/src/sources/primateai.rs
+++ b/crates/fastvep-sa/src/sources/primateai.rs
@@ -77,7 +77,11 @@ pub fn parse_primateai<R: BufRead>(
         });
     }
 
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 

--- a/crates/fastvep-sa/src/sources/revel.rs
+++ b/crates/fastvep-sa/src/sources/revel.rs
@@ -70,8 +70,7 @@ pub fn parse_revel<R: BufRead>(
             Err(_) => continue,
         };
 
-        let json = format!(r#"{{"score":{:.4}}}"#, score)
-            .replace(".0000}", ".0}");
+        let json = format!(r#"{{"score":{:.4}}}"#, score).replace(".0000}", ".0}");
 
         records.push(AnnotationRecord {
             chrom_idx,
@@ -82,7 +81,11 @@ pub fn parse_revel<R: BufRead>(
         });
     }
 
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 

--- a/crates/fastvep-sa/src/sources/scores.rs
+++ b/crates/fastvep-sa/src/sources/scores.rs
@@ -35,7 +35,10 @@ pub fn score_osa2_metadata(json_key: &str, assembly: &str) -> Osa2Metadata {
         is_array: false,
         is_positional: true,
         chunk_bits: 20,
-        description: format!("{} conservation/prediction scores for {}", json_key, assembly),
+        description: format!(
+            "{} conservation/prediction scores for {}",
+            json_key, assembly
+        ),
     }
 }
 
@@ -54,7 +57,11 @@ pub fn iter_score_tsv<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
     zero_based: bool,
 ) -> ScoreTsvIter<'_, R> {
-    ScoreTsvIter { lines: reader.lines(), chrom_to_idx, zero_based }
+    ScoreTsvIter {
+        lines: reader.lines(),
+        chrom_to_idx,
+        zero_based,
+    }
 }
 
 pub struct ScoreTsvIter<'a, R: BufRead> {
@@ -94,7 +101,11 @@ impl<R: BufRead> Iterator for ScoreTsvIter<'_, R> {
 
             let pos: u32 = match pos_str.parse::<u32>() {
                 Ok(p) => {
-                    if self.zero_based { p + 1 } else { p }
+                    if self.zero_based {
+                        p + 1
+                    } else {
+                        p
+                    }
                 }
                 Err(_) => continue,
             };
@@ -126,7 +137,11 @@ pub fn parse_score_tsv<R: BufRead>(
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> =
         iter_score_tsv(reader, chrom_to_idx, zero_based).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -144,8 +159,17 @@ pub fn parse_score_tsv<R: BufRead>(
 /// The input must already be sorted by chromosome (all standard UCSC
 /// per-chromosome releases are; concatenating them in chromosome order
 /// preserves this).
-pub fn iter_wigfix<R: BufRead>(reader: R, chrom_to_idx: &HashMap<String, u16>) -> WigFixIter<'_, R> {
-    WigFixIter { lines: reader.lines(), chrom_to_idx, current_chrom_idx: None, current_pos: 0, step: 1 }
+pub fn iter_wigfix<R: BufRead>(
+    reader: R,
+    chrom_to_idx: &HashMap<String, u16>,
+) -> WigFixIter<'_, R> {
+    WigFixIter {
+        lines: reader.lines(),
+        chrom_to_idx,
+        current_chrom_idx: None,
+        current_pos: 0,
+        step: 1,
+    }
 }
 
 pub struct WigFixIter<'a, R: BufRead> {
@@ -183,7 +207,10 @@ impl<R: BufRead> Iterator for WigFixIter<'_, R> {
                     }
                 }
 
-                self.current_chrom_idx = chrom.as_ref().and_then(|c| self.chrom_to_idx.get(c)).copied();
+                self.current_chrom_idx = chrom
+                    .as_ref()
+                    .and_then(|c| self.chrom_to_idx.get(c))
+                    .copied();
                 self.current_pos = start.unwrap_or(1);
                 continue;
             }
@@ -219,7 +246,11 @@ pub fn parse_wigfix<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> = iter_wigfix(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 

--- a/crates/fastvep-sa/src/sources/spliceai.rs
+++ b/crates/fastvep-sa/src/sources/spliceai.rs
@@ -190,7 +190,11 @@ pub fn parse_spliceai_vcf<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> = iter_spliceai_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 
@@ -545,10 +549,14 @@ mod tests {
     #[test]
     fn v2_records_encode_scores_positions_and_gene_index() {
         let genes = GeneInterner::new();
-        let recs: Vec<_> =
-            iter_spliceai_osa2(SAMPLE.as_bytes(), &chrom_map(), &chrom_list(), genes.clone())
-                .collect::<Result<_>>()
-                .unwrap();
+        let recs: Vec<_> = iter_spliceai_osa2(
+            SAMPLE.as_bytes(),
+            &chrom_map(),
+            &chrom_list(),
+            genes.clone(),
+        )
+        .collect::<Result<_>>()
+        .unwrap();
         assert_eq!(recs.len(), 3);
 
         let fields = spliceai_osa2_fields();
@@ -563,7 +571,10 @@ mod tests {
         assert_eq!(recs[2].values[DS_AG], fields[DS_AG].encode_float(0.50));
 
         // Two distinct symbols across the sample, interned in first-seen order.
-        assert_eq!(genes.table(), vec!["GENE1".to_string(), "GENE2".to_string()]);
+        assert_eq!(
+            genes.table(),
+            vec!["GENE1".to_string(), "GENE2".to_string()]
+        );
         assert_eq!(recs[0].values[GENE_FIELD], 0);
         assert_eq!(recs[1].values[GENE_FIELD], 1);
         assert_eq!(recs[2].values[GENE_FIELD], 1);
@@ -577,10 +588,14 @@ mod tests {
         // encoded columns and the global gene table.
         let genes = GeneInterner::new();
         let v1 = parse_spliceai_vcf(SAMPLE.as_bytes(), &chrom_map()).unwrap();
-        let v2: Vec<_> =
-            iter_spliceai_osa2(SAMPLE.as_bytes(), &chrom_map(), &chrom_list(), genes.clone())
-                .collect::<Result<_>>()
-                .unwrap();
+        let v2: Vec<_> = iter_spliceai_osa2(
+            SAMPLE.as_bytes(),
+            &chrom_map(),
+            &chrom_list(),
+            genes.clone(),
+        )
+        .collect::<Result<_>>()
+        .unwrap();
         let fields = spliceai_osa2_fields();
         let table = genes.table();
 
@@ -660,10 +675,14 @@ mod tests {
 1\t300\t.\tA\tG\t.\t.\tSpliceAI=G|GENE1|0.01|0.00|0.00|0.00|1|2|3|4
 ";
         let v1 = parse_spliceai_vcf(vcf.as_bytes(), &chrom_map()).unwrap();
-        let v2: Vec<_> =
-            iter_spliceai_osa2(vcf.as_bytes(), &chrom_map(), &chrom_list(), GeneInterner::new())
-                .collect::<Result<_>>()
-                .unwrap();
+        let v2: Vec<_> = iter_spliceai_osa2(
+            vcf.as_bytes(),
+            &chrom_map(),
+            &chrom_list(),
+            GeneInterner::new(),
+        )
+        .collect::<Result<_>>()
+        .unwrap();
         assert_eq!(v1.len(), 1);
         assert_eq!(v2.len(), 1);
         assert_eq!(v1[0].position, 300);

--- a/crates/fastvep-sa/src/sources/topmed.rs
+++ b/crates/fastvep-sa/src/sources/topmed.rs
@@ -21,19 +21,34 @@ use std::io::BufRead;
 pub fn topmed_osa2_fields() -> Vec<Field> {
     vec![
         Field {
-            field: "allAf".into(), alias: "allAf".into(), ftype: FieldType::Float,
-            multiplier: 2_000_000, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Global allele frequency".into(),
+            field: "allAf".into(),
+            alias: "allAf".into(),
+            ftype: FieldType::Float,
+            multiplier: 2_000_000,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Global allele frequency".into(),
         },
         Field {
-            field: "allAc".into(), alias: "allAc".into(), ftype: FieldType::Integer,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Allele count".into(),
+            field: "allAc".into(),
+            alias: "allAc".into(),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Allele count".into(),
         },
         Field {
-            field: "allAn".into(), alias: "allAn".into(), ftype: FieldType::Integer,
-            multiplier: 1, zigzag: false, missing_value: u32::MAX,
-            missing_string: ".".into(), description: "Total allele number".into(),
+            field: "allAn".into(),
+            alias: "allAn".into(),
+            ftype: FieldType::Integer,
+            multiplier: 1,
+            zigzag: false,
+            missing_value: u32::MAX,
+            missing_string: ".".into(),
+            description: "Total allele number".into(),
         },
     ]
 }
@@ -161,7 +176,11 @@ pub fn parse_topmed_vcf<R: BufRead>(
     chrom_to_idx: &HashMap<String, u16>,
 ) -> Result<Vec<AnnotationRecord>> {
     let mut records: Vec<_> = iter_topmed_vcf(reader, chrom_to_idx).collect::<Result<_>>()?;
-    records.sort_by(|a, b| a.chrom_idx.cmp(&b.chrom_idx).then(a.position.cmp(&b.position)));
+    records.sort_by(|a, b| {
+        a.chrom_idx
+            .cmp(&b.chrom_idx)
+            .then(a.position.cmp(&b.position))
+    });
     Ok(records)
 }
 

--- a/crates/fastvep-sa/src/var32.rs
+++ b/crates/fastvep-sa/src/var32.rs
@@ -51,7 +51,11 @@ const BASE_DEC: [u8; 4] = *b"ACGT";
 /// Returns true if the variant is too long for Var32 encoding.
 #[inline]
 pub fn is_long(ref_len: usize, alt_len: usize) -> bool {
-    ref_len + alt_len > MAX_COMBINED_LEN || ref_len == 0 || alt_len == 0 || ref_len > 4 || alt_len > 4
+    ref_len + alt_len > MAX_COMBINED_LEN
+        || ref_len == 0
+        || alt_len == 0
+        || ref_len > 4
+        || alt_len > 4
 }
 
 /// Encode a variant into a compact 32-bit representation.
@@ -237,7 +241,7 @@ mod tests {
         let v2 = encode(200, b"A", b"G").unwrap();
         let v3 = encode(100, b"A", b"T").unwrap();
         assert!(v1 < v2); // position 100 < 200
-        // Same position: sorted by allele encoding
+                          // Same position: sorted by allele encoding
         assert!(v1 != v3);
     }
 
@@ -248,7 +252,9 @@ mod tests {
         // historic bug where decoding the 4th base used a stale shift.
         for rlen in 1..=4usize {
             for alen in 1..=4usize {
-                if rlen + alen > MAX_COMBINED_LEN { continue; }
+                if rlen + alen > MAX_COMBINED_LEN {
+                    continue;
+                }
                 let r: Vec<u8> = (0..rlen).map(|i| BASE_DEC[i % 4]).collect();
                 let a: Vec<u8> = (0..alen).map(|i| BASE_DEC[(i + 1) % 4]).collect();
                 let encoded = encode(7, &r, &a)
@@ -271,7 +277,7 @@ mod tests {
         assert!(encode(0, b"a", b"x").is_none()); // arbitrary letter
         assert!(encode(0, &[0u8], b"A").is_none()); // null byte
         assert!(encode(0, &[0xC3, 0xA9], b"A").is_none()); // multi-byte UTF-8
-        // Valid ACGT (mixed case) still works.
+                                                           // Valid ACGT (mixed case) still works.
         assert!(encode(0, b"a", b"G").is_some());
         assert!(encode(0, b"Ac", b"gT").is_some());
     }

--- a/crates/fastvep-sa/src/writer.rs
+++ b/crates/fastvep-sa/src/writer.rs
@@ -174,8 +174,12 @@ impl SaWriter {
         let data_path = base_path.with_extension("osa");
         let idx_path = base_path.with_extension("osa.idx");
 
-        let data_file = std::fs::File::create(&data_path)
-            .with_context(|| format!("Creating output file {} (does the output directory exist?)", data_path.display()))?;
+        let data_file = std::fs::File::create(&data_path).with_context(|| {
+            format!(
+                "Creating output file {} (does the output directory exist?)",
+                data_path.display()
+            )
+        })?;
         let mut data_writer = BufWriter::new(data_file);
         self.write_all(&mut data_writer, records, chrom_map)?;
         data_writer.flush()?;
@@ -199,8 +203,12 @@ impl SaWriter {
         let data_path = base_path.with_extension("osa");
         let idx_path = base_path.with_extension("osa.idx");
 
-        let data_file = std::fs::File::create(&data_path)
-            .with_context(|| format!("Creating output file {} (does the output directory exist?)", data_path.display()))?;
+        let data_file = std::fs::File::create(&data_path).with_context(|| {
+            format!(
+                "Creating output file {} (does the output directory exist?)",
+                data_path.display()
+            )
+        })?;
         let mut data_writer = BufWriter::new(data_file);
         self.write_all_results(&mut data_writer, records, chrom_map)?;
         data_writer.flush()?;

--- a/crates/fastvep-sa/src/writer_v2.rs
+++ b/crates/fastvep-sa/src/writer_v2.rs
@@ -50,7 +50,11 @@ pub struct Osa2Writer {
 impl Osa2Writer {
     pub fn new(metadata: Osa2Metadata, fields: Vec<Field>) -> Self {
         let string_tables = fields.iter().map(|_| Vec::new()).collect();
-        Self { metadata, fields, string_tables }
+        Self {
+            metadata,
+            fields,
+            string_tables,
+        }
     }
 
     /// Set the string table for a categorical field.
@@ -64,11 +68,7 @@ impl Osa2Writer {
     ///
     /// Records MUST be sorted by (chrom, position) so that all records for a
     /// given (chrom, chunk) are contiguous.
-    pub fn write_all<W: Write + Seek>(
-        &self,
-        writer: W,
-        records: &[Osa2Record],
-    ) -> Result<()> {
+    pub fn write_all<W: Write + Seek>(&self, writer: W, records: &[Osa2Record]) -> Result<()> {
         let mut zip = zip::ZipWriter::new(writer);
         let options = default_options();
 
@@ -219,7 +219,11 @@ fn write_chunk_entries<W: Write + Seek>(
             // failure as the non-ACGT case rather than dropping the record.
             match kmer16::encode_var(&record.ref_allele, &record.alt_allele) {
                 Some(sequence) => long_entries.push((
-                    LongVariant { position: record.position, idx: 0, sequence },
+                    LongVariant {
+                        position: record.position,
+                        idx: 0,
+                        sequence,
+                    },
                     local_idx,
                 )),
                 None => other_entries.push((
@@ -325,7 +329,13 @@ fn write_chunk_entries<W: Write + Seek>(
         }
         let values: Vec<u32> = value_order
             .iter()
-            .map(|&li| chunk_records[li].values.get(fi).copied().unwrap_or(field.missing_value))
+            .map(|&li| {
+                chunk_records[li]
+                    .values
+                    .get(fi)
+                    .copied()
+                    .unwrap_or(field.missing_value)
+            })
             .collect();
         zip.start_file(format!("{}{}.bin", prefix, field.alias), options)?;
         write_u32_array(zip, &values)?;
@@ -441,7 +451,12 @@ impl<W: Write + Seek> Osa2StreamWriter<W> {
     /// Flush the final chunk, write string tables, and finalize the archive.
     pub fn finish(mut self) -> Result<()> {
         self.flush_current()?;
-        write_string_tables(&mut self.zip, self.options, &self.fields, &self.string_tables)?;
+        write_string_tables(
+            &mut self.zip,
+            self.options,
+            &self.fields,
+            &self.string_tables,
+        )?;
         // Flush the inner writer explicitly — `ZipWriter::finish` hands it back
         // unflushed, and a `BufWriter`'s Drop swallows flush errors, which would
         // silently leave a truncated `.osa2` on a full disk. See `write_all`.

--- a/crates/fastvep-sa/src/zipdir.rs
+++ b/crates/fastvep-sa/src/zipdir.rs
@@ -80,7 +80,10 @@ fn read_u64(buf: &[u8], at: usize) -> Result<u64> {
 /// rules out a stray signature inside compressed data.
 fn find_eocd(mmap: &[u8]) -> Result<usize> {
     if mmap.len() < EOCD_FIXED_LEN {
-        bail!("file is too small to be a ZIP archive ({} bytes)", mmap.len());
+        bail!(
+            "file is too small to be a ZIP archive ({} bytes)",
+            mmap.len()
+        );
     }
     let max_back = (u16::MAX as usize + EOCD_FIXED_LEN).min(mmap.len());
     let search_start = mmap.len() - max_back;
@@ -160,7 +163,10 @@ fn find_zip64_eocd(mmap: &[u8], eocd: usize) -> Result<Option<usize>> {
         .try_into()
         .map_err(|_| anyhow::anyhow!("ZIP64 EOCD offset {} exceeds usize", z64))?;
     if z64 >= mmap.len() || read_u32(mmap, z64)? != ZIP64_EOCD_SIG {
-        bail!("ZIP64 end-of-central-directory record not found at offset {}", z64);
+        bail!(
+            "ZIP64 end-of-central-directory record not found at offset {}",
+            z64
+        );
     }
     Ok(Some(z64))
 }
@@ -185,7 +191,10 @@ fn central_directory_range(mmap: &[u8], loc: &CentralDirectoryLocator) -> Result
         };
         match start.checked_add(size) {
             Some(end) if end <= mmap.len() => {
-                size == 0 || read_u32(mmap, start).map(|s| s == CENTRAL_HEADER_SIG).unwrap_or(false)
+                size == 0
+                    || read_u32(mmap, start)
+                        .map(|s| s == CENTRAL_HEADER_SIG)
+                        .unwrap_or(false)
             }
             _ => false,
         }
@@ -227,7 +236,10 @@ pub(crate) fn parse_central_directory(mmap: &[u8]) -> Result<Vec<CentralEntry>> 
     let mut at = 0usize;
     while at + CENTRAL_HEADER_FIXED_LEN <= cd.len() {
         if read_u32(cd, at)? != CENTRAL_HEADER_SIG {
-            bail!("bad central-directory record signature at offset {}", start + at);
+            bail!(
+                "bad central-directory record signature at offset {}",
+                start + at
+            );
         }
         let method = read_u16(cd, at + 10)?;
         let comp_size32 = read_u32(cd, at + 20)?;
@@ -241,7 +253,10 @@ pub(crate) fn parse_central_directory(mmap: &[u8]) -> Result<Vec<CentralEntry>> 
         let extra_at = name_at + name_len;
         let record_end = extra_at + extra_len + comment_len;
         if record_end > cd.len() {
-            bail!("central-directory record at offset {} is truncated", start + at);
+            bail!(
+                "central-directory record at offset {} is truncated",
+                start + at
+            );
         }
 
         let name = std::str::from_utf8(&cd[name_at..extra_at])
@@ -401,8 +416,18 @@ mod tests {
         for (i, entry) in parsed.iter().enumerate() {
             let zf = archive.by_index(i).unwrap();
             assert_eq!(entry.name, zf.name(), "name at {}", i);
-            assert_eq!(entry.comp_size, zf.compressed_size(), "comp_size of {}", entry.name);
-            assert_eq!(entry.header_start, zf.header_start(), "header_start of {}", entry.name);
+            assert_eq!(
+                entry.comp_size,
+                zf.compressed_size(),
+                "comp_size of {}",
+                entry.name
+            );
+            assert_eq!(
+                entry.header_start,
+                zf.header_start(),
+                "header_start of {}",
+                entry.name
+            );
             let expected_method = match zf.compression() {
                 zip::CompressionMethod::Stored => 0u16,
                 zip::CompressionMethod::Deflated => 8u16,
@@ -453,8 +478,11 @@ mod tests {
         {
             let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
             zw.set_comment("a comment that follows the EOCD record");
-            zw.start_file("fastsa/metadata.json", zip::write::SimpleFileOptions::default())
-                .unwrap();
+            zw.start_file(
+                "fastsa/metadata.json",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
             zw.write_all(b"{}").unwrap();
             zw.finish().unwrap();
         }
@@ -526,8 +554,7 @@ mod tests {
             f
         };
         // Sizes fit in 32 bits; only the header offset is a sentinel.
-        let (comp_size, header_start) =
-            resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
+        let (comp_size, header_start) = resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
         assert_eq!(comp_size, 11);
         assert_eq!(header_start, 0x1_0000_0000);
     }
@@ -537,8 +564,7 @@ mod tests {
     fn zip64_extra_field_of_minimal_length_holds_only_the_overflowed_value() {
         let mut field = vec![0x01, 0x00, 8, 0x00];
         field.extend_from_slice(&0x2_0000_0000u64.to_le_bytes());
-        let (comp_size, header_start) =
-            resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
+        let (comp_size, header_start) = resolve_zip64(&field, 7, 11, U32_SENTINEL).unwrap();
         assert_eq!(comp_size, 11);
         assert_eq!(header_start, 0x2_0000_0000);
     }
@@ -563,12 +589,17 @@ mod tests {
         let size = read_u32(&buf, eocd + 12).unwrap();
         buf[eocd + 12..eocd + 16].copy_from_slice(&(size / 2).to_le_bytes());
         let err = parse_central_directory(&buf).unwrap_err().to_string();
-        assert!(err.contains("declares 3 entries") || err.contains("trailing bytes"), "{err}");
+        assert!(
+            err.contains("declares 3 entries") || err.contains("trailing bytes"),
+            "{err}"
+        );
     }
 
     #[test]
     fn rejects_a_non_zip_file() {
-        let err = parse_central_directory(&[0u8; 512]).unwrap_err().to_string();
+        let err = parse_central_directory(&[0u8; 512])
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("no end-of-central-directory"), "{}", err);
     }
 

--- a/crates/fastvep-sa/tests/gnomad_indel_normalization.rs
+++ b/crates/fastvep-sa/tests/gnomad_indel_normalization.rs
@@ -74,7 +74,10 @@ fn gnomad_repeat_indel_matches_after_normalization() {
     // Normalize the raw query to gnomAD's minimal/left-aligned representation,
     // then query again — now it matches and we recover the real AF.
     let n = normalize_variant(&StrRef, "chr2", 5, "CTAAC", "C");
-    assert_eq!((n.pos, n.ref_allele.as_str(), n.alt_allele.as_str()), (1, "GTAAC", "G"));
+    assert_eq!(
+        (n.pos, n.ref_allele.as_str(), n.alt_allele.as_str()),
+        (1, "GTAAC", "G")
+    );
 
     let hit = reader
         .annotate_position("chr2", n.pos, &n.ref_allele, &n.alt_allele)

--- a/crates/fastvep-sa/tests/issue_37_contig_naming.rs
+++ b/crates/fastvep-sa/tests/issue_37_contig_naming.rs
@@ -119,11 +119,7 @@ fn mitochondrial_aliases_round_trip() {
         let base = dir.path().join(format!("mito_{}", stored_as));
         let mut writer = SaWriter::new(gnomad_header());
         writer
-            .write_to_files(
-                &base,
-                records.clone().into_iter(),
-                &[stored_as.to_string()],
-            )
+            .write_to_files(&base, records.clone().into_iter(), &[stored_as.to_string()])
             .unwrap();
         let reader = SaReader::open(&base.with_extension("osa")).unwrap();
 

--- a/crates/fastvep-sa/tests/issue_37_v2_cache_coherence.rs
+++ b/crates/fastvep-sa/tests/issue_37_v2_cache_coherence.rs
@@ -67,14 +67,18 @@ fn v2_reader_resolves_chr_query_against_bare_keyed_archive() {
     let reader = Osa2Reader::open(&path).unwrap();
 
     // chr*-prefixed query hits a bare-keyed archive.
-    let hit = reader
-        .annotate_position("chr1", 10_500, "A", "G")
-        .unwrap();
-    assert!(hit.is_some(), "chr1 query must resolve against bare archive");
+    let hit = reader.annotate_position("chr1", 10_500, "A", "G").unwrap();
+    assert!(
+        hit.is_some(),
+        "chr1 query must resolve against bare archive"
+    );
 
     // And the bare form still works.
     let hit = reader.annotate_position("1", 10_500, "A", "G").unwrap();
-    assert!(hit.is_some(), "bare query must resolve against bare archive");
+    assert!(
+        hit.is_some(),
+        "bare query must resolve against bare archive"
+    );
 }
 
 #[test]

--- a/crates/fastvep-sa/tests/issue_78_open_cost.rs
+++ b/crates/fastvep-sa/tests/issue_78_open_cost.rs
@@ -163,7 +163,11 @@ fn concurrent_first_touch_is_consistent() {
 
     let hits: usize = (0..64u32)
         .into_par_iter()
-        .flat_map(|c| (0..4u32).into_par_iter().map(move |k| ((c << 12) + 10 + k) as u64))
+        .flat_map(|c| {
+            (0..4u32)
+                .into_par_iter()
+                .map(move |k| ((c << 12) + 10 + k) as u64)
+        })
         .map(|position| {
             reader
                 .annotate_position("chr1", position, "A", "G")

--- a/crates/fastvep-sa/tests/query_path_allocations.rs
+++ b/crates/fastvep-sa/tests/query_path_allocations.rs
@@ -13,8 +13,8 @@
 
 use fastvep_cache::annotation::AnnotationProvider;
 use fastvep_sa::common::AnnotationRecord;
-use fastvep_sa::index::IndexHeader;
 use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::index::IndexHeader;
 use fastvep_sa::interval::{IntervalHeader, IntervalIndex};
 use fastvep_sa::reader::SaReader;
 use fastvep_sa::reader_v2::Osa2Reader;
@@ -187,10 +187,16 @@ fn resolving_a_chromosome_allocates_nothing_on_any_reader() {
         // build the alias Vec before discovering the miss.
         let allocs = allocations_during(|| {
             for _ in 0..1_000 {
-                assert!(reader.annotate_position("2", 10_000, "A", "G").unwrap().is_none());
+                assert!(reader
+                    .annotate_position("2", 10_000, "A", "G")
+                    .unwrap()
+                    .is_none());
             }
         });
-        assert_eq!(allocs, 0, "{name}: aliased absent-contig queries allocated {allocs} times");
+        assert_eq!(
+            allocs, 0,
+            "{name}: aliased absent-contig queries allocated {allocs} times"
+        );
 
         // A hit necessarily allocates (it returns an owned JSON String), but
         // resolving via an alias must cost the same as the canonical spelling.
@@ -204,7 +210,10 @@ fn resolving_a_chromosome_allocates_nothing_on_any_reader() {
         });
         let aliased = allocations_during(|| {
             for _ in 0..1_000 {
-                assert!(reader.annotate_position("1", 10_000, "A", "G").unwrap().is_some());
+                assert!(reader
+                    .annotate_position("1", 10_000, "A", "G")
+                    .unwrap()
+                    .is_some());
             }
         });
         assert_eq!(

--- a/crates/fastvep-sa/tests/round_trip.rs
+++ b/crates/fastvep-sa/tests/round_trip.rs
@@ -227,7 +227,7 @@ fn test_osa2_writer_reader_round_trip() {
                 alt_allele: b"G".to_vec(),
                 values: vec![
                     fields[0].encode_float(af), // AF
-                    (i + 1),               // AC
+                    (i + 1),                    // AC
                 ],
                 json_blob: None,
             }

--- a/crates/fastvep-sa/tests/v2_non_acgt_alleles.rs
+++ b/crates/fastvep-sa/tests/v2_non_acgt_alleles.rs
@@ -207,7 +207,12 @@ fn a_wrong_non_acgt_allele_still_misses() {
     // Right allele shape, wrong position.
     assert!(json_of(reader.annotate_position("chr1", 999, "A", "N").unwrap()).is_none());
     // A non-ACGT query against a position holding only ACGT records.
-    assert!(json_of(reader.annotate_position("chr1", 202, "GATTACN", "G").unwrap()).is_none());
+    assert!(json_of(
+        reader
+            .annotate_position("chr1", 202, "GATTACN", "G")
+            .unwrap()
+    )
+    .is_none());
     // And the ACGT record at a position that also holds a non-ACGT one is
     // unaffected by the bucket's presence.
     assert!(json_of(reader.annotate_position("chr1", 100, "A", "G").unwrap()).is_some());


### PR DESCRIPTION
The formatting drift had reached **919 hunks across 100 files**. It accumulated because nothing enforces `cargo fmt`, and it was left alone because a reformat mixed into a real change is unreviewable. Doing it alone, once, is the way out.

Two commits, deliberately separate:

1. **`style: rustfmt the workspace`** — pure `cargo fmt --all`, 100 files, all `.rs`. Nothing else in it, so it can be skipped wholesale when reading history.
2. **`chore: keep git blame useful across the reformat`** — a `.git-blame-ignore-revs` listing that commit. GitHub applies it automatically; locally it needs `git config blame.ignoreRevsFile .git-blame-ignore-revs`, documented in the file.

## It is not whitespace-only, and that was checked rather than assumed

rustfmt on stock defaults also collapses single-expression blocks into their match arm, reflows argument lists that now fit on one line, and sorts `use` statements within a group. None of that changes behaviour, but at 100 files "it's only whitespace" is not something to take on trust, and `git diff -w` does not settle it because rustfmt reflows across line boundaries.

So it was verified on real data instead. Benchmark run **v22 against v21**, the full ClinVar 2-star-or-better set, **673,660 variants** through the entire annotation and classification pipeline:

| Output | Result |
|---|---|
| `concordance_summary.txt` | identical |
| `concordance_matrix.csv` | identical |
| `criterion_firing_rates.csv` | identical |
| `rule_distribution.csv` | identical |
| `discrepancies.tsv` | identical |

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` both clean on 1.97.1.

## Ordering note

This should merge **before** any `cargo fmt --check` gate is added to CI, or that gate fails on 919 hunks. #83 is the natural home for the gate once this lands.