### PR TITLE
fix(hgvs): order the anchor candidates by strand, so a periodic reference resolves to the span the variant touches (#96)

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -622,12 +622,19 @@ impl AnnotationContext {
                                                 // repeat to `dup`, matching Ensembl VEP; it
                                                 // degrades to the unshifted description
                                                 // without one.
+                                                // `tr.strand` says which end
+                                                // of `aa.0` the `ps` above
+                                                // names: on the reverse strand a
+                                                // shrinking change arrives
+                                                // anchored at the end of its
+                                                // span (#89, #96).
                                                 ann.hgvsp = fastvep_hgvs::hgvsp_inframe_indel(
                                                     &versioned_pid,
                                                     ps,
                                                     &aa.0,
                                                     &aa.1,
                                                     tr.peptide.as_deref().map(str::as_bytes),
+                                                    tr.strand,
                                                 );
                                             } else {
                                                 let ref_aa_byte = aa
@@ -2080,6 +2087,78 @@ mod tests {
             "shrinking reverse-strand change should name the residues it deletes: {tc:?}"
         );
         assert_hgvsp_agrees_with_peptide(tc["hgvsp"].as_str().unwrap(), "MWFFK*");
+    }
+
+    #[test]
+    fn hgvsp_reads_a_periodic_reference_from_the_end_the_strand_determines() {
+        // The residue #93 left behind, filed as #96. Trying the other end of the
+        // span rescued the cases where the first end is not a match at all; where
+        // the reference is periodic *both* ends match, and taking whichever came
+        // first took the wrong one. The strand says which end applies, so it now
+        // decides instead of the iteration order.
+        //
+        // CDS ATG GAA GGT GAA GGT GAA GCT TAA = M E G E G E A * at genomic 51-74,
+        // so CDS base i sits at genomic 75 - i. `EGE` therefore sits at residues
+        // 2-4 and again at 4-6. Deleting CDS 4-12 (genomic 63-71) removes
+        // residues 2-4 and the anchor arrives as residue 4, the end of the range.
+        use fastvep_core::Strand;
+        let tr = cds_transcript(Strand::Reverse, "ATGGAAGGTGAAGGTGAAGCTTAA");
+        assert_eq!(
+            tr.peptide.as_deref(),
+            Some("MEGEGEA*"),
+            "test transcript premise"
+        );
+
+        let tc = annotate_one(tr, 62, "CTTCACCTTC", "C");
+        assert!(
+            tc["consequence_terms"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|t| t.as_str() == Some("inframe_deletion")),
+            "premise: should be an in-frame deletion, got {:?}",
+            tc["consequence_terms"]
+        );
+        assert_eq!(tc["amino_acids"], serde_json::json!("EGE/-"));
+        assert_eq!(tc["protein_start"], serde_json::json!(2));
+        assert_eq!(tc["protein_end"], serde_json::json!(4));
+
+        // Before the fix: `p.Glu4_Glu6del`. Both descriptions are well-formed and
+        // name real Glu residues, which is what makes this one dangerous - only
+        // one of them describes this variant. Deleting 2-4 leaves MGEA; deleting
+        // 4-6 leaves MEGA, so no later 3'-shift can reconcile them.
+        assert_eq!(
+            tc["hgvsp"],
+            serde_json::json!("ENSP_ANCHOR:p.Glu2_Glu4del"),
+            "periodic reference resolved to the wrong end of the span: {tc:?}"
+        );
+        assert_hgvsp_agrees_with_peptide(tc["hgvsp"].as_str().unwrap(), "MEGEGEA*");
+    }
+
+    #[test]
+    fn hgvsp_reads_the_same_periodic_reference_from_the_start_on_the_forward_strand() {
+        // The mirror: same peptide, same deleted residues, transcript running the
+        // other way. Here `protein_start` already *is* the first affected residue,
+        // so ordering the candidates by strand has to leave this untouched -
+        // otherwise the fix for #96 would trade one wrong end for the other.
+        //
+        // Genomic 54-62 is CDS 4-12 on this strand, anchored at 53.
+        use fastvep_core::Strand;
+        let tr = cds_transcript(Strand::Forward, "ATGGAAGGTGAAGGTGAAGCTTAA");
+        assert_eq!(
+            tr.peptide.as_deref(),
+            Some("MEGEGEA*"),
+            "test transcript premise"
+        );
+
+        let tc = annotate_one(tr, 53, "GGAAGGTGAA", "G");
+        assert_eq!(tc["amino_acids"], serde_json::json!("EGE/-"));
+        assert_eq!(
+            tc["hgvsp"],
+            serde_json::json!("ENSP_ANCHOR:p.Glu2_Glu4del"),
+            "forward-strand reading changed: {tc:?}"
+        );
+        assert_hgvsp_agrees_with_peptide(tc["hgvsp"].as_str().unwrap(), "MEGEGEA*");
     }
 
     #[test]

--- a/crates/fastvep-cli/src/pipeline.rs
+++ b/crates/fastvep-cli/src/pipeline.rs
@@ -1324,12 +1324,18 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
                                             // HGVS 3'-rule and collapse a repeat to `dup`,
                                             // matching Ensembl VEP; it degrades to the
                                             // unshifted description without one.
+                                            // `tr.strand` says which end of
+                                            // `aa.0` the `ps` above names: on
+                                            // the reverse strand a shrinking
+                                            // change arrives anchored at the
+                                            // end of its span (#89, #96).
                                             ann.hgvsp = fastvep_hgvs::hgvsp_inframe_indel(
                                                 &versioned_pid,
                                                 ps,
                                                 &aa.0,
                                                 &aa.1,
                                                 tr.peptide.as_deref().map(str::as_bytes),
+                                                tr.strand,
                                             );
                                         } else {
                                             let ref_aa_byte = aa.0.as_bytes().first().copied().unwrap_or(b'X');

--- a/crates/fastvep-cli/tests/hgvsp_reverse_strand_anchor.rs
+++ b/crates/fastvep-cli/tests/hgvsp_reverse_strand_anchor.rs
@@ -1,0 +1,160 @@
+//! End-to-end regression for issue #96: on the reverse strand the affected
+//! residue span is anchored at its *last* residue, and when the reference run is
+//! periodic the wrong end can look just as plausible as the right one.
+//!
+//! `protein_start` comes from the genomic left edge, which for a shrinking
+//! change on a right-to-left transcript is the end of the affected range. #93
+//! made `hgvsp_inframe_indel` try the other end when the peptide does not
+//! corroborate the first, which fixed the cases where the first end is not a
+//! match at all. It left the case where *both* ends match: `find()` takes the
+//! first, and on the reverse strand the first is the wrong one.
+//!
+//! The gene below is built so that both ends match. The peptide is `MEGEGEA`
+//! and the deletion removes `EGE` at residues 2-4 - a reference that also sits
+//! at 4-6. Naming 4-6 is not another spelling of the same event: deleting 2-4
+//! leaves `MGEA`, deleting 4-6 leaves `MEGA`, so the 3'-rule cannot merge them
+//! and the description names residues this variant does not touch.
+//!
+//! Driven through `run_annotate` rather than the unit under test, because the
+//! anchor convention is a property of the coordinates the pipeline hands over -
+//! a unit test that passes `protein_start` by hand would be asserting my own
+//! reading of the convention rather than the pipeline's.
+
+use fastvep_cli::pipeline::{run_annotate, AnnotateConfig};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+/// Single-exon coding transcript on contig `1`, CDS = the whole 24 bp exon.
+/// `ID=CDS:ENSP_REV1` supplies the HGVSp prefix.
+fn gff3(strand: char) -> String {
+    format!(
+        "##gff-version 3\n\
+         1\ttest\tgene\t1\t24\t.\t{strand}\t.\tID=gene:ENSG_REV1;Name=REVTEST;gene_name=REVTEST;biotype=protein_coding\n\
+         1\ttest\tmRNA\t1\t24\t.\t{strand}\t.\tID=transcript:ENST_REV1;Parent=gene:ENSG_REV1;biotype=protein_coding;tag=Ensembl_canonical\n\
+         1\ttest\texon\t1\t24\t.\t{strand}\t.\tID=exon:ENSE_REV1;Parent=transcript:ENST_REV1;rank=1\n\
+         1\ttest\tCDS\t1\t24\t.\t{strand}\t0\tID=CDS:ENSP_REV1;Parent=transcript:ENST_REV1\n"
+    )
+}
+
+// ATG GAA GGT GAA GGT GAA GCT TAA translates to Met Glu Gly Glu Gly Glu Ala Ter,
+// so `EGE` sits at residues 2-4 and again at 4-6. The reverse-strand contig
+// carries the reverse complement, so both strands describe the same protein and
+// the same variant, and the only difference is which end of the affected span
+// the pipeline hands to HGVSp.
+const CDS_FORWARD: &str = ">1\nATGGAAGGTGAAGGTGAAGCTTAA\n";
+const CDS_REVERSE: &str = ">1\nTTAAGCTTCACCTTCACCTTCCAT\n";
+
+// Delete the codons for residues 2, 3 and 4 - CDS 4-12 either way, which is
+// genomic 4-12 on the forward strand and genomic 13-21 on the reverse. Both
+// VCF-anchored on the base before the deletion, as a caller's VCF would be.
+const VCF_FORWARD: &str = "##fileformat=VCFv4.2\n\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+1\t3\t.\tGGAAGGTGAA\tG\t.\tPASS\t.\n";
+const VCF_REVERSE: &str = "##fileformat=VCFv4.2\n\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+1\t12\t.\tCTTCACCTTC\tC\t.\tPASS\t.\n";
+
+fn write(path: &Path, contents: &str) {
+    File::create(path)
+        .unwrap()
+        .write_all(contents.as_bytes())
+        .unwrap();
+}
+
+fn annotate(dir: &Path, strand: char) -> String {
+    let gff3_path = dir.join("rev.gff3");
+    let fasta = dir.join("rev.fa");
+    let vcf_in = dir.join("in.vcf");
+    let vcf_out = dir.join("out.vcf");
+    let (contig, vcf) = if strand == '-' {
+        (CDS_REVERSE, VCF_REVERSE)
+    } else {
+        (CDS_FORWARD, VCF_FORWARD)
+    };
+    write(&gff3_path, &gff3(strand));
+    write(&fasta, contig);
+    write(&vcf_in, vcf);
+
+    run_annotate(AnnotateConfig {
+        input: vcf_in.to_string_lossy().into(),
+        output: vcf_out.to_string_lossy().into(),
+        gff3: vec![gff3_path.to_string_lossy().into()],
+        fasta: Some(fasta.to_string_lossy().into()),
+        output_format: "vcf".into(),
+        pick: false,
+        hgvs: true,
+        distance: 5000,
+        cache_dir: None,
+        transcript_cache: None,
+        sa_dir: None,
+        sa_only: false,
+        acmg: false,
+        acmg_config: None,
+        pick_order: None,
+        functional_evidence: None,
+        proband: None,
+        mother: None,
+        father: None,
+        gene_list: None,
+        explicit_alleles: false,
+        qc_rules: None,
+        show_progress: false,
+    })
+    .expect("annotation should succeed");
+
+    std::fs::read_to_string(&vcf_out).unwrap()
+}
+
+#[test]
+fn cli_reverse_strand_deletion_names_the_residues_it_deletes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = annotate(tmp.path(), '-');
+
+    // Guard the premise twice over: a different consequence or a different
+    // protein position would make the HGVSp assertion pass or fail for reasons
+    // that have nothing to do with the anchor.
+    assert!(
+        out.contains("inframe_deletion"),
+        "expected an inframe_deletion consequence, got:\n{out}"
+    );
+    assert!(
+        out.contains("|2-4|"),
+        "expected Protein_position 2-4 for the deleted residues, got:\n{out}"
+    );
+
+    assert!(
+        out.contains("p.Glu2_Glu4del"),
+        "expected the deletion of residues 2-4, got:\n{out}"
+    );
+    // The specific wrong answer, spelled out: `EGE` also sits at 4-6, and
+    // taking the first corroborated anchor picks it.
+    assert!(
+        !out.contains("p.Glu4_Glu6del"),
+        "HGVSp named residues 4-6, which this variant does not touch (issue #96):\n{out}"
+    );
+}
+
+#[test]
+fn cli_forward_strand_deletion_of_the_same_residues_is_unchanged() {
+    // The mirror image, on a transcript that runs the other way. The protein,
+    // the deleted residues and the expected description are identical; only the
+    // end of the span the pipeline passes differs. Ordering the anchors by
+    // strand is only correct if it leaves this case exactly as it was, so this
+    // is the half of #96 that guards against overcorrecting.
+    let tmp = tempfile::tempdir().unwrap();
+    let out = annotate(tmp.path(), '+');
+
+    assert!(
+        out.contains("inframe_deletion"),
+        "expected an inframe_deletion consequence, got:\n{out}"
+    );
+    assert!(
+        out.contains("|2-4|"),
+        "expected Protein_position 2-4 for the deleted residues, got:\n{out}"
+    );
+    assert!(
+        out.contains("p.Glu2_Glu4del"),
+        "expected the deletion of residues 2-4, got:\n{out}"
+    );
+}

