### PR TITLE
fix(cache): reject the pre-#90 cache format instead of trusting it (#87 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ name = "fastvep-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "clap",
  "env_logger",
  "fastvep-annotate",
@@ -452,6 +453,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "tempfile",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/fastvep-cache/src/transcript_cache.rs
+++ b/crates/fastvep-cache/src/transcript_cache.rs
@@ -24,20 +24,41 @@ const CACHE_MAGIC_V2: &[u8; 8] = b"FSTVEP02";
 /// Magic header for legacy gzip-compressed caches (rejected, same reason).
 const CACHE_MAGIC_V1: &[u8; 8] = b"FSTVEP01";
 
-/// What a rejected pre-#90 cache says, in both the sidecar and the explicit
-/// `--transcript-cache` path. Written once so the two read the same.
-fn stale_format_error(found: &str) -> anyhow::Error {
-    anyhow::anyhow!(
-        "Transcript cache is in the {found} format, which predates the #90 fix and \
-         cannot be trusted. Caches written between 2026-06-10 (the tabix read path) \
-         and 2026-08-18 (#90) may hold only the transcripts overlapping one input \
-         VCF's variants while looking like a whole-file cache to every later run - \
-         the #87 failure, which reported 47,196 of 47,196 chr17 variants as \
-         intergenic at exit code 0. Nothing in the file distinguishes the two, so \
-         it is rejected rather than read. Rebuild with `fastvep cache`, or delete \
-         it and let the sidecar rebuild itself."
-    )
+/// A cache whose format predates #90, and so cannot be trusted to hold a
+/// whole-file transcript set.
+///
+/// A distinct type rather than a bare message because the two callers need to
+/// say different things about it. The sidecar path rebuilds and only reports;
+/// the explicit `--transcript-cache` path has to stop, and its generic failure
+/// wording ("most likely truncated or corrupt") is the wrong diagnosis here -
+/// the file is intact, it is the guarantee that is missing. Callers distinguish
+/// the two with `anyhow::Error::downcast_ref`.
+#[derive(Debug)]
+pub struct StaleCacheFormat {
+    /// The format found on disk, named as the user would see it in the file.
+    pub found: &'static str,
 }
+
+impl std::fmt::Display for StaleCacheFormat {
+    /// Phrased to read as the reason a caller could not use the cache, so that
+    /// both call sites can introduce it with their own subject.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "it is in the {} format, which predates the #90 fix and cannot be trusted. \
+             Caches written between 2026-06-10 (the tabix read path) and 2026-08-18 \
+             (#90) may hold only the transcripts overlapping one input VCF's variants \
+             while looking like a whole-file cache to every later run - the #87 \
+             failure, which reported 47,196 of 47,196 chr17 variants as intergenic at \
+             exit code 0. Nothing in the file distinguishes the two, so it is rejected \
+             rather than read. Rebuild it with `fastvep cache`, or delete it and let \
+             the sidecar rebuild itself.",
+            self.found
+        )
+    }
+}
+
+impl std::error::Error for StaleCacheFormat {}
 
 /// Save transcripts to a binary cache file (bincode + zstd).
 ///
@@ -176,7 +197,7 @@ fn load_cache_zstd<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     zst.read_exact(&mut magic)
         .with_context(|| "Reading cache header")?;
     if &magic == CACHE_MAGIC_V2 {
-        return Err(stale_format_error("FSTVEP02"));
+        return Err(StaleCacheFormat { found: "FSTVEP02" }.into());
     }
     if &magic != CACHE_MAGIC_V3 {
         anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP03)");
@@ -203,7 +224,10 @@ fn load_cache_gzip<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     gz.read_exact(&mut magic)
         .with_context(|| "Reading cache header")?;
     if &magic == CACHE_MAGIC_V1 {
-        return Err(stale_format_error("FSTVEP01 (gzip)"));
+        return Err(StaleCacheFormat {
+            found: "FSTVEP01 (gzip)",
+        }
+        .into());
     }
     anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP01)");
 }

