### PR TITLE
fix(hgvs): route in-frame insertions to delins, not substitution

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -610,11 +610,24 @@ impl AnnotationContext {
                                                 || ac
                                                     .consequences
                                                     .contains(&Consequence::InframeDeletion)
+                                                || ac
+                                                    .consequences
+                                                    .contains(&Consequence::InframeInsertion)
                                             {
-                                                // In-frame deletion / delins (frameshift
-                                                // handled above). aa.0 holds the deleted
+                                                // In-frame indel / delins (frameshift
+                                                // handled above). aa.0 holds the replaced
                                                 // residues, aa.1 the replacement ("-" for a
                                                 // pure deletion).
+                                                //
+                                                // Insertions must route here too, not to
+                                                // `hgvsp()`: that compares only the first
+                                                // residue of each side, so `W/WR` reads as
+                                                // unchanged and renders `p.Trp185=` for a
+                                                // variant that lengthens the protein. The
+                                                // resulting `delins` is un-normalised (VEP
+                                                // would collapse a repeat to `dup`), but it
+                                                // is valid HGVS and never a substitution
+                                                // shape. See issue #81.
                                                 ann.hgvsp = fastvep_hgvs::hgvsp_inframe_deletion(
                                                     &versioned_pid,
                                                     ps,
@@ -1686,6 +1699,144 @@ mod tests {
             tc.get("hgvsp").is_none(),
             "hgvsp should be omitted (skipped), not present, when spliced_seq is \
              shorter than coding_start_idx implies: {:?}",
+            tc
+        );
+    }
+
+    #[test]
+    fn hgvsp_inframe_insertion_is_a_delins_not_a_substitution() {
+        // Regression for issue #81: the HGVSp routing tested only
+        // `aa.1 == "-" || InframeDeletion`, which no in-frame *insertion*
+        // satisfies, so insertions fell through to `hgvsp()`. That compares
+        // one byte per side, so `R/RR` looked unchanged and produced
+        // `p.Arg3=` -- a synonymous call for a variant that lengthens the
+        // protein by a residue. Unlike the malformed `p.Xaa123???` that #58
+        // fixed, a well-formed `=` or missense is indistinguishable from a
+        // genuine call downstream, which is what makes it dangerous.
+        //
+        // The emitted `delins` here is deliberately un-normalised: Ensembl
+        // VEP collapses this repeat to `p.Arg3dup`. Protein-level 3'-shift
+        // and duplication collapse are tracked separately in #81; this test
+        // pins only the property that matters clinically, that an insertion
+        // never renders as a substitution.
+        use fastvep_genome::{Exon, Gene, Transcript, Translation};
+
+        // Single-CDS-exon transcript on chr1 behind a 50 bp 5' UTR.
+        // CDS (genomic 51-62) is ATG TGG CGG TAA = Met Trp Arg Ter.
+        let mut transcript = Transcript {
+            stable_id: "ENST_INS_TEST".into(),
+            version: None,
+            gene: Gene {
+                stable_id: "ENSG_INS_TEST".into(),
+                symbol: Some("INS-TEST".into()),
+                symbol_source: None,
+                hgnc_id: None,
+                biotype: "protein_coding".into(),
+                chromosome: "1".into(),
+                start: 1,
+                end: 62,
+                strand: fastvep_core::Strand::Forward,
+            },
+            biotype: "protein_coding".into(),
+            chromosome: "1".into(),
+            start: 1,
+            end: 62,
+            strand: fastvep_core::Strand::Forward,
+            exons: vec![
+                Exon {
+                    stable_id: "ENSE_INS_TEST_1".into(),
+                    start: 1,
+                    end: 50,
+                    strand: fastvep_core::Strand::Forward,
+                    phase: -1,
+                    end_phase: 0,
+                    rank: 1,
+                },
+                Exon {
+                    stable_id: "ENSE_INS_TEST_2".into(),
+                    start: 51,
+                    end: 62,
+                    strand: fastvep_core::Strand::Forward,
+                    phase: 0,
+                    end_phase: -1,
+                    rank: 2,
+                },
+            ],
+            translation: Some(Translation {
+                stable_id: "ENSP_INS_TEST".into(),
+                genomic_start: 51,
+                genomic_end: 62,
+                start_exon_rank: 2,
+                start_exon_offset: 0,
+                end_exon_rank: 2,
+                end_exon_offset: 11,
+            }),
+            cdna_coding_start: Some(51),
+            cdna_coding_end: Some(62),
+            coding_region_start: Some(51),
+            coding_region_end: Some(62),
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: true,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: Some("ENSP_INS_TEST".into()),
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
+        };
+
+        transcript
+            .build_sequences(|_chrom, start, _end| {
+                if start == 1 {
+                    Ok(b"N".repeat(50))
+                } else {
+                    Ok(b"ATGTGGCGGTAA".to_vec())
+                }
+            })
+            .expect("build_sequences should succeed for a well-formed test transcript");
+
+        let mut ctx = empty_context();
+        ctx.transcript_provider = IndexedTranscriptProvider::new(vec![transcript]);
+
+        // Insert CGG after the Trp codon (genomic 54-56), anchored at 56:
+        // Met Trp Arg Ter -> Met Trp Arg Arg Ter, an in-frame duplication
+        // of Arg3.
+        let vcf = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+                   1\t56\t.\tG\tGCGG\t.\tPASS\t.\n";
+
+        let results = ctx.annotate_vcf_text_with_acmg(vcf, false, None).unwrap();
+        assert_eq!(results.len(), 1);
+        let tc = &results[0]["transcript_consequences"][0];
+
+        // Guard the premise: if this stops being classified as an in-frame
+        // insertion the assertion below would pass for the wrong reason.
+        let terms = tc["consequence_terms"]
+            .as_array()
+            .expect("consequence_terms should be present");
+        assert!(
+            terms
+                .iter()
+                .any(|t| t.as_str() == Some("inframe_insertion")),
+            "expected inframe_insertion, got: {:?}",
+            terms
+        );
+        assert_eq!(tc["amino_acids"], serde_json::json!("R/RR"));
+
+        assert_eq!(
+            tc["hgvsp"],
+            serde_json::json!("ENSP_INS_TEST:p.Arg3delinsArgArg"),
+            "in-frame insertion must render as a delins, not a substitution: {:?}",
             tc
         );
     }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1186,10 +1186,20 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                                             }
                                         } else if aa.1 == "-"
                                             || ac.consequences.contains(&Consequence::InframeDeletion)
