### PR TITLE
fix(hgvs): normalise in-frame indels per the HGVS 3'-rule

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -618,16 +618,19 @@ impl AnnotationContext {
                                                 // `hgvsp()`: that compares only the first
                                                 // residue of each side, so `W/WR` reads as
                                                 // unchanged and renders `p.Trp185=` for a
-                                                // variant that lengthens the protein. The
-                                                // resulting `delins` is un-normalised (VEP
-                                                // would collapse a repeat to `dup`), but it
-                                                // is valid HGVS and never a substitution
-                                                // shape. See issue #81.
-                                                ann.hgvsp = fastvep_hgvs::hgvsp_inframe_deletion(
+                                                // variant that lengthens the protein.
+                                                //
+                                                // The peptide lets `hgvsp_inframe_indel`
+                                                // apply the HGVS 3'-rule and collapse a
+                                                // repeat to `dup`, matching Ensembl VEP; it
+                                                // degrades to the unshifted description
+                                                // without one.
+                                                ann.hgvsp = fastvep_hgvs::hgvsp_inframe_indel(
                                                     &versioned_pid,
                                                     ps,
                                                     &aa.0,
                                                     &aa.1,
+                                                    tr.peptide.as_deref().map(str::as_bytes),
                                                 );
                                             } else {
                                                 let ref_aa_byte = aa
@@ -1692,7 +1695,7 @@ mod tests {
     }
 
     #[test]
-    fn hgvsp_inframe_insertion_is_a_delins_not_a_substitution() {
+    fn hgvsp_inframe_insertion_is_normalised_not_a_substitution() {
         // Regression for issue #81: the HGVSp routing tested only
         // `aa.1 == "-" || InframeDeletion`, which no in-frame *insertion*
         // satisfies, so insertions fell through to `hgvsp()`. That compares
@@ -1702,11 +1705,12 @@ mod tests {
         // fixed, a well-formed `=` or missense is indistinguishable from a
         // genuine call downstream, which is what makes it dangerous.
         //
-        // The emitted `delins` here is deliberately un-normalised: Ensembl
-        // VEP collapses this repeat to `p.Arg3dup`. Protein-level 3'-shift
-        // and duplication collapse are tracked separately in #81; this test
-        // pins only the property that matters clinically, that an insertion
-        // never renders as a substitution.
+        // `CGG` inserted after the Trp codon repeats the Arg that follows it,
+        // so the HGVS 3'-rule shifts the insertion one residue right and
+        // writes the repeat as a duplication. This is the value Ensembl VEP
+        // reports, and it exercises both halves of the guard: an insertion
+        // never renders as a substitution, and the description it does render
+        // is normalised rather than a literal `delinsArgArg`.
         use fastvep_genome::{Exon, Gene, Transcript, Translation};
 
         // Single-CDS-exon transcript on chr1 behind a 50 bp 5' UTR.
@@ -1823,8 +1827,9 @@ mod tests {
 
         assert_eq!(
             tc["hgvsp"],
-            serde_json::json!("ENSP_INS_TEST:p.Arg3delinsArgArg"),
-            "in-frame insertion must render as a delins, not a substitution: {:?}",
+            serde_json::json!("ENSP_INS_TEST:p.Arg3dup"),
+            "in-frame insertion must render as a normalised duplication, not a \
+             substitution and not an unshifted delins: {:?}",
             tc
         );
     }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1250,12 +1250,18 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                                             // that compares only the first residue of each side,
                                             // so `W/WR` reads as unchanged and renders
                                             // `p.Trp185=` for a variant that lengthens the
-                                            // protein. The resulting `delins` is un-normalised
-                                            // (VEP would collapse a repeat to `dup`), but it is
-                                            // valid HGVS and never a substitution shape. See
-                                            // issue #81.
-                                            ann.hgvsp = fastvep_hgvs::hgvsp_inframe_deletion(
-                                                &versioned_pid, ps, &aa.0, &aa.1,
+                                            // protein.
+                                            //
+                                            // The peptide lets `hgvsp_inframe_indel` apply the
+                                            // HGVS 3'-rule and collapse a repeat to `dup`,
+                                            // matching Ensembl VEP; it degrades to the
+                                            // unshifted description without one.
+                                            ann.hgvsp = fastvep_hgvs::hgvsp_inframe_indel(
+                                                &versioned_pid,
+                                                ps,
+                                                &aa.0,
+                                                &aa.1,
+                                                tr.peptide.as_deref().map(str::as_bytes),
                                             );
                                         } else {
                                             let ref_aa_byte = aa.0.as_bytes().first().copied().unwrap_or(b'X');

--- a/crates/fastvep-cli/tests/hgvsp_inframe_insertion.rs
+++ b/crates/fastvep-cli/tests/hgvsp_inframe_insertion.rs
@@ -38,7 +38,7 @@ fn write(path: &Path, contents: &str) {
 }
 
 #[test]
-fn cli_inframe_insertion_hgvsp_is_a_delins_not_a_substitution() {
+fn cli_inframe_insertion_hgvsp_is_normalised_not_a_substitution() {
     let tmp = tempfile::tempdir().unwrap();
     let gff3 = tmp.path().join("test.gff3");
     let fasta = tmp.path().join("test.fa");
@@ -93,9 +93,16 @@ fn cli_inframe_insertion_hgvsp_is_a_delins_not_a_substitution() {
         "in-frame insertion rendered as synonymous (issue #81):\n{}",
         out
     );
+    // `CGG` inserted after the Trp codon repeats the Arg that follows it, so
+    // the HGVS 3'-rule shifts the insertion right and writes the repeat as a
+    // duplication -- the value Ensembl VEP reports. Asserting the normalised
+    // form rather than a literal `delinsArgArg` also guards the peptide
+    // reaching this call site: `hgvsp_inframe_indel` falls back to the
+    // unshifted description whenever it has no usable peptide, so a pipeline
+    // that stopped passing `tr.peptide` would fail here.
     assert!(
-        out.contains("p.Arg3delinsArgArg"),
-        "expected an un-normalised delins for the in-frame insertion, got:\n{}",
+        out.contains("p.Arg3dup"),
+        "expected a normalised duplication for the in-frame insertion, got:\n{}",
         out
     );
 }

--- a/crates/fastvep-hgvs/src/lib.rs
+++ b/crates/fastvep-hgvs/src/lib.rs
@@ -7,7 +7,7 @@ pub use coding::{
     hgvsc_noncoding_intronic_range, hgvsc_with_seq,
 };
 pub use genomic::hgvsg;
-pub use protein::{hgvsp, hgvsp_frameshift, hgvsp_inframe_deletion};
+pub use protein::{hgvsp, hgvsp_frameshift, hgvsp_inframe_indel};
 
 /// Full HGVS annotation result.
 #[derive(Debug, Clone, Default)]

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -41,41 +41,231 @@ pub fn hgvsp(
     Some(format!("{}{}{}{}", prefix, ref_aa3, protein_pos, alt_aa3))
 }
 
-/// Generate HGVSp notation for an in-frame deletion or delins.
+/// Render a 1-based inclusive residue range, e.g. `Gly41` or `Asn587_Asp600`.
+fn residue_span(first_pos: u64, residues: &[u8]) -> String {
+    let first = aa_one_to_three(residues[0]);
+    if residues.len() == 1 {
+        format!("{}{}", first, first_pos)
+    } else {
+        let last = aa_one_to_three(residues[residues.len() - 1]);
+        format!(
+            "{}{}_{}{}",
+            first,
+            first_pos,
+            last,
+            first_pos + residues.len() as u64 - 1
+        )
+    }
+}
+
+fn three_letter(residues: &[u8]) -> String {
+    residues.iter().map(|&b| aa_one_to_three(b)).collect()
+}
+
+/// Describe the change using only the residues the caller supplied, without
+/// consulting the peptide. Always available when there is at least one
+/// reference residue, and the fallback whenever the peptide is missing or
+/// cannot be trusted — a valid, unshifted description beats emitting nothing.
+fn unshifted_description(
+    prefix: &str,
+    start: u64,
+    reference: &[u8],
+    alternate: &[u8],
+) -> Option<String> {
+    if reference.is_empty() {
+        return None;
+    }
+    let range = residue_span(start, reference);
+    if alternate.is_empty() {
+        Some(format!("{}{}del", prefix, range))
+    } else {
+        Some(format!(
+            "{}{}delins{}",
+            prefix,
+            range,
+            three_letter(alternate)
+        ))
+    }
+}
+
+/// Whether `peptide` actually carries `reference` at `protein_start`.
 ///
-/// `ref_aas` are the affected reference residues (one-letter, in order) starting
-/// at `protein_start`; `alt_aas` is the replacement ("-" or empty for a pure
-/// deletion). Produces standard HGVS:
-///   ENSP0:p.Phe157del                 (single-residue deletion)
-///   ENSP0:p.Tyr43_Gln45del            (multi-residue deletion)
-///   ENSP0:p.Asn2173_Leu2174delinsLys  (in-frame delins)
+/// A transcript whose sequence disagrees with its own coordinates would
+/// otherwise produce a confident, well-formed, wrong description — worse than
+/// no normalisation at all.
+fn peptide_carries(peptide: &[u8], protein_start: u64, reference: &[u8]) -> bool {
+    let Some(lo) = protein_start.checked_sub(1).map(|v| v as usize) else {
+        return false;
+    };
+    if reference.is_empty() {
+        // Pure insertion: only the flanking position is read.
+        return lo <= peptide.len();
+    }
+    peptide.get(lo..lo + reference.len()) == Some(reference)
+}
+
+/// Generate HGVSp notation for an in-frame indel — deletion, delins, insertion
+/// or duplication.
 ///
-/// This replaces the incorrect missense-style output (e.g. `p.Tyr43???`, where
-/// the deletion marker `-` had no three-letter code) for in-frame deletions.
-pub fn hgvsp_inframe_deletion(
+/// `ref_aas` are the affected reference residues (one-letter, in order)
+/// starting at `protein_start`; `alt_aas` is the replacement ("-" or empty for
+/// a pure deletion, longer than `ref_aas` for an insertion).
+///
+///   ENSP0:p.Phe157del            single-residue deletion
+///   ENSP0:p.Tyr43_Gln45del       multi-residue deletion
+///   ENSP0:p.Asn2173_Leu2174delinsLys   delins
+///   ENSP0:p.Ser92_Ser93insGly    insertion
+///   ENSP0:p.Asn587_Asp600dup     insertion that repeats what it follows
+///
+/// This is the only correct rendering for an in-frame indel: `hgvsp` compares
+/// just the first residue of each side, so it would describe these as a
+/// substitution — synonymous when that residue is unchanged, missense when it
+/// differs, and neither is true of a variant that changes the protein's length.
+///
+/// `ref_peptide` is the reference protein in one-letter codes, residue 1 at
+/// index 0 — pass `Transcript::peptide`, which is translated in frame from
+/// `codon_table_start_phase` and with the right codon table for the contig. Any
+/// terminator it carries is trimmed here. Given one, insertions and deletions
+/// are normalised per the HGVS 3'-rule — shifted as far C-terminal as they can
+/// go, with duplications collapsed to `dup` — matching Ensembl VEP. `delins` is
+/// not shifted.
+///
+/// Every peptide-dependent step degrades to the unshifted description rather
+/// than failing: a peptide that is absent, too short, or inconsistent with
+/// `protein_start` still yields valid HGVS, just unnormalised.
+pub fn hgvsp_inframe_indel(
     protein_id: &str,
     protein_start: u64,
     ref_aas: &str,
     alt_aas: &str,
+    ref_peptide: Option<&[u8]>,
 ) -> Option<String> {
-    let ref_bytes = ref_aas.as_bytes();
-    if ref_bytes.is_empty() {
+    let strip = |s: &str| -> Vec<u8> {
+        if s == "-" {
+            Vec::new()
+        } else {
+            s.bytes().collect()
+        }
+    };
+    let original_ref = strip(ref_aas);
+    let original_alt = strip(alt_aas);
+    let prefix = format!("{}:p.", protein_id);
+    let fallback = || unshifted_description(&prefix, protein_start, &original_ref, &original_alt);
+
+    // Transcript::peptide runs to cdna_coding_end, so it carries the terminator
+    // as a final `*` — and anything translated past an internal one on a
+    // mis-annotated CDS. Those residues are not part of the protein, so bound
+    // the peptide at the first terminator before shifting against it.
+    let ref_peptide = ref_peptide.map(|p| match p.iter().position(|&b| b == b'*') {
+        Some(terminator) => &p[..terminator],
+        None => p,
+    });
+    // Everything below re-anchors the description relative to `protein_start`,
+    // so none of it is safe unless the peptide corroborates that the caller's
+    // residues really sit there. They do not always: for a shrinking change
+    // like `FF/F` the call sites pass the end of the affected range rather than
+    // its start, and trimming from an anchor that is one residue off names a
+    // position the protein does not have. Without corroboration, emit exactly
+    // what the un-normalised path emits.
+    let Some(peptide) = ref_peptide.filter(|p| peptide_carries(p, protein_start, &original_ref))
+    else {
+        return fallback();
+    };
+
+    // Reduce to the minimal changed region: residues shared at either end are
+    // not part of the description. Trimming the prefix moves the start right.
+    let mut reference = original_ref.clone();
+    let mut alternate = original_alt.clone();
+    let mut start = protein_start;
+    while !reference.is_empty() && !alternate.is_empty() && reference[0] == alternate[0] {
+        reference.remove(0);
+        alternate.remove(0);
+        start += 1;
+    }
+    while !reference.is_empty() && !alternate.is_empty() && reference.last() == alternate.last() {
+        reference.pop();
+        alternate.pop();
+    }
+
+    if reference.is_empty() && alternate.is_empty() {
         return None;
     }
-    let prefix = format!("{}:p.", protein_id);
-    let first = aa_one_to_three(ref_bytes[0]);
-    let range = if ref_bytes.len() == 1 {
-        format!("{}{}", first, protein_start)
+
+    if reference.is_empty() {
+        // Pure insertion, sitting between residues (start - 1) and start.
+        let Some(mut at) = start.checked_sub(1).map(|v| v as usize) else {
+            return fallback();
+        };
+        let mut inserted = alternate;
+        // 3'-rule: slide right while the residue the insertion sits in front of
+        // is the one it would place there.
+        while at < peptide.len() && peptide[at] == inserted[0] {
+            inserted.rotate_left(1);
+            at += 1;
+        }
+        // A duplication is an insertion whose residues repeat those immediately
+        // before it.
+        let preceding = at
+            .checked_sub(inserted.len())
+            .and_then(|lo| peptide.get(lo..at));
+        if preceding == Some(inserted.as_slice()) {
+            let dup_start = (at - inserted.len() + 1) as u64;
+            return Some(format!(
+                "{}{}dup",
+                prefix,
+                residue_span(dup_start, &inserted)
+            ));
+        }
+        // Otherwise name the flanking pair. At a terminus there is no pair, so
+        // fall back rather than drop the annotation.
+        match (
+            at.checked_sub(1).and_then(|i| peptide.get(i)),
+            peptide.get(at),
+        ) {
+            (Some(&before), Some(&after)) => Some(format!(
+                "{}{}{}_{}{}ins{}",
+                prefix,
+                aa_one_to_three(before),
+                at,
+                aa_one_to_three(after),
+                at + 1,
+                three_letter(&inserted)
+            )),
+            _ => fallback(),
+        }
+    } else if alternate.is_empty() {
+        // Pure deletion of `reference` starting at `start`.
+        let mut at = start;
+        let mut residues = reference;
+        {
+            let len = residues.len();
+            // 3'-rule: slide right while the residue following the deleted block
+            // repeats the first deleted residue.
+            loop {
+                let first = at.checked_sub(1).and_then(|i| peptide.get(i as usize));
+                let following = peptide.get(at as usize + len - 1);
+                match (first, following) {
+                    (Some(a), Some(b)) if a == b => at += 1,
+                    _ => break,
+                }
+            }
+            match at
+                .checked_sub(1)
+                .and_then(|lo| peptide.get(lo as usize..lo as usize + len))
+            {
+                Some(block) => residues = block.to_vec(),
+                None => return fallback(),
+            }
+        }
+        Some(format!("{}{}del", prefix, residue_span(at, &residues)))
     } else {
-        let last = aa_one_to_three(ref_bytes[ref_bytes.len() - 1]);
-        let end = protein_start + ref_bytes.len() as u64 - 1;
-        format!("{}{}_{}{}", first, protein_start, last, end)
-    };
-    if alt_aas.is_empty() || alt_aas == "-" {
-        Some(format!("{}{}del", prefix, range))
-    } else {
-        let ins: String = alt_aas.bytes().map(aa_one_to_three).collect();
-        Some(format!("{}{}delins{}", prefix, range, ins))
+        // Replacement of one residue run by another.
+        Some(format!(
+            "{}{}delins{}",
+            prefix,
+            residue_span(start, &reference),
+            three_letter(&alternate)
+        ))
     }
 }
 
@@ -269,25 +459,295 @@ mod tests {
     #[test]
     fn test_hgvsp_inframe_deletion_single() {
         // single-residue in-frame deletion
-        let r = hgvsp_inframe_deletion("ENSP00000001", 157, "F", "-");
+        let r = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None);
         assert_eq!(r, Some("ENSP00000001:p.Phe157del".to_string()));
     }
 
     #[test]
     fn test_hgvsp_inframe_deletion_range() {
         // multi-residue in-frame deletion (regression for the p.Tyr43??? bug)
-        let r = hgvsp_inframe_deletion("ENSP00000001", 43, "YXQ", "-");
+        let r = hgvsp_inframe_indel("ENSP00000001", 43, "YXQ", "-", None);
         assert_eq!(r, Some("ENSP00000001:p.Tyr43_Gln45del".to_string()));
     }
 
     #[test]
     fn test_hgvsp_inframe_delins() {
         // in-frame deletion-insertion
-        let r = hgvsp_inframe_deletion("ENSP00000001", 2173, "NL", "K");
+        let r = hgvsp_inframe_indel("ENSP00000001", 2173, "NL", "K", None);
         assert_eq!(
             r,
             Some("ENSP00000001:p.Asn2173_Leu2174delinsLys".to_string())
         );
+    }
+
+    // In-frame insertions previously fell through to the substitution branch,
+    // which compares only the first residue of each side. Every case below is
+    // real fastVEP output from a clinical panel, checked against Ensembl VEP.
+
+    /// Build a reference peptide with `residues` placed at 1-based `at`, padded
+    /// with a filler residue that cannot be confused with the payload.
+    fn peptide_with(at: u64, residues: &str, length: usize) -> Vec<u8> {
+        let mut pep = vec![b'M'; length];
+        for (i, b) in residues.bytes().enumerate() {
+            pep[at as usize - 1 + i] = b;
+        }
+        pep
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_insertion_collapses_to_duplication() {
+        // C8A c.553_554insGGA, amino_acids "W/WR" at 185 — previously p.Trp185=.
+        // Residue 186 is already Arg, so inserting Arg duplicates it.
+        let pep = peptide_with(185, "WRQ", 200);
+        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Arg186dup".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_insertion_multi_residue_duplication() {
+        // FLT3 c.1759_1800dup, a 14-codon ITD — previously p.Asp600=. The delins
+        // spelling runs to ~55 characters; the duplication form is 18.
+        let dup = "NEYFYVDFREYEYD";
+        let pep = peptide_with(587, &format!("{}K", dup), 700);
+        let alt = format!("D{}", dup);
+        let r = hgvsp_inframe_indel("ENSP00000001", 600, "D", &alt, Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Asn587_Asp600dup".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_insertion_true_insertion_uses_ins_form() {
+        // ITPKB c.275_276insGGT, amino_acids "S/SG" at 92 — previously p.Ser92=.
+        // Gly does not repeat the preceding residues, so it stays an insertion.
+        let pep = peptide_with(92, "SSK", 200);
+        let r = hgvsp_inframe_indel("ENSP00000001", 92, "S", "SG", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Ser92_Ser93insGly".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_deletion_is_three_prime_shifted() {
+        // A deletion inside a homopolymer run is reported at the most C-terminal
+        // position it can occupy: deleting one Ala from AAA at 2..4 is p.Ala4del.
+        let pep: Vec<u8> = "MAAAGK".bytes().collect();
+        let r = hgvsp_inframe_indel("ENSP00000001", 2, "A", "-", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Ala4del".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_without_peptide_stays_valid() {
+        // No sequence context: emit an unshifted but well-formed description
+        // rather than nothing, and never a substitution shape.
+        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", None);
+        assert_eq!(r, Some("ENSP00000001:p.Trp185delinsTrpArg".to_string()));
+        let d = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None);
+        assert_eq!(d, Some("ENSP00000001:p.Phe157del".to_string()));
+    }
+
+    // The peptide is caller-derived, so every index into it has to survive a
+    // transcript whose sequence disagrees with its own coordinates. Each case
+    // below aborted the process before the bounds checks were added.
+
+    /// `(case name, protein_start, ref_aas, alt_aas, peptide, expected)`.
+    type UnusablePeptideCase<'a> = (&'a str, u64, &'a str, &'a str, &'a [u8], Option<&'a str>);
+
+    #[test]
+    fn test_hgvsp_inframe_indel_survives_unusable_peptides() {
+        let short: Vec<u8> = "MAAAGK".bytes().collect();
+        let cases: Vec<UnusablePeptideCase> = vec![
+            // Deleted block overruns the peptide end.
+            (
+                "block overruns end",
+                6,
+                "KX",
+                "-",
+                &short,
+                Some("ENSP00000001:p.Lys6_Xaa7del"),
+            ),
+            // protein_start past the peptide entirely.
+            (
+                "start beyond peptide",
+                100,
+                "AK",
+                "-",
+                &short,
+                Some("ENSP00000001:p.Ala100_Lys101del"),
+            ),
+            // Insertion anchored past the peptide.
+            ("insertion beyond peptide", 500, "-", "R", &short, None),
+            // Empty peptide (truncated transcript).
+            (
+                "empty peptide",
+                1,
+                "F",
+                "-",
+                &[],
+                Some("ENSP00000001:p.Phe1del"),
+            ),
+            // Insertion one residue past the C-terminus.
+            (
+                "insertion at C-terminus",
+                7,
+                "K",
+                "KG",
+                &short,
+                Some("ENSP00000001:p.Lys7delinsLysGly"),
+            ),
+            // protein_start of 0 would underflow a 1-based conversion.
+            (
+                "zero protein_start",
+                0,
+                "F",
+                "-",
+                &short,
+                Some("ENSP00000001:p.Phe0del"),
+            ),
+        ];
+        for (name, start, reference, alternate, pep, expected) in cases {
+            let got = hgvsp_inframe_indel("ENSP00000001", start, reference, alternate, Some(pep));
+            assert_eq!(got.as_deref(), expected, "case: {name}");
+        }
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_does_not_shift_onto_the_terminator() {
+        // Transcript::peptide ends with `*`. A change abutting the stop must not
+        // shift onto it or name it as a flanking residue: Ter is not a residue
+        // of the protein, and a position at or past it is not a real position.
+        let pep: Vec<u8> = "MKKG*".bytes().collect();
+
+        // Deleting one Lys from the KK run shifts to the 3'-most Lys (3), not
+        // onto Gly4 or the terminator.
+        let deletion = hgvsp_inframe_indel("ENSP00000001", 2, "K", "-", Some(&pep));
+        assert_eq!(deletion, Some("ENSP00000001:p.Lys3del".to_string()));
+
+        // An insertion immediately before the terminator has no residue on its
+        // 3' side once the stop is excluded, so it falls back rather than
+        // emitting a Ter-flanked range.
+        let insertion = hgvsp_inframe_indel("ENSP00000001", 4, "G", "GS", Some(&pep));
+        assert_eq!(
+            insertion,
+            Some("ENSP00000001:p.Gly4delinsGlySer".to_string())
+        );
+        for out in [deletion, insertion] {
+            let out = out.unwrap();
+            assert!(!out.contains("Ter"), "terminator named as a residue: {out}");
+        }
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_ignores_a_peptide_that_disagrees() {
+        // The peptide says Gln at 2; the caller says Phe. Trusting the peptide
+        // would emit a confident, well-formed, wrong description (p.Gln6del).
+        // Fall back to the caller's residues instead.
+        let pep: Vec<u8> = "MQQQQQK".bytes().collect();
+        let r = hgvsp_inframe_indel("ENSP00000001", 2, "F", "-", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Phe2del".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_does_not_trim_from_an_uncorroborated_anchor() {
+        // Guards against normalising off an anchor the peptide contradicts.
+        // For a shrinking change the call sites do not always pass the start of
+        // `ref_aas`: real output from a ClinVar run has `Protein_position`
+        // 328-329 with `Amino_acids` FF/F reaching this function as
+        // protein_start 329, one past the F pair. Trimming the shared F then
+        // advances the anchor again and describes a deletion at 330 -- which is
+        // Ala, not Phe. Trimming is only sound once the peptide confirms the
+        // residues are where the caller says, so an uncorroborated anchor takes
+        // the un-normalised path instead.
+        //
+        // The peptide here is M R I F F A S M: the F pair is at 4-5, and the
+        // caller names 5. The expected output still describes position 6 as Phe
+        // -- it inherits the caller's anchor, and correcting that belongs at the
+        // call site -- but it must not claim the more specific `p.Phe6del`.
+        let pep: Vec<u8> = "MRIFFASM".bytes().collect();
+        let r = hgvsp_inframe_indel("ENSP00000001", 5, "FF", "F", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Phe5_Phe6delinsPhe".to_string()));
+
+        // Same shape, anchored correctly: the peptide corroborates position 4,
+        // so this one does normalise, to a deletion of the second F.
+        let r = hgvsp_inframe_indel("ENSP00000001", 4, "FF", "F", Some(&pep));
+        assert_eq!(r, Some("ENSP00000001:p.Phe5del".to_string()));
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_never_drops_a_terminal_insertion() {
+        // An insertion with no flanking pair still has to produce something —
+        // returning None would be a regression against the pre-normalisation
+        // behaviour, which always emitted a (wrong) substitution.
+        let pep: Vec<u8> = "MKKRSTV".bytes().collect();
+        for start in [1u64, 8] {
+            let got = hgvsp_inframe_indel("ENSP00000001", start, "G", "GG", Some(&pep));
+            assert!(got.is_some(), "dropped annotation at protein_start {start}");
+        }
+    }
+
+    #[test]
+    fn test_hgvsp_inframe_indel_never_emits_substitution_shape() {
+        // Every in-frame insertion observed in a clinical panel run, as
+        // (protein_start, amino_acids ref, amino_acids alt, prior output).
+        // All fifteen previously rendered in a substitution shape: eight as
+        // synonymous, seven as a plausible missense. Two (FLT3 at 598 and 596)
+        // are ITDs, where a missense reading is clinically misleading.
+        let insertions: &[(u64, &str, &str, &str)] = &[
+            (41, "G", "AG", "p.Gly41Ala"),
+            (185, "W", "WR", "p.Trp185="),
+            (92, "S", "SG", "p.Ser92="),
+            (2927, "E", "DE", "p.Glu2927Asp"),
+            (375, "Q", "PLGPAKPPAQQ", "p.Gln375Pro"),
+            (1829, "G", "GSSG", "p.Gly1829="),
+            (510, "P", "QP", "p.Pro510Gln"),
+            (510, "P", "QQP", "p.Pro510Gln"),
+            (498, "Q", "QQ", "p.Gln498="),
+            (600, "D", "DNEYFYVDFREYEYD", "p.Asp600="),
+            (598, "E", "DVDFREYE", "p.Glu598Asp"),
+            (596, "E", "VPSDNEYFYVDFRE", "p.Glu596Val"),
+            (439, "I", "IKKK", "p.Ile439="),
+            (
+                1688,
+                "S",
+                "CSKDLEAFNPESKELLDLVEFTNEIQTLLGSS",
+                "p.Ser1688Cys",
+            ),
+            (188, "S", "SD", "p.Ser188="),
+        ];
+        let deletions: &[(u64, &str, &str)] = &[(157, "F", "-"), (43, "YXQ", "-")];
+
+        // Run each case twice: with no peptide, and with a peptide that really
+        // carries the stated reference residues at the stated position.
+        for &(start, ref_aas, alt_aas, prior) in insertions {
+            let pep = peptide_with(start, ref_aas, start as usize + ref_aas.len() + 64);
+            for context in [None, Some(pep.as_slice())] {
+                let out = hgvsp_inframe_indel("ENSP00000001", start, ref_aas, alt_aas, context)
+                    .expect("in-frame indel must produce a protein description");
+                let change = out.split(":p.").nth(1).unwrap();
+                // "delins" contains both "del" and "ins", so require one of the
+                // whole forms rather than a substring of another.
+                assert!(
+                    change.ends_with("del")
+                        || change.ends_with("dup")
+                        || change.contains("delins")
+                        || change.contains("ins"),
+                    "{ref_aas}/{alt_aas} at {start} (was {prior}) rendered \
+                     without an indel form: {out}"
+                );
+                assert!(!out.contains('?'), "placeholder residue in {out}");
+                assert!(!out.ends_with('='), "synonymous shape: {out} (was {prior})");
+                assert_ne!(
+                    out.split(':').nth(1).unwrap(),
+                    prior,
+                    "still emitting {prior}"
+                );
+            }
+        }
+
+        for &(start, ref_aas, alt_aas) in deletions {
+            let pep = peptide_with(start, ref_aas, start as usize + ref_aas.len() + 64);
+            for context in [None, Some(pep.as_slice())] {
+                let out = hgvsp_inframe_indel("ENSP00000001", start, ref_aas, alt_aas, context)
+                    .expect("deletion must produce a protein description");
+                assert!(out.ends_with("del"), "deletion regressed: {out}");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes the normalisation half of #81. #85 landed the routing fix while this was in flight, so this is one commit on top of it rather than the two we discussed.

`p.Arg3delinsArgArg` becomes `p.Arg3dup` — the value your #85 commit message says Ensembl VEP reports. Your two regression tests from #85 are unchanged apart from that expected string, and it was the only thing that failed when I rebased onto your tip.

## What it does

Given the reference peptide, insertions and deletions shift as far C-terminal as the HGVS 3'-rule allows, and an insertion that repeats the residues before it collapses to `dup`. `delins` is not shifted, matching VEP. Descriptions stop restating unchanged residues:

| | before | after |
|---|---|---|
| BCOR, 31 codons | `p.Ser1688delins…` (~105 chars) | `p.Cys1709_Ser1739dup` |
| FLT3 ITD, 14 codons | `p.Asp600delins…` (~55) | `p.Asn587_Asp600dup` |
| C8A | `p.Trp185delinsTrpArg` | `p.Arg186dup` |
| ITPKB | `p.Ser92delinsSerGly` | `p.Ser92_Ser93insGly` |

## 1. The 15 observed insertions, with and without peptide context

`test_hgvsp_inframe_indel_never_emits_substitution_shape` runs all fifteen twice, once with `None` and once against a peptide that genuinely carries the stated residues, plus the two deletions that already worked.

`cargo test --workspace`: 903 pass, 0 fail. `cargo fmt --check` clean. `cargo clippy --workspace --all-targets -- -D warnings` clean apart from two warnings already present on `9d4e695` (`coding.rs:141`, `sv_predictor.rs:116`), which I left alone.

## 2. Real-data run vs Ensembl VEP

All figures below come from `validation/compare_vep.py`, against `ensemblorg/ensembl-vep:release_115.1` — the image the script pins — with Ensembl 115 GFF3 + primary assembly on GRCh38.

### How I got `run_validation.sh human` to run

Worth confirming this is what you would have done, since the numbers depend on it. `run_human` annotates the two fixtures with fastVEP and then stops at `Skipping VEP for now`, so I made three local changes. I have deliberately **not** put them in this PR — they are harness changes, not part of the fix, and I would rather you confirm the method than review a script alongside a nomenclature change. Happy to send them separately.

**a. Built a sorted, bgzipped, tabix-indexed GFF3.** VEP reads a GFF3 through tabix and will not take the plain file:

```
grep -v '^#' Homo_sapiens.GRCh38.115.gff3 \
  | sort -k1,1 -k4,4n -k5,5n -t$'\t' \
  | bgzip -@ 4 -c > Homo_sapiens.GRCh38.115.sorted.gff3.gz
tabix -p gff Homo_sapiens.GRCh38.115.sorted.gff3.gz
```

Run inside the VEP image, which ships `bgzip` and `tabix`, so no htslib is needed on the host. It emits many `WARNING: Parent entries with the following IDs were not found or skipped due to invalid types`, which I read as benign given the field results — say if that is not a safe assumption.

**b. Dropped `--offline` from `run_vep_docker`.** It implies `--cache`, and VEP aborts with `ERROR: Cache directory /opt/vep/.vep/homo_sapiens not found` before annotating anything. `--gff` plus `--fasta` is already a self-contained offline source. The mouse path shares this helper and would hit the same error if its sorted GFF3 were present.

**c. Left fastVEP on the plain `.gff3`.** I first pointed both tools at the same `sorted.gff3.gz` so the `SOURCE` field — which carries the annotation filename, and otherwise mismatches on every row — would agree. fastVEP reads the bgzipped file, but loads **498,386 transcripts from it against 508,530 from the plain GFF3** (231,621 vs 234,024 coding), presumably because the sort strips the header pragmas and puts children before parents. Annotating from a 2% smaller transcript set to tidy up one cosmetic field is the wrong trade, so fastVEP reads the plain file and `SOURCE` reports 0%. Flagging it in case you would rather the harness did something else.

No fastVEP changes were needed, and the FASTA needs no preparation — VEP writes the `.fai` itself.

### The human fixtures

| set | variants | (allele, tx) rows | HGVSp before | HGVSp after |
|---|---|---|---|---|
| `vep_example_GRCh38.vcf` | 173 | 2,920 | 100.00% | 100.00% |
| `chr22_1kgp.vcf` | 1,000 | 2,616 | 100.00% | 100.00% |

Every other compared field is 100% on both, before and after, except two that predate this PR and are identical in both runs: `TSL` (56.03% and 54.66%), where VEP leaves the field empty in GFF3 mode and fastVEP emits a value, and `SOURCE` per (c). fastVEP's annotated output is byte-identical before and after on both files.

That is regression evidence and nothing more: **neither fixture contains a single in-frame indel.** Grepping the annotated output for `inframe_insertion|inframe_deletion` returns nothing in either, so the human set cannot exercise this change. Run on its own it shows four identical numbers and no signal.

### A public in-frame-indel set

So for generalisation I added 3,120 ClinVar GRCh38 in-frame indels — every 10th of the 31,200 records whose `MC` is an in-frame consequence - annotated and compared the same way. 65,318 (allele, transcript) rows shared with VEP:

| field | before | after |
|---|---|---|
| **HGVSp** | 33,486 match / 31,832 mismatch - **51.27%** | 54,455 match / 10,863 mismatch - **83.37%** |
| Consequence | 96.20% | 96.20% |
| IMPACT | 98.82% | 98.82% |
| Protein_position | 99.53% | 99.53% |
| Amino_acids | 91.53% | 91.53% |
| Codons | 66.53% | 66.53% |

HGVSp mismatches drop by 20,969, a 66% reduction, and **every other field is unchanged to the row**. The non-HGVSp gaps are pre-existing fastVEP-vs-VEP differences on in-frame indels, untouched here.

Restricted to rows where either tool emitted an HGVSp at all (`compare_vep.py` scores a both-empty row as a match, and 27,799 rows are non-coding transcripts where neither tool emits one) the same data reads 15.16% → 71.05%. Same mismatch counts, smaller denominator.

## 3. ACMG concordance

Byte-identical on all three sets, checked two ways on ClinVar over 71,955 variant-by-transcript rows:

- **Structural**: comparing the two fastVEP runs to each other, every field ACMG reads is unchanged: `Consequence`, `Protein_position`, `Amino_acids`, `Codons` and `IMPACT` differ in **0 of 71,955** rows, while `HGVSp` differs in **28,461**, so the comparison is not vacuous.
- **Empirical**: all 71,955 ACMG calls and criteria sets are identical. `PM4`, the protein-length-changing criterion and the one most exposed to this change, fires 37,124 times in both runs.

On both human fixtures the `--acmg` output files are byte-identical before and after.

Normalisation stayed inside the HGVSp layer as you asked; nothing reads or writes `protein_start`/`amino_acids` on the way in.

## One thing I hit that I think belongs at the call site

You asked to be told rather than have it surface in review, so: **`protein_start` does not consistently mean the start of `ref_aas`.**

Over the 37,122 in-frame rows in that run, `ref_aas` sits in the peptide at `protein_start` in 71.1% of rows, at `protein_start - 1` in 11.9%, and at neither in 17.0%. The 11.9% is almost entirely shrinking changes. Real example: `Protein_position` 328-329 with `Amino_acids` `FF/F` arrives here as `protein_start = 329`, one past the F pair. I translated ENST00000892995 from the GFF3 independently to confirm — residues 328-329 are `FF`, and 330 is `A`.

This predates the PR: `hgvsp_inframe_deletion` rendered that case `p.Phe329_Phe330delinsPhe`, which also names 330 as Phe. But trimming the shared F from an already-off anchor advances it again and emits the more confident-looking `p.Phe330del`. So normalisation now runs **only once the peptide corroborates that the caller's residues sit at `protein_start`**; an uncorroborated anchor takes the un-normalised path and is byte-identical to `9d4e695`. `test_hgvsp_inframe_indel_does_not_trim_from_an_uncorroborated_anchor` covers it and fails without the guard, producing `p.Phe6del`.

I did **not** re-anchor to `protein_start - 1`, since that is the "adjust the predictor's input" move you asked me to raise first. I prototyped it (confined to this function, so it still touches nothing ACMG reads) and it takes HGVSp on that run from 83.37% to roughly 90%. It is a one-line change on top of this PR; your call whether it belongs here, at the call site where `ps` is computed, or in its own issue. Happy to do any of the three.

Worth noting the figures above are the *conservative* ones. An earlier revision that trimmed from the uncorroborated anchor scored marginally higher because 48 rows happened to land on VEP's answer from a wrong anchor. I took the lower number.

## Reviewer notes

- **Insertions immediately before the stop** fall back to `delins` rather than emitting a `Ter`-flanked range. Valid HGVS, possibly not byte-identical to VEP there. Naming a residue the protein does not have seemed the worse error.
- **The peptide is bounded at the first terminator before use.** `Transcript::peptide` runs to `cdna_coding_end` and carries the terminal `*` - your own fixtures assert `peptide == "MWK*"` - and a mis-annotated CDS can translate past an internal one. Bounded at the point of use rather than in `build_sequences`, since that peptide is shared with the frameshift path and asserted terminator-inclusive by those fixtures.
- **Every peptide-dependent step degrades rather than failing.** Absent, short, or inconsistent peptides fall back; so does an insertion at either terminus, where there is no flanking pair to name. Every index into the peptide is bounds-checked — five inputs aborted the process in an earlier revision of this work, and a truncated transcript must not kill a whole-genome run.
- **`hgvsp_inframe_deletion` is gone rather than aliased**, per your note.
- **Unrelated, but noticed while doing this:** a `.fastvep.cache` that is still being written is read back silently as a partial transcript set. I hit it by starting a second annotation immediately after a first and got 5,139 CSQ entries instead of 71,955, with no warning. Happy to file it separately.
- Reproducing the ClinVar run needs Docker, a GRCh38 GFF3 + FASTA (~4.3 GB from Ensembl FTP) and the ClinVar GRCh38 VCF. Let me know if you would like the exact commands or the subset VCF.