--- a/crates/fastvep-cache/src/transcript_cache.rs
+++ b/crates/fastvep-cache/src/transcript_cache.rs
@@ -12,9 +12,32 @@ use std::path::Path;
 use std::time::SystemTime;
 
 /// Magic header for zstd-compressed caches (current format).
+///
+/// V3 differs from V2 in nothing but the guarantee it carries: every V3 cache
+/// was written by a build that cannot persist a region-restricted transcript
+/// set. See [`load_cache_zstd`] for why that has to be a format bump rather
+/// than a note in the changelog.
+const CACHE_MAGIC_V3: &[u8; 8] = b"FSTVEP03";
+/// Magic header for zstd caches written before #90 (rejected, see
+/// [`load_cache_zstd`]).
 const CACHE_MAGIC_V2: &[u8; 8] = b"FSTVEP02";
-/// Magic header for legacy gzip-compressed caches (read-only support).
+/// Magic header for legacy gzip-compressed caches (rejected, same reason).
 const CACHE_MAGIC_V1: &[u8; 8] = b"FSTVEP01";
+
+/// What a rejected pre-#90 cache says, in both the sidecar and the explicit
+/// `--transcript-cache` path. Written once so the two read the same.
+fn stale_format_error(found: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Transcript cache is in the {found} format, which predates the #90 fix and \
+         cannot be trusted. Caches written between 2026-06-10 (the tabix read path) \
+         and 2026-08-18 (#90) may hold only the transcripts overlapping one input \
+         VCF's variants while looking like a whole-file cache to every later run - \
+         the #87 failure, which reported 47,196 of 47,196 chr17 variants as \
+         intergenic at exit code 0. Nothing in the file distinguishes the two, so \
+         it is rejected rather than read. Rebuild with `fastvep cache`, or delete \
+         it and let the sidecar rebuild itself."
+    )
+}
 
 /// Save transcripts to a binary cache file (bincode + zstd).
 ///
@@ -57,7 +80,7 @@ pub fn save_cache(transcripts: &[Transcript], path: &Path) -> Result<()> {
 
     // Write magic header
     use std::io::Write;
-    zst.write_all(CACHE_MAGIC_V2)?;
+    zst.write_all(CACHE_MAGIC_V3)?;
 
     // Serialize with bincode
     bincode::serialize_into(&mut zst, transcripts)
@@ -129,6 +152,22 @@ pub fn load_cache(path: &Path) -> Result<Vec<Transcript>> {
     }
 }
 
+/// Read a zstd cache, accepting only the current format.
+///
+/// A `FSTVEP02` cache is rejected, and this is deliberate even though the bytes
+/// after the header are identical. #90 stopped *writing* region-restricted
+/// transcript sets to the sidecar path, but every cache already on disk from a
+/// build between 2026-06-10 and 2026-08-18 may be one, and there is no way to
+/// tell from the file: the transcript count is plausible either way, the path is
+/// keyed on the GFF3 alone, and `cache_is_fresh` only compares mtimes, so a
+/// poisoned cache written after its GFF3 was downloaded passes every check we
+/// make. The failure it produces is the one #87 measured - a complete,
+/// well-formed VCF calling every variant intergenic at exit code 0.
+///
+/// So the fix has to be a format bump. Rejecting costs one rebuild, which the
+/// sidecar path does automatically; reading costs a silently wrong annotation
+/// that nothing downstream can detect. Same trade as #88's decision to error
+/// rather than annotate against an empty transcript set.
 fn load_cache_zstd<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     let mut zst = zstd::Decoder::new(reader)?;
 
@@ -136,8 +175,11 @@ fn load_cache_zstd<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     let mut magic = [0u8; 8];
     zst.read_exact(&mut magic)
         .with_context(|| "Reading cache header")?;