+                                            || ac.consequences.contains(&Consequence::InframeInsertion)
                                         {
-                                            // In-frame deletion / delins (frameshift handled
-                                            // above). aa.0 holds the deleted residues, aa.1 the
+                                            // In-frame indel / delins (frameshift handled
+                                            // above). aa.0 holds the replaced residues, aa.1 the
                                             // replacement ("-" for a pure deletion).
+                                            //
+                                            // Insertions must route here too, not to `hgvsp()`:
+                                            // that compares only the first residue of each side,
+                                            // so `W/WR` reads as unchanged and renders
+                                            // `p.Trp185=` for a variant that lengthens the
+                                            // protein. The resulting `delins` is un-normalised
+                                            // (VEP would collapse a repeat to `dup`), but it is
+                                            // valid HGVS and never a substitution shape. See
+                                            // issue #81.
                                             ann.hgvsp = fastvep_hgvs::hgvsp_inframe_deletion(
                                                 &versioned_pid, ps, &aa.0, &aa.1,
                                             );

--- a/crates/fastvep-cli/tests/hgvsp_inframe_insertion.rs
+++ b/crates/fastvep-cli/tests/hgvsp_inframe_insertion.rs
@@ -1,0 +1,101 @@
+//! End-to-end regression for issue #81: an in-frame insertion must not be
+//! reported as a substitution in HGVSp.
+//!
+//! The CLI pipeline carries its own copy of the HGVSp routing block, separate
+//! from the one in `fastvep-annotate`. Both had the same bug and both need
+//! their own test, because nothing structurally keeps the two copies in step.
+//! This one drives the real `run_annotate` entry point over a GFF3 + FASTA +
+//! VCF on disk, so it fails if the routing regresses anywhere between parsing
+//! the variant and writing the CSQ field.
+
+use fastvep_cli::pipeline::{run_annotate, AnnotateConfig};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+// Single-exon coding transcript on contig `1`, CDS = the whole 12 bp exon.
+// `ID=CDS:ENSP_INS1` supplies the protein ID that HGVSp is prefixed with.
+const GFF3: &str = "##gff-version 3\n\
+1\ttest\tgene\t1\t12\t.\t+\t.\tID=gene:ENSG_INS1;Name=INSTEST;gene_name=INSTEST;biotype=protein_coding\n\
+1\ttest\tmRNA\t1\t12\t.\t+\t.\tID=transcript:ENST_INS1;Parent=gene:ENSG_INS1;biotype=protein_coding\n\
+1\ttest\texon\t1\t12\t.\t+\t.\tID=exon:ENSE_INS1;Parent=transcript:ENST_INS1;rank=1\n\
+1\ttest\tCDS\t1\t12\t.\t+\t0\tID=CDS:ENSP_INS1;Parent=transcript:ENST_INS1\n";
+
+// ATG TGG CGG TAA = Met Trp Arg Ter.
+const FASTA: &str = ">1\nATGTGGCGGTAA\n";
+
+// Insert CGG after the Trp codon (bases 4-6), VCF-anchored at base 6:
+// Met Trp Arg Ter -> Met Trp Arg Arg Ter, an in-frame duplication of Arg3.
+const VCF: &str = "##fileformat=VCFv4.2\n\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+1\t6\t.\tG\tGCGG\t.\tPASS\t.\n";
+
+fn write(path: &Path, contents: &str) {
+    File::create(path)
+        .unwrap()
+        .write_all(contents.as_bytes())
+        .unwrap();
+}
+
+#[test]
+fn cli_inframe_insertion_hgvsp_is_a_delins_not_a_substitution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gff3 = tmp.path().join("test.gff3");
+    let fasta = tmp.path().join("test.fa");
+    let vcf_in = tmp.path().join("in.vcf");
+    let vcf_out = tmp.path().join("out.vcf");
+    write(&gff3, GFF3);
+    write(&fasta, FASTA);
+    write(&vcf_in, VCF);
+
+    run_annotate(AnnotateConfig {
+        input: vcf_in.to_string_lossy().into(),
+        output: vcf_out.to_string_lossy().into(),
+        gff3: vec![gff3.to_string_lossy().into()],
+        fasta: Some(fasta.to_string_lossy().into()),
+        output_format: "vcf".into(),
+        pick: false,
+        hgvs: true,
+        distance: 5000,
+        cache_dir: None,
+        transcript_cache: None,
+        sa_dir: None,
+        sa_only: false,
+        acmg: false,
+        acmg_config: None,
+        pick_order: None,
+        functional_evidence: None,
+        proband: None,
+        mother: None,
+        father: None,
+        gene_list: None,
+        explicit_alleles: false,
+        qc_rules: None,
+        show_progress: false,
+    })
+    .expect("annotation should succeed");
+
+    let out = std::fs::read_to_string(&vcf_out).unwrap();
+
+    // Guard the premise: if this stops being classified as an in-frame
+    // insertion, the HGVSp assertions below would pass for the wrong reason.
+    assert!(
+        out.contains("inframe_insertion"),
+        "expected an inframe_insertion consequence, got:\n{}",
+        out
+    );
+
+    // The bug: `hgvsp()` compared only the first residue of `R` vs `RR`,
+    // found them equal, and emitted a synonymous call for a variant that
+    // lengthens the protein.
+    assert!(
+        !out.contains("p.Arg3="),
+        "in-frame insertion rendered as synonymous (issue #81):\n{}",
+        out
+    );
+    assert!(
+        out.contains("p.Arg3delinsArgArg"),
+        "expected an un-normalised delins for the in-frame insertion, got:\n{}",
+        out
+    );
+}