--- a/crates/fastvep-hgvs/src/protein.rs
+++ b/crates/fastvep-hgvs/src/protein.rs
@@ -1,3 +1,4 @@
+use fastvep_core::Strand;
 use fastvep_genome::codon::{aa_one_to_three, CodonTable};
 
 /// Generate HGVSp (protein) notation.
@@ -116,7 +117,25 @@ fn peptide_carries(peptide: &[u8], protein_start: u64, reference: &[u8]) -> bool
     peptide.get(lo..lo + reference.len()) == Some(reference)
 }
 
-/// The positions at which `reference` may sit, given the caller's anchor.
+/// Whether `protein_start` names the *end* of the affected span rather than its
+/// start.
+///
+/// `protein_start` is derived from the genomic left edge. On a transcript that
+/// runs left to right that edge is the first affected residue; on one that runs
+/// right to left it is the last. The residues themselves are built from the
+/// lower of the two CDS coordinates for a shrinking change and from `cds_start`
+/// otherwise (see `predict_coding_consequence`), so it is exactly the shrinking
+/// change on the reverse strand whose span arrives anchored at its end. An
+/// insertion is anchored at `protein_start` on either strand.
+///
+/// This is a property of the coordinate convention, not of the sequence, which
+/// is why it can be decided here rather than guessed from the peptide.
+fn anchored_at_span_end(strand: Strand, reference_len: usize, alternate_len: usize) -> bool {
+    strand == Strand::Reverse && alternate_len < reference_len
+}
+
+/// The positions at which `reference` may sit, given the caller's anchor, most
+/// likely first.
 ///
 /// `protein_start` is the first affected residue on the forward strand, but for
 /// a shrinking change it can be the *last*: the field is derived from the