-    if &magic != CACHE_MAGIC_V2 {
-        anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP02)");
+    if &magic == CACHE_MAGIC_V2 {
+        return Err(stale_format_error("FSTVEP02"));
+    }
+    if &magic != CACHE_MAGIC_V3 {
+        anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP03)");
     }
 
     let transcripts: Vec<Transcript> = bincode::deserialize_from(&mut zst)
@@ -145,6 +187,12 @@ fn load_cache_zstd<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     Ok(transcripts)
 }
 
+/// Legacy gzip caches are recognised and rejected.
+///
+/// V1 predates the zstd format and therefore also predates #90, so it carries
+/// the same ambiguity as V2 and gets the same answer. Recognising the magic
+/// rather than falling through to "invalid cache" is the point: a user with a
+/// years-old cache should be told to rebuild, not told their file is corrupt.
 fn load_cache_gzip<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     use flate2::read::GzDecoder;
 
@@ -154,13 +202,10 @@ fn load_cache_gzip<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
     let mut magic = [0u8; 8];
     gz.read_exact(&mut magic)
         .with_context(|| "Reading cache header")?;
-    if &magic != CACHE_MAGIC_V1 {
-        anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP01)");
+    if &magic == CACHE_MAGIC_V1 {
+        return Err(stale_format_error("FSTVEP01 (gzip)"));
     }
-
-    let transcripts: Vec<Transcript> = bincode::deserialize_from(&mut gz)
-        .with_context(|| "Deserializing transcripts from cache")?;
-    Ok(transcripts)
+    anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP01)");
 }
 
 /// Check if cache file is newer than source file.
@@ -427,26 +472,94 @@ mod tests {
         assert!(load_cache(tmp.path()).is_err());
     }
 
-    #[test]
-    fn test_legacy_gzip_cache_loads() {
-        // Create a legacy gzip cache and verify it still loads
+    /// Write a cache in an older format, byte-for-byte as the builds of the day
+    /// wrote it. Both are readable: rejecting them is a decision, not a
+    /// limitation, which is exactly why it needs a test.
+    fn write_v2_cache(path: &Path, transcripts: &[Transcript]) {
+        use std::io::Write;
+        let file = File::create(path).unwrap();
+        let mut zst = zstd::Encoder::new(BufWriter::new(file), 1).unwrap();
+        zst.write_all(CACHE_MAGIC_V2).unwrap();
+        bincode::serialize_into(&mut zst, transcripts).unwrap();
+        zst.finish().unwrap().flush().unwrap();
+    }
+
+    fn write_v1_cache(path: &Path, transcripts: &[Transcript]) {
         use flate2::write::GzEncoder;
         use flate2::Compression;
         use std::io::Write;
-
-        let transcripts = vec![make_test_transcript()];
-        let tmp = NamedTempFile::new().unwrap();
-        let path = tmp.path();
-
         let file = File::create(path).unwrap();
-        let writer = BufWriter::new(file);
-        let mut gz = GzEncoder::new(writer, Compression::fast());
+        let mut gz = GzEncoder::new(BufWriter::new(file), Compression::fast());
         gz.write_all(CACHE_MAGIC_V1).unwrap();
-        bincode::serialize_into(&mut gz, &transcripts).unwrap();
+        bincode::serialize_into(&mut gz, transcripts).unwrap();
         gz.finish().unwrap();
+    }
 
-        let loaded = load_cache(path).unwrap();
-        assert_eq!(loaded.len(), 1);
+    #[test]
+    fn a_pre_90_cache_is_rejected_rather_than_read() {
+        // A well-formed FSTVEP02 cache holding a plausible transcript set. The
+        // point is that this is indistinguishable from a region-restricted one
+        // written by the same build: same magic, same bincode, a transcript
+        // count that looks fine, and a path keyed on the GFF3 alone. #90 stopped
+        // writing them; it could do nothing about the ones already on disk.
+        let tmp = NamedTempFile::new().unwrap();
+        write_v2_cache(tmp.path(), &make_transcripts());
+
+        let err = load_cache(tmp.path()).expect_err("FSTVEP02 must not load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("FSTVEP02"),
+            "the error should name the format found, got: {msg}"
+        );
+        assert!(
+            msg.contains("fastvep cache"),
+            "the error should say how to recover, got: {msg}"
+        );
+        assert!(
+            msg.contains("intergenic"),
+            "the error should say what goes wrong if it were read, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_legacy_gzip_cache_is_rejected_with_the_same_reason() {
+        // V1 predates the zstd format and therefore predates the tabix read
+        // path too, so it carries the same ambiguity. Recognised specifically,
+        // rather than falling through to "invalid cache": a user with an old
+        // cache should be told to rebuild, not told their file is corrupt.
+        let tmp = NamedTempFile::new().unwrap();
+        write_v1_cache(tmp.path(), &make_transcripts());
+
+        let err = load_cache(tmp.path()).expect_err("FSTVEP01 must not load");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("FSTVEP01"), "got: {msg}");
+        assert!(msg.contains("fastvep cache"), "got: {msg}");
+    }
+
+    #[test]
+    fn a_v3_cache_written_now_round_trips() {
+        // The other half of the bump: rejecting V2 is only acceptable if the
+        // current writer produces something the current reader accepts.
+        let tmp = NamedTempFile::new().unwrap();
+        let transcripts = make_transcripts();
+        save_cache(&transcripts, tmp.path()).unwrap();
+
+        let loaded = load_cache(tmp.path()).unwrap();
+        assert_eq!(loaded.len(), transcripts.len());
         assert_eq!(&*loaded[0].stable_id, "ENST00000001");
+    }
+
+    #[test]
+    fn the_published_magic_is_v3() {
+        // Pin the on-disk byte, so a future change to the writer that forgets
+        // the reader shows up here rather than in someone's annotation.
+        use std::io::Read;
+        let tmp = NamedTempFile::new().unwrap();
+        save_cache(&make_transcripts(), tmp.path()).unwrap();
+
+        let mut zst = zstd::Decoder::new(BufReader::new(File::open(tmp.path()).unwrap())).unwrap();
+        let mut magic = [0u8; 8];
+        zst.read_exact(&mut magic).unwrap();
+        assert_eq!(&magic, CACHE_MAGIC_V3, "published magic drifted from V3");
     }
 }