### PR DESCRIPTION
Fixes the half of #81 that produces a silent wrong answer. Protein-level normalisation (3'-shift and `dup` collapse) is **not** in this PR and is left to @MarcusOlivecrona, who has an implementation in flight.

## The bug

The HGVSp routing tested `aa.1 == "-" || consequences.contains(InframeDeletion)`. An in-frame *insertion* satisfies neither, so it fell through to `hgvsp()`, which compares one residue per side:

```rust
if ref_aa == alt_aa {
    return Some(format!("{}{}{}=", prefix, ref_aa3, protein_pos));
}
```

For `amino_acids` `R/RR` that yields `p.Arg3=`, a synonymous call for a variant that lengthens the protein. For `E/DVDFREYE` it yields `p.Glu598Asp`, a well-formed missense. Unlike the malformed `p.Xaa123???` that #58 fixed, both are indistinguishable from genuine calls, so nothing downstream can detect them. In the reporter's clinical panel run all 15 distinct in-frame insertions were affected (8 synonymous, 7 missense), two of them FLT3 ITDs.

Reproduced through the real annotation path before fixing:

```
consequence_terms = ["inframe_insertion"]
amino_acids       = "R/RR"
codons            = "cgg/CGGcgg"
hgvsp             = "ENSP_INS_TEST:p.Arg3="     <- Ensembl VEP: p.Arg3dup
```