@@ -130,22 +149,44 @@ fn peptide_carries(peptide: &[u8], protein_start: u64, reference: &[u8]) -> bool
 /// consequence of the coordinate convention. An empty or single-residue
 /// reference has one candidate, which leaves insertions - where `protein_start`
 /// is already the far end of the pair - on exactly the path they had before.
-fn anchor_candidates(protein_start: u64, reference_len: usize) -> [Option<u64>; 2] {
+///
+/// `end_first` puts them in the order [`anchored_at_span_end`] determines, which
+/// is what makes the choice between them a reading of the convention rather than
+/// a coincidence. Taking the first *corroborated* candidate is not enough on its
+/// own: where the reference is periodic with period n-1 both ends corroborate,
+/// and before #96 the wrong one won whenever it was tried first. `MEGEGEA` with
+/// `EGE` arriving at `protein_start` 4 is the smallest case - residues 2-4 and
+/// 4-6 both read `EGE`, and deleting them leaves different proteins (`MGEA` and
+/// `MEGA`), so the 3'-rule cannot reconcile the two descriptions afterwards.
+///
+/// The other end stays as a fallback rather than being dropped. The residues are
+/// not guaranteed to sit at either scalar - over 37,122 in-frame ClinVar rows
+/// they sat at `protein_start` in 71.1% of cases, one residue earlier in 11.9%,
+/// and at neither in 17.0% - so ordering is all the strand can honestly buy. The
+/// peptide still decides.
+fn anchor_candidates(
+    protein_start: u64,
+    reference_len: usize,
+    end_first: bool,
+) -> [Option<u64>; 2] {
     let from_end = reference_len
         .checked_sub(1)
         .filter(|&back| back > 0)
         .and_then(|back| protein_start.checked_sub(back as u64))
         // Residues are numbered from 1, so 0 is not a position to try.
         .filter(|&anchor| anchor > 0);
-    [Some(protein_start), from_end]
+    match from_end {
+        Some(other) if end_first => [Some(other), Some(protein_start)],
+        _ => [Some(protein_start), from_end],
+    }
 }
 
 /// Generate HGVSp notation for an in-frame indel — deletion, delins, insertion
 /// or duplication.
 ///
-/// `ref_aas` are the affected reference residues (one-letter, in order)
-/// starting at `protein_start`; `alt_aas` is the replacement ("-" or empty for
-/// a pure deletion, longer than `ref_aas` for an insertion).
+/// `ref_aas` are the affected reference residues (one-letter, in order);
+/// `alt_aas` is the replacement ("-" or empty for a pure deletion, longer than
+/// `ref_aas` for an insertion).
 ///
 ///   ENSP0:p.Phe157del            single-residue deletion
 ///   ENSP0:p.Tyr43_Gln45del       multi-residue deletion
@@ -173,6 +214,13 @@ fn anchor_candidates(protein_start: u64, reference_len: usize) -> [Option<u64>; 
 /// which is what the 3'-rule specifies and what our HGVSc for the same variant
 /// already describes. See issue #94.
 ///
+/// `strand` says which end of `ref_aas` the caller's `protein_start` names,
+/// which the coordinate convention fixes rather than leaves open: see
+/// [`anchored_at_span_end`]. Pass the strand of the transcript the residues were
+/// derived from - not the strand the caller finds convenient - because a wrong
+/// one here reorders the anchor candidates and, where the reference is periodic,
+/// selects a span the variant does not touch.
+///
 /// Every peptide-dependent step degrades to the unshifted description rather
 /// than failing: a peptide that is absent, too short, or inconsistent with
 /// `protein_start` still yields valid HGVS, just unnormalised.
@@ -182,6 +230,7 @@ pub fn hgvsp_inframe_indel(
     ref_aas: &str,
     alt_aas: &str,
     ref_peptide: Option<&[u8]>,
+    strand: Strand,
 ) -> Option<String> {
     let strip = |s: &str| -> Vec<u8> {
         if s == "-" {
@@ -217,7 +266,8 @@ pub fn hgvsp_inframe_indel(
     // the numbers contradict each other. Over 47,013 ClinVar indels that was
     // 17,654 descriptions.
     let Some((peptide, protein_start)) = ref_peptide.and_then(|p| {
-        anchor_candidates(protein_start, original_ref.len())
+        let end_first = anchored_at_span_end(strand, original_ref.len(), original_alt.len());
+        anchor_candidates(protein_start, original_ref.len(), end_first)
             .into_iter()
             .flatten()
             .find(|&anchor| peptide_carries(p, anchor, &original_ref))
@@ -521,21 +571,21 @@ mod tests {
     #[test]
     fn test_hgvsp_inframe_deletion_single() {
         // single-residue in-frame deletion
-        let r = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None);
+        let r = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None, Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Phe157del".to_string()));
     }
 
     #[test]
     fn test_hgvsp_inframe_deletion_range() {
         // multi-residue in-frame deletion (regression for the p.Tyr43??? bug)
-        let r = hgvsp_inframe_indel("ENSP00000001", 43, "YXQ", "-", None);
+        let r = hgvsp_inframe_indel("ENSP00000001", 43, "YXQ", "-", None, Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Tyr43_Gln45del".to_string()));
     }
 
     #[test]
     fn test_hgvsp_inframe_delins() {
         // in-frame deletion-insertion
-        let r = hgvsp_inframe_indel("ENSP00000001", 2173, "NL", "K", None);
+        let r = hgvsp_inframe_indel("ENSP00000001", 2173, "NL", "K", None, Strand::Forward);
         assert_eq!(
             r,
             Some("ENSP00000001:p.Asn2173_Leu2174delinsLys".to_string())
@@ -561,7 +611,7 @@ mod tests {
         // C8A c.553_554insGGA, amino_acids "W/WR" at 185 — previously p.Trp185=.
         // Residue 186 is already Arg, so inserting Arg duplicates it.
         let pep = peptide_with(185, "WRQ", 200);
-        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Arg186dup".to_string()));
     }
 
@@ -572,7 +622,7 @@ mod tests {
         let dup = "NEYFYVDFREYEYD";
         let pep = peptide_with(587, &format!("{}K", dup), 700);
         let alt = format!("D{}", dup);
-        let r = hgvsp_inframe_indel("ENSP00000001", 600, "D", &alt, Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 600, "D", &alt, Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Asn587_Asp600dup".to_string()));
     }
 
@@ -581,7 +631,7 @@ mod tests {
         // ITPKB c.275_276insGGT, amino_acids "S/SG" at 92 — previously p.Ser92=.
         // Gly does not repeat the preceding residues, so it stays an insertion.
         let pep = peptide_with(92, "SSK", 200);
-        let r = hgvsp_inframe_indel("ENSP00000001", 92, "S", "SG", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 92, "S", "SG", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Ser92_Ser93insGly".to_string()));
     }
 
@@ -590,7 +640,7 @@ mod tests {
         // A deletion inside a homopolymer run is reported at the most C-terminal
         // position it can occupy: deleting one Ala from AAA at 2..4 is p.Ala4del.
         let pep: Vec<u8> = "MAAAGK".bytes().collect();
-        let r = hgvsp_inframe_indel("ENSP00000001", 2, "A", "-", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 2, "A", "-", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Ala4del".to_string()));
     }
 
@@ -603,7 +653,7 @@ mod tests {
         // c.1674_1679del is p.Glu560_Glu561del on a 561-residue protein, which
         // VEP reports as p.Glu559_Glu560del.
         let pep: Vec<u8> = "MKEEEEE*".bytes().collect();
-        let r = hgvsp_inframe_indel("ENSP00000001", 3, "EE", "-", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 3, "EE", "-", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Glu6_Glu7del".to_string()));
     }
 
@@ -611,9 +661,9 @@ mod tests {
     fn test_hgvsp_inframe_indel_without_peptide_stays_valid() {
         // No sequence context: emit an unshifted but well-formed description
         // rather than nothing, and never a substitution shape.
-        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", None);
+        let r = hgvsp_inframe_indel("ENSP00000001", 185, "W", "WR", None, Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Trp185delinsTrpArg".to_string()));
-        let d = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None);
+        let d = hgvsp_inframe_indel("ENSP00000001", 157, "F", "-", None, Strand::Forward);
         assert_eq!(d, Some("ENSP00000001:p.Phe157del".to_string()));
     }
 
@@ -677,7 +727,14 @@ mod tests {
             ),
         ];
         for (name, start, reference, alternate, pep, expected) in cases {
-            let got = hgvsp_inframe_indel("ENSP00000001", start, reference, alternate, Some(pep));
+            let got = hgvsp_inframe_indel(
+                "ENSP00000001",
+                start,
+                reference,
+                alternate,
+                Some(pep),
+                Strand::Forward,
+            );
             assert_eq!(got.as_deref(), expected, "case: {name}");
         }
     }
@@ -691,13 +748,15 @@ mod tests {
 
         // Deleting one Lys from the KK run shifts to the 3'-most Lys (3), not
         // onto Gly4 or the terminator.
-        let deletion = hgvsp_inframe_indel("ENSP00000001", 2, "K", "-", Some(&pep));
+        let deletion =
+            hgvsp_inframe_indel("ENSP00000001", 2, "K", "-", Some(&pep), Strand::Forward);
         assert_eq!(deletion, Some("ENSP00000001:p.Lys3del".to_string()));
 
         // An insertion immediately before the terminator has no residue on its
         // 3' side once the stop is excluded, so it falls back rather than
         // emitting a Ter-flanked range.
-        let insertion = hgvsp_inframe_indel("ENSP00000001", 4, "G", "GS", Some(&pep));
+        let insertion =
+            hgvsp_inframe_indel("ENSP00000001", 4, "G", "GS", Some(&pep), Strand::Forward);
         assert_eq!(
             insertion,
             Some("ENSP00000001:p.Gly4delinsGlySer".to_string())
@@ -714,7 +773,7 @@ mod tests {
         // would emit a confident, well-formed, wrong description (p.Gln6del).
         // Fall back to the caller's residues instead.
         let pep: Vec<u8> = "MQQQQQK".bytes().collect();
-        let r = hgvsp_inframe_indel("ENSP00000001", 2, "F", "-", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 2, "F", "-", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Phe2del".to_string()));
     }
 
@@ -726,15 +785,27 @@ mod tests {
         // pair rather than its start. Both numbers name the same span, so the
         // description must not depend on which end the caller happened to send.
         //
-        // The peptide is M R I F F A S M, so the F pair is at 4-5.
+        // The peptide is M R I F F A S M, so the F pair is at 4-5. Which end
+        // the caller sends follows from the strand (#96), so the two readings
+        // are paired with the strand that produces them - but the answer has to
+        // be the same either way, which is what this test is for.
         let pep: Vec<u8> = "MRIFFASM".bytes().collect();
-        for anchor in [4u64, 5] {
+        for (anchor, strand) in [(4u64, Strand::Forward), (5, Strand::Reverse)] {
             assert_eq!(
-                hgvsp_inframe_indel("ENSP00000001", anchor, "FF", "F", Some(&pep)),
+                hgvsp_inframe_indel("ENSP00000001", anchor, "FF", "F", Some(&pep), strand),
                 Some("ENSP00000001:p.Phe5del".to_string()),
-                "anchor {anchor} should describe the same deletion"
+                "anchor {anchor} on {strand:?} should describe the same deletion"
             );
         }
+
+        // And the pairing is a preference, not a requirement: a reverse-strand
+        // caller whose residues really do sit at `protein_start` still
+        // normalises, because the other end stays as a fallback.
+        assert_eq!(
+            hgvsp_inframe_indel("ENSP00000001", 4, "FF", "F", Some(&pep), Strand::Reverse),
+            Some("ENSP00000001:p.Phe5del".to_string()),
+            "the unpreferred end must still be tried"
+        );
 
         // This case used to take the un-normalised path and emit
         // `p.Phe5_Phe6delinsPhe`, naming residue 6 as Phe when the peptide has
@@ -753,13 +824,27 @@ mod tests {
         // KCNA2 `MNII/I` at residues 1-4, and POLE `EA/A` at 1-2.
         let kcna2: Vec<u8> = "MNIIDIVAIIPY".bytes().collect();
         assert_eq!(
-            hgvsp_inframe_indel("ENSP00000491354", 1, "MNII", "I", Some(&kcna2)),
+            hgvsp_inframe_indel(
+                "ENSP00000491354",
+                1,
+                "MNII",
+                "I",
+                Some(&kcna2),
+                Strand::Forward
+            ),
             Some("ENSP00000491354:p.MetAsnIle1_?3".to_string())
         );
 
         let pole: Vec<u8> = "EAKRQ".bytes().collect();
         assert_eq!(
-            hgvsp_inframe_indel("ENSP00000500921", 1, "EA", "A", Some(&pole)),
+            hgvsp_inframe_indel(
+                "ENSP00000500921",
+                1,
+                "EA",
+                "A",
+                Some(&pole),
+                Strand::Forward
+            ),
             Some("ENSP00000500921:p.Glu1?".to_string())
         );
     }
@@ -770,13 +855,13 @@ mod tests {
         // else is an ordinary `del`, including one that starts at residue 2.
         let pep: Vec<u8> = "MKFFASM".bytes().collect();
         assert_eq!(
-            hgvsp_inframe_indel("ENSP00000001", 2, "K", "-", Some(&pep)),
+            hgvsp_inframe_indel("ENSP00000001", 2, "K", "-", Some(&pep), Strand::Forward),
             Some("ENSP00000001:p.Lys2del".to_string())
         );
 
         // And a delins at the start is still a delins - residues are replaced
         // rather than removed, so the reading frame still begins somewhere known.
-        let r = hgvsp_inframe_indel("ENSP00000001", 1, "MK", "W", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 1, "MK", "W", Some(&pep), Strand::Forward);
         assert!(
             r.as_deref().is_some_and(|d| d.contains("delins")),
             "expected a delins, got {r:?}"
@@ -790,12 +875,18 @@ mod tests {
         // neither end of the span, there is no evidence for any anchor and the
         // un-normalised description is still the honest answer.
         let pep: Vec<u8> = "MRIFFASM".bytes().collect();
-        let r = hgvsp_inframe_indel("ENSP00000001", 5, "KK", "K", Some(&pep));
-        assert_eq!(r, Some("ENSP00000001:p.Lys5_Lys6delinsLys".to_string()));
+        for strand in [Strand::Forward, Strand::Reverse] {
+            let r = hgvsp_inframe_indel("ENSP00000001", 5, "KK", "K", Some(&pep), strand);
+            assert_eq!(
+                r,
+                Some("ENSP00000001:p.Lys5_Lys6delinsLys".to_string()),
+                "on {strand:?} an uncorroborated span must stay unshifted"
+            );
+        }
 
         // A single residue has only one candidate: there is no other end to try,
         // so an uncorroborated anchor cannot be rescued and must not be guessed.
-        let r = hgvsp_inframe_indel("ENSP00000001", 2, "W", "-", Some(&pep));
+        let r = hgvsp_inframe_indel("ENSP00000001", 2, "W", "-", Some(&pep), Strand::Forward);
         assert_eq!(r, Some("ENSP00000001:p.Trp2del".to_string()));
     }
 
@@ -803,13 +894,253 @@ mod tests {
     fn anchor_candidates_offers_the_other_end_only_when_there_is_one() {
         // An empty or single reference has one reading, which keeps insertions -
         // where protein_start is already the far end of the pair - unchanged.
-        assert_eq!(anchor_candidates(10, 0), [Some(10), None]);
-        assert_eq!(anchor_candidates(10, 1), [Some(10), None]);
-        assert_eq!(anchor_candidates(10, 2), [Some(10), Some(9)]);
-        assert_eq!(anchor_candidates(10, 5), [Some(10), Some(6)]);
+        assert_eq!(anchor_candidates(10, 0, false), [Some(10), None]);
+        assert_eq!(anchor_candidates(10, 1, false), [Some(10), None]);
+        assert_eq!(anchor_candidates(10, 2, false), [Some(10), Some(9)]);
+        assert_eq!(anchor_candidates(10, 5, false), [Some(10), Some(6)]);
         // Never underflows past residue 1.
-        assert_eq!(anchor_candidates(2, 5), [Some(2), None]);
-        assert_eq!(anchor_candidates(1, 2), [Some(1), None]);
+        assert_eq!(anchor_candidates(2, 5, false), [Some(2), None]);
+        assert_eq!(anchor_candidates(1, 2, false), [Some(1), None]);
+    }
+
+    #[test]
+    fn anchor_candidates_puts_the_determined_end_first() {
+        // Same pair, opposite order: which one is tried first is what decides a
+        // periodic reference, where both corroborate (#96).
+        assert_eq!(anchor_candidates(10, 5, true), [Some(6), Some(10)]);
+        assert_eq!(anchor_candidates(10, 5, false), [Some(10), Some(6)]);
+
+        // With only one candidate there is nothing to order, and the request for
+        // the other end must not invent one or lose the one there is.
+        assert_eq!(anchor_candidates(10, 1, true), [Some(10), None]);
+        assert_eq!(anchor_candidates(10, 0, true), [Some(10), None]);
+        assert_eq!(anchor_candidates(2, 5, true), [Some(2), None]);
+        assert_eq!(anchor_candidates(1, 2, true), [Some(1), None]);
+    }
+
+    #[test]
+    fn only_a_shrinking_change_on_the_reverse_strand_is_anchored_at_its_end() {
+        // The four combinations, because the rule is a reading of how the
+        // coordinates were built (see `predict_coding_consequence`): the
+        // residues come from the lower CDS coordinate for a shrinking change and
+        // from `cds_start` otherwise, and only on the reverse strand are those
+        // two different ends of the span.
+        assert!(anchored_at_span_end(Strand::Reverse, 3, 0), "deletion");
+        assert!(
+            anchored_at_span_end(Strand::Reverse, 3, 1),
+            "shrinking delins"
+        );
+        assert!(
+            !anchored_at_span_end(Strand::Forward, 3, 0),
+            "forward strand"
+        );
+        assert!(!anchored_at_span_end(Strand::Reverse, 1, 3), "insertion");
+        assert!(
+            !anchored_at_span_end(Strand::Reverse, 3, 3),
+            "equal-length replacement does not shrink"
+        );
+    }
+
+    #[test]
+    fn a_periodic_reference_on_the_reverse_strand_names_the_span_the_caller_meant() {
+        // Issue #96. `EGE` sits at residues 2-4 *and* at 4-6, so both anchors
+        // are corroborated and taking whichever came first picked the wrong one.
+        // These are not two spellings of one variant: deleting 2-4 leaves MGEA
+        // and deleting 4-6 leaves MEGA, so the 3'-rule cannot merge them
+        // afterwards - the wrong answer named residues the variant never touched.
+        let pep: Vec<u8> = "MEGEGEA".bytes().collect();
+        assert_eq!(
+            hgvsp_inframe_indel("ENSP00000001", 4, "EGE", "-", Some(&pep), Strand::Reverse),
+            Some("ENSP00000001:p.Glu2_Glu4del".to_string())
+        );
+
+        // Period 3 at n = 4, the same shape one residue longer.
+        let pep: Vec<u8> = "MABCABCA".bytes().collect();
+        assert_eq!(
+            hgvsp_inframe_indel("ENSP00000001", 5, "ABCA", "-", Some(&pep), Strand::Reverse),
+            Some("ENSP00000001:p.Ala2_Ala5del".to_string())
+        );
+    }
+
+    #[test]
+    fn a_periodic_reference_on_the_forward_strand_is_read_from_the_start() {
+        // The mirror of the case above, and the reason the fix is an ordering
+        // rather than a preference for the earlier residue: on the forward strand
+        // `protein_start` *is* the first affected residue, so the same peptide
+        // and the same reference must resolve to the other span.
+        let pep: Vec<u8> = "MEGEGEA".bytes().collect();
+        assert_eq!(
+            hgvsp_inframe_indel("ENSP00000001", 4, "EGE", "-", Some(&pep), Strand::Forward),
+            Some("ENSP00000001:p.Glu4_Glu6del".to_string())
+        );
+        // And the caller that means residues 2-4 on the forward strand says so.
+        assert_eq!(
+            hgvsp_inframe_indel("ENSP00000001", 2, "EGE", "-", Some(&pep), Strand::Forward),
+            Some("ENSP00000001:p.Glu2_Glu4del".to_string())
+        );
+    }
+
+    /// Deterministic pseudo-random source. A seeded LCG rather than a `rand`
+    /// dependency: the sweep below has to fail the same way twice, or a failure
+    /// cannot be investigated.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn below(&mut self, n: usize) -> usize {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((self.0 >> 33) as usize) % n
+        }
+    }
+
+    /// Apply an emitted HGVSp description back to the reference peptide, and
+    /// check on the way that every residue it names is the residue the peptide
+    /// has at that position.
+    ///
+    /// This is the inverse of the description, which is what makes it a check
+    /// worth having: a span that is well-formed, corroborated and *wrong* still
+    /// reconstructs the wrong protein.
+    fn apply_to_peptide(description: &str, peptide: &str) -> String {
+        let one = |aa3: &str| -> char {
+            match aa3 {
+                "Ala" => 'A',
+                "Glu" => 'E',
+                "Gly" => 'G',
+                "Lys" => 'K',
+                "Met" => 'M',
+                other => panic!("unexpected residue {other} in {description}"),
+            }
+        };
+        let body = description
+            .split(":p.")
+            .nth(1)
+            .unwrap_or_else(|| panic!("no :p. in {description}"));
+        let (span, replacement) = match body.split_once("delins") {
+            Some((span, inserted)) => (
+                span,
+                inserted
+                    .as_bytes()
+                    .chunks(3)
+                    .map(|c| one(std::str::from_utf8(c).unwrap()))
+                    .collect::<String>(),
+            ),
+            None => (
+                body.strip_suffix("del")
+                    .unwrap_or_else(|| panic!("neither del nor delins: {description}")),
+                String::new(),
+            ),
+        };
+
+        // `Glu2` or `Glu2_Glu4`, and both ends are checked against the peptide.
+        let mut bounds = Vec::new();
+        for part in span.split('_') {
+            let (aa3, digits) = part.split_at(3);
+            let pos: usize = digits
+                .parse()
+                .unwrap_or_else(|_| panic!("unparsable position in {description}"));
+            assert_eq!(
+                peptide.chars().nth(pos - 1),
+                Some(one(aa3)),
+                "{description} names {aa3} at {pos}, peptide has {:?} ({peptide})",
+                peptide.chars().nth(pos - 1)
+            );
+            bounds.push(pos);
+        }
+        let lo = bounds[0];
+        let hi = *bounds.last().unwrap();
+        assert!(lo <= hi, "inverted span in {description}");
+        format!("{}{}{}", &peptide[..lo - 1], replacement, &peptide[hi..])
+    }
+
+    #[test]
+    fn every_description_reconstructs_the_protein_the_variant_produces() {
+        // The property that matters, over 4,000 shrinking in-frame changes on a
+        // four-residue alphabet chosen to make periodic references common: apply
+        // the description back to the reference peptide and you must get the
+        // protein the variant actually produces. A description can be
+        // well-formed, name real residues, and still fail this - that is exactly
+        // what #96 was, and what #91 was before it.
+        //
+        // Both strands, each with the anchor its coordinate convention produces:
+        // the start of the span on the forward strand, the end of it on the
+        // reverse. Spans start at residue 2 or later, because a deletion reaching
+        // the initiation codon is deliberately described as unresolvable (`?`)
+        // rather than as a reconstructible event.
+        const ALPHABET: &[u8] = b"AEGK";
+        let mut rng = Lcg(0x5EED_1234_9ABC_DEF0);
+        let mut checked = 0;
+
+        for _ in 0..4_000 {
+            let len = 6 + rng.below(14);
+            let peptide: String = (0..len)
+                .map(|_| ALPHABET[rng.below(ALPHABET.len())] as char)
+                .collect();
+            let n = 1 + rng.below(4);
+            if len < n + 2 {
+                continue;
+            }
+            // 1-based, and never residue 1.
+            let lo = 2 + rng.below(len - n);
+            let hi = lo + n - 1;
+            let reference = &peptide[lo - 1..hi];
+            // Shrinking: a pure deletion, or a replacement by fewer residues.
+            let m = rng.below(n);
+            let replacement: String = (0..m)
+                .map(|_| ALPHABET[rng.below(ALPHABET.len())] as char)
+                .collect();
+            let alt_aas = if m == 0 { "-".to_string() } else { replacement };
+            let expected = format!(
+                "{}{}{}",
+                &peptide[..lo - 1],
+                alt_aas.replace('-', ""),
+                &peptide[hi..]
+            );
+
+            for (anchor, strand) in [(lo as u64, Strand::Forward), (hi as u64, Strand::Reverse)] {
+                let got = hgvsp_inframe_indel(
+                    "P",
+                    anchor,
+                    reference,
+                    &alt_aas,
+                    Some(peptide.as_bytes()),
+                    strand,
+                )
+                .unwrap_or_else(|| {
+                    panic!("no description for {reference}/{alt_aas} at {lo}-{hi} in {peptide}")
+                });
+                assert_eq!(
+                    apply_to_peptide(&got, &peptide),
+                    expected,
+                    "{got} does not reconstruct {expected} from {peptide} \
+                     ({reference}/{alt_aas} at {lo}-{hi}, anchor {anchor} on {strand:?})"
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked > 5_000, "sweep covered only {checked} cases");
+    }
+
+    #[test]
+    fn a_two_residue_homopolymer_reads_the_same_from_either_end() {
+        // Where the reference is a homopolymer inside a longer run both anchors
+        // are corroborated at n = 2, but the 3'-shift converges on one answer, so
+        // the strand cannot change it. Worth pinning: it bounds the exposure the
+        // ordering fix was needed for to n >= 3.
+        let pep: Vec<u8> = "MAKKKA".bytes().collect();
+        for (anchor, strand) in [
+            (3u64, Strand::Forward),
+            (4, Strand::Forward),
+            (3, Strand::Reverse),
+            (4, Strand::Reverse),
+        ] {
+            assert_eq!(
+                hgvsp_inframe_indel("ENSP00000001", anchor, "KK", "-", Some(&pep), strand),
+                Some("ENSP00000001:p.Lys4_Lys5del".to_string()),
+                "anchor {anchor} on {strand:?}"
+            );
+        }
     }
 
     #[test]
@@ -819,8 +1150,15 @@ mod tests {
         // behaviour, which always emitted a (wrong) substitution.
         let pep: Vec<u8> = "MKKRSTV".bytes().collect();
         for start in [1u64, 8] {
-            let got = hgvsp_inframe_indel("ENSP00000001", start, "G", "GG", Some(&pep));
-            assert!(got.is_some(), "dropped annotation at protein_start {start}");
+            // Both strands: an insertion is anchored at `protein_start` whichever
+            // way the transcript runs, so the strand must make no difference here.
+            for strand in [Strand::Forward, Strand::Reverse] {
+                let got = hgvsp_inframe_indel("ENSP00000001", start, "G", "GG", Some(&pep), strand);
+                assert!(
+                    got.is_some(),
+                    "dropped annotation at protein_start {start} on {strand:?}"
+                );
+            }
         }
     }
 
@@ -860,35 +1198,59 @@ mod tests {
         for &(start, ref_aas, alt_aas, prior) in insertions {
             let pep = peptide_with(start, ref_aas, start as usize + ref_aas.len() + 64);
             for context in [None, Some(pep.as_slice())] {
-                let out = hgvsp_inframe_indel("ENSP00000001", start, ref_aas, alt_aas, context)
+                // Both strands. An insertion is anchored at `protein_start`
+                // regardless (#96), so every assertion below has to hold either
+                // way; a strand-dependent answer here would be a bug.
+                for strand in [Strand::Forward, Strand::Reverse] {
+                    let out = hgvsp_inframe_indel(
+                        "ENSP00000001",
+                        start,
+                        ref_aas,
+                        alt_aas,
+                        context,
+                        strand,
+                    )
                     .expect("in-frame indel must produce a protein description");
-                let change = out.split(":p.").nth(1).unwrap();
-                // "delins" contains both "del" and "ins", so require one of the
-                // whole forms rather than a substring of another.
-                assert!(
-                    change.ends_with("del")
-                        || change.ends_with("dup")
-                        || change.contains("delins")
-                        || change.contains("ins"),
-                    "{ref_aas}/{alt_aas} at {start} (was {prior}) rendered \
+                    let change = out.split(":p.").nth(1).unwrap();
+                    // "delins" contains both "del" and "ins", so require one of the
+                    // whole forms rather than a substring of another.
+                    assert!(
+                        change.ends_with("del")
+                            || change.ends_with("dup")
+                            || change.contains("delins")
+                            || change.contains("ins"),
+                        "{ref_aas}/{alt_aas} at {start} (was {prior}) rendered \
                      without an indel form: {out}"
-                );
-                assert!(!out.contains('?'), "placeholder residue in {out}");
-                assert!(!out.ends_with('='), "synonymous shape: {out} (was {prior})");
-                assert_ne!(
-                    out.split(':').nth(1).unwrap(),
-                    prior,
-                    "still emitting {prior}"
-                );
+                    );
+                    assert!(!out.contains('?'), "placeholder residue in {out}");
+                    assert!(!out.ends_with('='), "synonymous shape: {out} (was {prior})");
+                    assert_ne!(
+                        out.split(':').nth(1).unwrap(),
+                        prior,
+                        "still emitting {prior}"
+                    );
+                }
             }
         }
 
         for &(start, ref_aas, alt_aas) in deletions {
             let pep = peptide_with(start, ref_aas, start as usize + ref_aas.len() + 64);
             for context in [None, Some(pep.as_slice())] {
-                let out = hgvsp_inframe_indel("ENSP00000001", start, ref_aas, alt_aas, context)
+                for strand in [Strand::Forward, Strand::Reverse] {
+                    let out = hgvsp_inframe_indel(
+                        "ENSP00000001",
+                        start,
+                        ref_aas,
+                        alt_aas,
+                        context,
+                        strand,
+                    )
                     .expect("deletion must produce a protein description");
-                assert!(out.ends_with("del"), "deletion regressed: {out}");
+                    assert!(
+                        out.ends_with("del"),
+                        "deletion regressed on {strand:?}: {out}"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #96, taking option 1 from the issue: pass the strand, because the coordinate convention already determines which end of the span `protein_start` names.

## The residue #93 left

#93 gave `hgvsp_inframe_indel` a second anchor to try when the peptide does not corroborate the first. That fixed every case where the first end is not a match at all - 99.7% of the declines. It left the case where **both** ends corroborate: `find()` takes the first, and for a shrinking change on the reverse strand the first is the wrong one.

The wrong answer is not another spelling of the right one. With peptide `MEGEGEA`, `EGE` sits at 2-4 and again at 4-6; deleting 2-4 leaves `MGEA` and deleting 4-6 leaves `MEGA`, so no later 3'-shift can reconcile them. The description names residues the variant does not touch, which is the family #91 and #58 were both about.

## What decides it now

`protein_start` comes from the genomic left edge. The residues come from the lower of the two CDS coordinates for a shrinking change and from `cds_start` otherwise (`predict_coding_consequence`), so it is exactly **the shrinking change on the reverse strand** whose span arrives anchored at its end. `anchored_at_span_end` states that as a predicate and `anchor_candidates` orders the pair by it, instead of leaving the choice to iteration order.

The other end stays as a fallback rather than being dropped. Over 37,122 in-frame ClinVar rows the residues sat at `protein_start` in 71.1% of cases, one residue earlier in 11.9%, and at neither in 17.0% - so ordering is all the strand can honestly buy, and the peptide still decides. A reverse-strand caller whose residues really do sit at `protein_start` still normalises; there is a test for exactly that.

Both routing copies pass `tr.strand`: the CLI pipeline, and the one in `fastvep-annotate` that serves the web path. Nothing structurally keeps those two in step, so each has its own end-to-end test.

## Measured end to end

The real-data gate is in [this comment](https://github.com/Huang-lab/fastVEP/pull/97#issuecomment-5363034308): over the whole 673,660-variant ClinVar 2-star corpus, 15,684,064 consequence rows, **6 HGVSp rows change and nothing else does** - `Protein_position` and every other CSQ field are byte-identical. All six are ClinVar 421481 (PCDH15, reverse strand, `PAP/-`), verified against a peptide recomputed independently in Python.

Before that corpus was located, the same question was answered synthetically, and the synthetic run is still the broader of the two: **8,000 synthetic in-frame deletions**, 4,000 per strand, each on its own single-exon gene with a real translated peptide, driven through `fastvep annotate --hgvs` on both binaries. Scoring applies each emitted description back to the reference peptide and compares the result to the protein the variant actually produces - the invariant a well-formed-but-wrong span breaks.

| | correct | wrong protein |
|---|---|---|
| `fd982f4` (master) | 7,985 | **15** |
| this branch | **8,000** | 0 |

15 descriptions changed, every one on the reverse strand, every one from wrong to right. **No forward-strand description changes at all.** Examples, as `peptide del<span>`:

```
MGAGAGAE   del3-5   p.Ala5_Ala7del  ->  p.Ala3_Ala5del
MKAKAKGK   del2-4   p.Lys4_Lys6del  ->  p.Lys2_Lys4del
MEEEGEEGEAEAAG del3-6  p.Glu6_Glu9del -> p.Glu4_Glu7del
MEAGAGAAGAA del3-5  p.Gly9_Ala11del ->  p.Ala3_Ala5del
```

The last one is worth noting: the old answer had been 3'-shifted off the wrong anchor onto residues 9-11, which really are `GAA` in that peptide. Nothing about it looks wrong.

The 0.4% rate on reverse-strand rows is inflated by design - the fixtures use a four-residue alphabet so periodic references are common, which is what made the synthetic run useful before the real corpus was to hand. On real ClinVar data the rate is 6 rows in 15.7M: 2,453 in-frame rows satisfied the necessary condition for the ambiguity and 2,447 of those either failed to corroborate both anchors or converged after the 3'-shift.

A differential run over `vep_example_GRCh38.vcf`, `clinvar_inframe_deletions.vcf`, `chr22_1kgp.vcf` and `tests/test.vcf` against the in-repo fixture annotation is byte-identical too, but that one is weak evidence and worth labelling as such: the fixture FASTA has no chr17 sequence, so those runs carry no protein descriptions at all. The ClinVar run above is the one that counts.

## Tests

10 new, each confirmed to fail with the ordering removed (`[Some(protein_start), from_end]` unconditionally):

```
a_periodic_reference_on_the_reverse_strand_names_the_span_the_caller_meant
a_periodic_reference_on_the_forward_strand_is_read_from_the_start        (guard)
a_two_residue_homopolymer_reads_the_same_from_either_end                 (guard)
only_a_shrinking_change_on_the_reverse_strand_is_anchored_at_its_end
anchor_candidates_puts_the_determined_end_first
every_description_reconstructs_the_protein_the_variant_produces
hgvsp_reads_a_periodic_reference_from_the_end_the_strand_determines      (fastvep-annotate)
hgvsp_reads_the_same_periodic_reference_from_the_start_on_the_forward_strand
cli_reverse_strand_deletion_names_the_residues_it_deletes                (run_annotate)
cli_forward_strand_deletion_of_the_same_residues_is_unchanged
```

The five that assert the new behaviour fail without it; the four guards pass either way, which is their job - they exist so the fix cannot trade one wrong end for the other.

`every_description_reconstructs_the_protein_the_variant_produces` is the one worth keeping an eye on: 4,000 shrinking changes from a seeded LCG, each applied back to its peptide. It found a shape the issue did not mention - shrinking **delins**, not just pure deletions:

```
P:p.Lys6_Lys7delinsGly does not reconstruct EGKAGKGEGAKE from EGKAKKKGEGAKE
  (KK/G at 5-6, anchor 6 on Reverse)
```

The existing real-data tables (`test_hgvsp_inframe_indel_never_emits_substitution_shape` and the terminal-insertion case) now run under both strands, which pins that insertions are anchored at `protein_start` either way.

**941 tests pass**, up from 931. `clippy --all-targets -D warnings` clean, `rustfmt` clean.

## Not in scope

The E2E fixtures deliberately reproduce the bug through `run_annotate` rather than by handing `protein_start` to the unit under test: the anchor convention is a property of the coordinates the pipeline produces, and a unit test that passes the anchor by hand asserts the author's reading of the convention rather than the pipeline's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