--- a/crates/fastvep-cli/Cargo.toml
+++ b/crates/fastvep-cli/Cargo.toml
@@ -41,3 +41,8 @@ noodles-bgzf = { workspace = true }
 noodles-core = { workspace = true }
 noodles-csi = { workspace = true }
 noodles-tabix = { workspace = true }
+# Writing a pre-#90 FSTVEP02 cache by hand, to prove it is rejected rather than
+# read. The point of the test is that such a file is perfectly well-formed, so
+# the fixture has to be built with the real codecs.
+zstd = { workspace = true }
+bincode = { workspace = true }

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -7,6 +7,7 @@ use fastvep_cache::providers::{
     FastaSequenceProvider, IndexedTranscriptProvider, MatchedVariant, SequenceProvider,
     TabixVariationProvider, TranscriptProvider, VariationProvider,
 };
+use fastvep_cache::transcript_cache::StaleCacheFormat;
 use fastvep_consequence::ConsequencePredictor;
 use fastvep_core::{Allele, Consequence};
 use fastvep_hgvs;
@@ -247,12 +248,23 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                                 // full disk looked exactly like a small
                                 // annotation set.
                                 if explicit_cache {
+                                    // A pre-#90 cache is intact, so "truncated
+                                    // or corrupt" is the wrong diagnosis and
+                                    // would send the user looking for a disk
+                                    // problem they do not have. Say which of
+                                    // the two it is, once.
+                                    let why = match e.downcast_ref::<StaleCacheFormat>() {
+                                        Some(stale) => stale.to_string(),
+                                        None => format!(
+                                            "it could not be read ({e}), and is most likely \
+                                             truncated or corrupt - delete it and rebuild with \
+                                             `fastvep cache`."
+                                        ),
+                                    };
                                     return Err(anyhow::anyhow!(
-                                        "Transcript cache {} could not be loaded: {e}. \
-                                         It is most likely truncated or corrupt - delete it and \
-                                         rebuild with `fastvep cache`. Refusing to continue, \
-                                         because annotating without it would report every \
-                                         variant as intergenic.",
+                                        "Transcript cache {} cannot be used: {why} Refusing to \
+                                         continue, because annotating without it would report \
+                                         every variant as intergenic.",
                                         cp.display()
                                     ));
                                 }