## The change

In-frame insertions now route into `hgvsp_inframe_deletion` alongside deletions and delins, giving `p.Arg3delinsArgArg`.

That output is **deliberately un-normalised**. Ensembl VEP collapses this repeat to `p.Arg3dup`, and for a 31-codon BCOR duplication the `delins` form runs to ~105 characters. That is the tradeoff being accepted here: correct-but-verbose now, normalised when #81 lands. What matters clinically is the property this PR establishes, that an in-frame insertion never renders as a substitution.

**Both call sites are fixed.** `fastvep-annotate` (library/web) and `fastvep-cli` (CLI pipeline) carry separate copies of this routing block, and both had the bug. Nothing structurally keeps them in step, so each gets its own regression test.

## Testing

- `crates/fastvep-annotate/src/lib.rs` - annotates a VCF against a synthetic transcript through `annotate_vcf_text_with_acmg`, asserting the emitted HGVSp.
- `crates/fastvep-cli/tests/hgvsp_inframe_insertion.rs` - end-to-end through `run_annotate` with a GFF3 + FASTA + VCF on disk, asserting on the CSQ field in the output VCF.

Both fail on `master` with `p.Arg3=` and pass here. Both assert the `inframe_insertion` consequence first, so they cannot pass for the wrong reason if classification changes.

`cargo test --workspace` (0 failures) and `cargo clippy --workspace --all-targets` (clean) both pass.

`cargo fmt --check` is not clean on `master` and is not made worse here: the violation count in the two touched files is 111 before and after this change, and the new test file is rustfmt-clean on its own. The pending `chore/rustfmt-the-workspace` branch reformats the workspace separately and will absorb these lines.

## ACMG is untouched by construction

We just shipped a large ACMG pass (#82), so the blast radius matters. ACMG never reads `hgvsp` - PS1, PM1 and PM5 read `protein_position` and `amino_acids` directly, and the PVS1 truncation percentage reads `protein_position`. This change touches neither, so no classification can move. That containment is also the constraint requested of the normalisation work in #81.

Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