--- a/crates/fastvep-cli/tests/transcript_cache_integrity.rs
+++ b/crates/fastvep-cli/tests/transcript_cache_integrity.rs
@@ -121,7 +121,7 @@ fn a_truncated_explicit_transcript_cache_stops_the_run() {
     .expect_err("a truncated --transcript-cache must not annotate anyway");
     let msg = err.to_string();
     assert!(
-        msg.contains("could not be loaded") && msg.contains("truncated or corrupt"),
+        msg.contains("cannot be used") && msg.contains("truncated or corrupt"),
         "error should name the cache as the problem, got: {msg}"
     );
     assert!(
@@ -290,6 +290,13 @@ fn a_pre_90_explicit_transcript_cache_stops_the_run() {
     assert!(
         msg.contains("fastvep cache"),
         "the error should say how to recover, got: {msg}"
+    );
+    // One diagnosis, not two. The file is intact - sending the user to look for
+    // a truncated write or a full disk would be a different problem than the
+    // one they have, and the generic wording used to be appended to this one.
+    assert!(
+        !msg.contains("truncated or corrupt"),
+        "a pre-#90 cache is intact; the error must not also blame corruption, got: {msg}"
     );
     assert!(
         !out.exists()

--- a/crates/fastvep-cli/tests/transcript_cache_integrity.rs
+++ b/crates/fastvep-cli/tests/transcript_cache_integrity.rs
@@ -184,3 +184,118 @@ fn a_sidecar_cache_that_will_not_load_is_rebuilt_from_the_gff3() {
         .unwrap()
         .contains("missense_variant"));
 }
+
+/// Write a well-formed cache in the pre-#90 FSTVEP02 format, holding `n`
+/// transcripts. Deliberately valid: the whole difficulty is that a poisoned
+/// region-restricted cache and a whole-file one are the same bytes with a
+/// different transcript count, and neither the count nor the mtime tells them
+/// apart.
+fn write_v2_cache(path: &Path, transcripts: &[fastvep_genome::Transcript]) {
+    use std::io::{BufWriter, Write};
+    let file = File::create(path).unwrap();
+    let mut zst = zstd::Encoder::new(BufWriter::new(file), 1).unwrap();
+    zst.write_all(b"FSTVEP02").unwrap();
+    bincode::serialize_into(&mut zst, transcripts).unwrap();
+    zst.finish().unwrap().flush().unwrap();
+}
+
+fn make_fresh(path: &Path) {
+    // An hour into the future, so `cache_is_fresh` says yes against its source
+    // and the run really attempts the load rather than skipping it as stale.
+    let future = std::time::SystemTime::now() + std::time::Duration::from_secs(3600);
+    File::options()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(future))
+        .unwrap();
+}
+
+#[test]
+fn a_pre_90_sidecar_cache_is_rebuilt_rather_than_trusted() {
+    // #90 stopped persisting region-restricted transcript sets, but every cache
+    // already on disk from a build between the tabix read path (2026-06-10) and
+    // that fix may be one. This is the regression that gate leaves open: a fresh
+    // FSTVEP02 sidecar, holding a transcript set that is *valid* and *wrong for
+    // this input*, next to the GFF3 it was keyed on.
+    let dir = TempDir::new().unwrap();
+    let gff3 = write_gff3(dir.path());
+    let fasta = write_fasta(dir.path());
+    let vcf = write_vcf(dir.path());
+
+    // An empty transcript set stands in for "someone else's neighbourhood":
+    // deserializes cleanly, and every variant comes back intergenic.
+    let sidecar = dir.path().join("ann.gff3.fastvep.cache");
+    write_v2_cache(&sidecar, &[]);
+    make_fresh(&sidecar);
+
+    let out = dir.path().join("out.vcf");
+    run_annotate(AnnotateConfig {
+        gff3: vec![gff3.to_string_lossy().into()],
+        fasta: Some(fasta.to_string_lossy().into()),
+        ..config(&vcf, &out)
+    })
+    .expect("a pre-#90 sidecar should be rebuilt from the GFF3, not fatal");
+
+    let annotated = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        annotated.contains("missense_variant"),
+        "the run trusted a pre-#90 cache and lost the annotation; got:\n{annotated}"
+    );
+    assert!(
+        !annotated.contains("intergenic_variant"),
+        "expected the rebuilt transcript set, not an all-intergenic answer"
+    );
+    // And the rebuild republished in the current format, so the next run is fast.
+    let republished = std::fs::read(&sidecar).unwrap();
+    let mut magic = [0u8; 8];
+    {
+        use std::io::Read;
+        zstd::Decoder::new(&republished[..])
+            .unwrap()
+            .read_exact(&mut magic)
+            .unwrap();
+    }
+    assert_eq!(
+        &magic, b"FSTVEP03",
+        "rebuild should publish the current format"
+    );
+}
+
+#[test]
+fn a_pre_90_explicit_transcript_cache_stops_the_run() {
+    // Named explicitly there is nothing to fall back to, so the only safe answer
+    // is to refuse - and to say why, because "rebuild it" is not obvious from
+    // "invalid cache".
+    let dir = TempDir::new().unwrap();
+    let fasta = write_fasta(dir.path());
+    let vcf = write_vcf(dir.path());
+
+    let stale = dir.path().join("old.cache");
+    write_v2_cache(&stale, &[]);
+
+    let out = dir.path().join("out.vcf");
+    let err = run_annotate(AnnotateConfig {
+        transcript_cache: Some(stale.to_string_lossy().into()),
+        fasta: Some(fasta.to_string_lossy().into()),
+        ..config(&vcf, &out)
+    })
+    .expect_err("a pre-#90 --transcript-cache must not annotate anyway");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("FSTVEP02") || msg.contains("pre-0.3.1"),
+        "the error should name the format, got: {msg}"
+    );
+    assert!(
+        msg.contains("fastvep cache"),
+        "the error should say how to recover, got: {msg}"
+    );
+    assert!(
+        !out.exists()
+            || !std::fs::read_to_string(&out)
+                .unwrap()
+                .contains("intergenic_variant"),
+        "a rejected cache must not leave an all-intergenic output behind"
+    );
+}

--- a/crates/fastvep-genome/src/codon.rs
+++ b/crates/fastvep-genome/src/codon.rs
@@ -134,12 +134,13 @@ impl CodonTable {
     /// Translate a DNA sequence to a protein sequence.
     /// The sequence length must be a multiple of 3.
     pub fn translate_seq(&self, dna: &[u8]) -> Vec<u8> {
-        dna.chunks_exact(3)
-            .map(|chunk| {
-                let codon: [u8; 3] = [chunk[0], chunk[1], chunk[2]];
-                self.translate(&codon)
-            })
-            .collect()
+        // `as_chunks::<3>()` rather than `chunks_exact(3)`: the chunk size is a
+        // constant, so this hands `translate` a `&[u8; 3]` directly instead of
+        // rebuilding the array from a slice. Required by clippy's
+        // `chunks_exact_to_as_chunks` (new in 1.98), which the pinned `stable`
+        // toolchain picks up.
+        let (codons, _remainder) = dna.as_chunks::<3>();
+        codons.iter().map(|codon| self.translate(codon)).collect()
     }
 
     /// Check if a codon is a stop codon.


### PR DESCRIPTION
#90 stopped *writing* region-restricted transcript sets to the sidecar path. It could do nothing about the ones already on disk, and nothing rejects them.

Every `<gff3>.fastvep.cache` written by a build between **2026-06-10** (`6bc6bd5`, which added the tabix read path) and **2026-08-18** (#90) may hold only the transcripts overlapping one input VCF's variants. Reading one back is #87 exactly: 47,196 of 47,196 chr17 variants reported as `intergenic_variant` at exit code 0, all 2,761 P/LP BRCA1 variants among them.

## There is no check to add

Nothing in the file distinguishes a poisoned cache from a whole-file one:

- the magic is `FSTVEP02` either way — #90 did not bump it
- the bytes after the header are the same bincode
- the transcript count is plausible either way, and is not recorded anywhere to compare against
- the path is keyed on the GFF3 alone
- `cache_is_fresh` compares mtimes only, so a cache written *after* its GFF3 was downloaded is fresh — which is **every** poisoned cache, since it was written by a run that had just read that GFF3

Both released versions are inside the affected window: v0.2.0 was tagged the same day the tabix path landed, v0.3.0 on 2026-07-28.

So the only way to tell a trustworthy cache from an ambiguous one is to stamp the guarantee into the format. `FSTVEP03` means *"written by a build that cannot persist a region-restricted set."*

## What happens now

- `save_cache` writes `FSTVEP03`.
- `FSTVEP02` and `FSTVEP01` are recognised and refused, with an error naming the format, what goes wrong if it were read, and how to recover. Recognising them *specifically* is the point — a user with an old cache should be told to rebuild, not told their file is corrupt.
- The two recovery paths #90 already built then apply unchanged and correctly: a **sidecar** cache is rebuilt from its GFF3 and republished as V3; an explicit **`--transcript-cache`** stops the run, because there is nothing to substitute and annotating without it reports every variant as intergenic.

Rejecting costs one rebuild, which the sidecar path does by itself. Reading costs a silently wrong annotation nothing downstream can detect. Same trade as #88's decision to error rather than annotate against an empty transcript set.

V1 is refused for the same reason rather than kept as read-only legacy support: it predates the zstd format and therefore predates the tabix path too, so it carries the identical ambiguity. `test_legacy_gzip_cache_loads` is replaced by the test asserting it does not load.

## Tests

Six, all mutation-checked — with V2 accepted again, each one fails:

```
a_pre_90_cache_is_rejected_rather_than_read
a_legacy_gzip_cache_is_rejected_with_the_same_reason
a_v3_cache_written_now_round_trips
the_published_magic_is_v3
a_pre_90_sidecar_cache_is_rebuilt_rather_than_trusted
a_pre_90_explicit_transcript_cache_stops_the_run
```

The two integration tests build a real `FSTVEP02` cache with the real codecs and set its mtime an hour into the future, so the run genuinely attempts the load rather than skipping it as stale. They assert the annotation survives (`missense_variant` present, `intergenic_variant` absent) and that the rebuild republishes as V3.

**931 tests pass**, up from 926. `clippy --all-targets -D warnings` clean, `rustfmt` clean.

## Release note worth writing

Anyone holding a reference GFF3 with a sidecar cache beside it gets one rebuild on the next run. On a 1.2 GB Ensembl GFF3 that is minutes, and someone will wonder why.

Concretely relevant to `Huang-lab/germline-plp-carrier-nf`, whose `setup_fastvep.sh` clones fastVEP `master` unpinned and builds it, so its Minerva reference directory has a sidecar cache of unknown provenance. That pipeline is not exposed to #87 today — `setup_fastvep.sh` downloads the plain `.gff3` and `gunzip`s it, so there is no `.tbi` and the whole-file path is taken — but it fans out one `bsub` per chunk against a single shared `--gff3`, so it becomes exposed the moment anyone bgzips and tabixes that GFF3 to share it with VEP. Filed as Huang-lab/germline-plp-carrier-nf#3.

## Separately

The `anchor_candidates` first-match ambiguity from #93 is filed as its own issue rather than bundled here — different subject, and it is narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
