### PR TITLE
fix: report both terms at a CDS boundary (#100), and make a dense .osa2 usable instead of silently thin (#101)

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -431,8 +431,8 @@ impl AnnotationContext {
                                     let (hgvs_ref, hgvs_alt) =
                                         if tr.strand == fastvep_core::Strand::Reverse {
                                             (
-                                                complement_allele(&vf.ref_allele),
-                                                complement_allele(&ac.allele),
+                                                reverse_complement_allele(&vf.ref_allele),
+                                                reverse_complement_allele(&ac.allele),
                                             )
                                         } else {
                                             (vf.ref_allele.clone(), ac.allele.clone())
@@ -990,20 +990,17 @@ pub fn zip_positions(start: Option<u64>, end: Option<u64>) -> Option<(u64, u64)>
     }
 }
 
-pub fn complement_allele(allele: &Allele) -> Allele {
+/// Put an allele into transcript orientation for a reverse-strand transcript.
+///
+/// VCF alleles are given in genomic order, so reading them on the minus strand
+/// means reversing them as well as complementing each base. Complementing in
+/// place is indistinguishable for a single base, which is why it survived: it
+/// showed up only once a multi-base alternate reached HGVS, where a
+/// reverse-strand `ACG` was written `delinsTGC` instead of `delinsCGT`.
+pub fn reverse_complement_allele(allele: &Allele) -> Allele {
     match allele {
         Allele::Sequence(bases) => {
-            let comp: Vec<u8> = bases
-                .iter()
-                .map(|&b| match b {
-                    b'A' | b'a' => b'T',
-                    b'T' | b't' => b'A',
-                    b'C' | b'c' => b'G',
-                    b'G' | b'g' => b'C',
-                    other => other,
-                })
-                .collect();
-            Allele::Sequence(comp)
+            Allele::Sequence(fastvep_genome::codon::reverse_complement(bases))
         }
         other => other.clone(),
     }
@@ -2314,5 +2311,34 @@ mod tests {
              substitution and not an unshifted delins: {:?}",
             tc
         );
+    }
+
+    /// A minus-strand transcript reads a VCF allele reverse-complemented, not
+    /// complemented base-by-base. The two agree for a single base, which is why
+    /// complementing in place survived until a multi-base alternate reached
+    /// HGVS: `ACG` was written `TGC` instead of `CGT`.
+    #[test]
+    fn an_allele_in_transcript_orientation_is_reversed_as_well_as_complemented() {
+        assert_eq!(
+            reverse_complement_allele(&Allele::Sequence(b"ACG".to_vec())),
+            Allele::Sequence(b"CGT".to_vec())
+        );
+        // A palindrome would not have caught the bug, and neither would an SNV.
+        assert_eq!(
+            reverse_complement_allele(&Allele::Sequence(b"A".to_vec())),
+            Allele::Sequence(b"T".to_vec())
+        );
+        // Applying it twice is the identity, on any sequence.
+        let original = Allele::Sequence(b"ACGGTTA".to_vec());
+        assert_eq!(
+            reverse_complement_allele(&reverse_complement_allele(&original)),
+            original
+        );
+        // The placeholder alleles carry no sequence to orient.
+        assert_eq!(
+            reverse_complement_allele(&Allele::Deletion),
+            Allele::Deletion
+        );
+        assert_eq!(reverse_complement_allele(&Allele::Missing), Allele::Missing);
     }
 }

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -753,16 +753,20 @@ impl AnnotationContext {
                             } else {
                                 (vf.position.start, ref_str.as_str(), alt_str.as_str())
                             };
-                            if let Ok(Some(ann)) = sa.annotate_position(chrom, q_pos, q_ref, q_alt)
-                            {
-                                let json_str = match ann {
-                                    AnnotationValue::Json(j) => j,
-                                    AnnotationValue::Positional(j) => j,
-                                    AnnotationValue::Interval(v) => {
-                                        format!("[{}]", v.join(","))
-                                    }
-                                };
-                                results.push((sa.json_key().to_string(), json_str));
+                            // A failed lookup is not a miss: see `SaLookupErrors`.
+                            match sa.annotate_position(chrom, q_pos, q_ref, q_alt) {
+                                Ok(Some(ann)) => {
+                                    let json_str = match ann {
+                                        AnnotationValue::Json(j) => j,
+                                        AnnotationValue::Positional(j) => j,
+                                        AnnotationValue::Interval(v) => {
+                                            format!("[{}]", v.join(","))
+                                        }
+                                    };
+                                    results.push((sa.json_key().to_string(), json_str));
+                                }
+                                Ok(None) => {}
+                                Err(e) => sa_lookup_errors().record(sa.json_key(), &e),
                             }
                         }
                         allele_results.insert(alt_str, results);
@@ -987,6 +991,79 @@ pub fn zip_positions(start: Option<u64>, end: Option<u64>) -> Option<(u64, u64)>
         (Some(s), None) => Some((s, s)),
         (None, Some(e)) => Some((e, e)),
         _ => None,
+    }
+}
+
+/// Supplementary-annotation lookups that failed, counted per source.
+///
+/// A provider error and a provider miss used to be the same thing at the call
+/// site - both per-variant loops wrote `if let Ok(Some(ann))`, so a source that
+/// *could not answer* produced a record indistinguishable from one it simply had
+/// nothing for. That is the silent wrong answer this codebase is most exposed
+/// to. A `.osa2` chunk whose JSON blob exceeds the decompression limit fails
+/// every lookup in its megabase of the genome, and the only visible effect was a
+/// missing column: on a dense converted SpliceAI database, 295 of 300 variants
+/// came back with no score and the run reported success (#101).
+///
+/// Reporting per variant is not an option - the loop runs millions of times - so
+/// the first message from each source is kept and the rest counted, for one
+/// summary at the end of the run.
+#[derive(Default)]
+pub struct SaLookupErrors {
+    /// `json_key -> (failures, first message)`.
+    inner: std::sync::Mutex<std::collections::HashMap<String, (u64, String)>>,
+}
+
+impl SaLookupErrors {
+    /// Record one failed lookup. Only ever called off the happy path, so the
+    /// mutex is never contended by a successful annotation.
+    pub fn record(&self, source: &str, err: &anyhow::Error) {
+        let Ok(mut map) = self.inner.lock() else {
+            return; // a poisoned counter must not take the run down with it
+        };
+        // Look the source up borrowed, and build the strings only when it is
+        // new. A source that is unreadable rather than merely missing a record
+        // fails on *every* variant, so this runs once per variant per broken
+        // source across every worker; `entry()` would allocate the key and
+        // format the error again each time.
+        if let Some(seen) = map.get_mut(source) {
+            seen.0 += 1;
+            return;
+        }
+        map.insert(source.to_string(), (1, err.to_string()));
+    }
+
+    /// One line per source that failed, sorted so the output is reproducible.
+    pub fn report_lines(&self) -> Vec<String> {
+        let Ok(map) = self.inner.lock() else {
+            return Vec::new();
+        };
+        let mut rows: Vec<_> = map.iter().collect();
+        rows.sort_by(|a, b| a.0.cmp(b.0));
+        rows.iter()
+            .map(|(source, (count, first))| {
+                format!(
+                    "warning: {source} could not be read for {count} variant lookup(s); \
+                     those variants carry no {source} annotation, which is not the same as \
+                     having none. First error: {first}"
+                )
+            })
+            .collect()
+    }
+}
+
+/// The process-wide collector, shared by both annotation pipelines for the same
+/// reason the SA caches are shared: the providers are reached from deep inside
+/// two independent per-variant loops.
+pub fn sa_lookup_errors() -> &'static SaLookupErrors {
+    static ERRORS: std::sync::OnceLock<SaLookupErrors> = std::sync::OnceLock::new();
+    ERRORS.get_or_init(SaLookupErrors::default)
+}
+
+/// Print the supplementary-annotation failure summary, if there is one.
+pub fn report_sa_lookup_errors() {
+    for line in sa_lookup_errors().report_lines() {
+        eprintln!("{line}");
     }
 }
 

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -260,6 +260,19 @@ enum Commands {
         #[arg(short, long)]
         output: Option<String>,
 
+        /// Genomic width of one chunk, as a power of two (1..=20). A chunk is
+        /// the unit a query loads, and a conversion stores whole-record JSON
+        /// blobs, so the whole chunk's blobs are decompressed to read one
+        /// record. The default of 20 (1 Mb) suits the sparse sources - dbSNP,
+        /// ClinVar, COSMIC, REVEL - and keeps them compact. A source that
+        /// scores nearly every base, SpliceAI above all, puts so much in one
+        /// megabase that queries slow to a crawl and can exceed the blob
+        /// decompression limit outright; pass 16 (65 kb) for those. Measured on
+        /// a SpliceAI-density source, 300 scattered queries went from 9.7s
+        /// (with most lookups failing) to 0.5s, for 12% more file size.
+        #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=20))]
+        chunk_bits: u32,
+
         /// Suppress periodic progress output
         #[arg(long, default_value_t = false)]
         no_progress: bool,
@@ -381,6 +394,7 @@ fn main() -> Result<()> {
         Commands::SaConvert {
             input,
             output,
+            chunk_bits,
             no_progress,
         } => {
             // Default the output alongside the input: `foo.osa` -> `foo.osa2`.
@@ -391,7 +405,7 @@ fn main() -> Result<()> {
                     .to_string_lossy()
                     .into_owned()
             });
-            pipeline::run_sa_convert(&input, &output, !no_progress)?
+            pipeline::run_sa_convert(&input, &output, chunk_bits, !no_progress)?
         }
         Commands::Filter {
             input,

--- a/crates/fastvep-cli/src/pipeline/annotate.rs
+++ b/crates/fastvep-cli/src/pipeline/annotate.rs
@@ -30,9 +30,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 // Shared annotation utilities from fastvep-annotate (used by batch pipeline).
 use fastvep_annotate::{
-    annotate_intergenic, annotate_sa_only_scaffold, complement_allele, convert_ins_to_dup,
+    annotate_intergenic, annotate_sa_only_scaffold, convert_ins_to_dup,
     convert_ins_to_dup_noncoding, load_gene_providers, load_sa_providers,
-    three_prime_shift_intronic, zip_positions,
+    reverse_complement_allele, three_prime_shift_intronic, zip_positions,
 };
 
 const BATCH_SIZE: usize = 1024;
@@ -269,7 +269,7 @@ fn annotate_variant(
 
                                 // Determine alleles for HGVS - complement for minus strand
                                 let (hgvs_ref, hgvs_alt) = if tr.strand == fastvep_core::Strand::Reverse {
-                                    (complement_allele(&vf.ref_allele), complement_allele(&ac.allele))
+                                    (reverse_complement_allele(&vf.ref_allele), reverse_complement_allele(&ac.allele))
                                 } else {
                                     (vf.ref_allele.clone(), ac.allele.clone())
                                 };

--- a/crates/fastvep-cli/src/pipeline/annotate.rs
+++ b/crates/fastvep-cli/src/pipeline/annotate.rs
@@ -791,15 +791,20 @@ fn annotate_variant(
                     } else {
                         (vf.position.start, "", "")
                     };
-                    if let Ok(Some(ann)) = sa.annotate_position(chrom, sa_pos, sa_ref, sa_alt) {
-                        let json_str = match ann {
-                            AnnotationValue::Json(j) => j,
-                            AnnotationValue::Positional(j) => j,
-                            AnnotationValue::Interval(v) => {
-                                format!("[{}]", v.join(","))
-                            }
-                        };
-                        results.push((sa.json_key().to_string(), json_str));
+                    // A failed lookup is not a miss: see `SaLookupErrors`.
+                    match sa.annotate_position(chrom, sa_pos, sa_ref, sa_alt) {
+                        Ok(Some(ann)) => {
+                            let json_str = match ann {
+                                AnnotationValue::Json(j) => j,
+                                AnnotationValue::Positional(j) => j,
+                                AnnotationValue::Interval(v) => {
+                                    format!("[{}]", v.join(","))
+                                }
+                            };
+                            results.push((sa.json_key().to_string(), json_str));
+                        }
+                        Ok(None) => {}
+                        Err(e) => fastvep_annotate::sa_lookup_errors().record(sa.json_key(), &e),
                     }
                 }
                 allele_results.insert(allele_key, results);
@@ -1773,6 +1778,9 @@ pub fn run_annotate(mut config: AnnotateConfig) -> Result<()> {
 
     writer.flush()?;
     meter.finish();
+    // After the meter, so a run that lost annotations says so last and the
+    // warning is not buried in progress output.
+    fastvep_annotate::report_sa_lookup_errors();
 
     Ok(())
 }

--- a/crates/fastvep-cli/src/pipeline/sa_build.rs
+++ b/crates/fastvep-cli/src/pipeline/sa_build.rs
@@ -1280,7 +1280,12 @@ where
 /// ends up smaller is data-dependent (blob columns zstd well when adjacent
 /// records are similar; value columns win when the payload is genuinely
 /// numeric), so the tool points at the rebuild without promising a size win.
-pub fn run_sa_convert(input: &str, output: &str, show_progress: bool) -> Result<()> {
+pub fn run_sa_convert(
+    input: &str,
+    output: &str,
+    chunk_bits: u32,
+    show_progress: bool,
+) -> Result<()> {
     use fastvep_sa::reader::SaReader;
     use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record};
 
@@ -1346,7 +1351,7 @@ pub fn run_sa_convert(input: &str, output: &str, show_progress: bool) -> Result<
         match_by_allele: header.match_by_allele,
         is_array: header.is_array,
         is_positional: header.is_positional,
-        chunk_bits: 20,
+        chunk_bits,
         description: header.description.clone(),
     };
 

--- a/crates/fastvep-cli/tests/sa_convert.rs
+++ b/crates/fastvep-cli/tests/sa_convert.rs
@@ -47,7 +47,7 @@ fn build_and_convert(
         "v1 build should have produced {}",
         osa.display()
     );
-    run_sa_convert(osa.to_str().unwrap(), base.to_str().unwrap(), false).unwrap();
+    run_sa_convert(osa.to_str().unwrap(), base.to_str().unwrap(), 20, false).unwrap();
 
     let osa2 = base.with_extension("osa2");
     assert!(
@@ -198,6 +198,7 @@ fn rejects_inputs_that_have_no_v2_form() {
     let err = run_sa_convert(
         osa2.to_str().unwrap(),
         dir.path().join("o").to_str().unwrap(),
+        20,
         false,
     )
     .unwrap_err();
@@ -212,6 +213,7 @@ fn rejects_inputs_that_have_no_v2_form() {
         let err = run_sa_convert(
             path.to_str().unwrap(),
             dir.path().join("o").to_str().unwrap(),
+            20,
             false,
         )
         .unwrap_err();
@@ -227,6 +229,7 @@ fn rejects_inputs_that_have_no_v2_form() {
     let err = run_sa_convert(
         other.to_str().unwrap(),
         dir.path().join("o").to_str().unwrap(),
+        20,
         false,
     )
     .unwrap_err();
@@ -254,7 +257,8 @@ fn refuses_to_overwrite_its_own_input() {
     // collide — asking for an output path that resolves onto the input file.
     let osa2_in = base.with_extension("osa2");
     fs::rename(base.with_extension("osa"), &osa2_in).unwrap();
-    let err = run_sa_convert(osa2_in.to_str().unwrap(), base.to_str().unwrap(), false).unwrap_err();
+    let err =
+        run_sa_convert(osa2_in.to_str().unwrap(), base.to_str().unwrap(), 20, false).unwrap_err();
     assert!(err.to_string().contains("already a v2"), "got: {err}");
 }
 
@@ -282,7 +286,7 @@ fn a_failed_conversion_leaves_no_partial_output() {
     fs::write(&osa, &truncated).unwrap();
 
     let out_base = dir.path().join("converted");
-    let result = run_sa_convert(osa.to_str().unwrap(), out_base.to_str().unwrap(), false);
+    let result = run_sa_convert(osa.to_str().unwrap(), out_base.to_str().unwrap(), 20, false);
     assert!(
         result.is_err(),
         "a truncated .osa must not convert successfully"

--- a/crates/fastvep-consequence/src/predictor.rs
+++ b/crates/fastvep-consequence/src/predictor.rs
@@ -400,19 +400,32 @@ impl ConsequencePredictor {
                 protein_end = Some(Transcript::cds_to_protein(cds_e));
             }
 
-            let in_coding_region =
-                self.is_in_coding_region(var_start, var_end, coding_start, coding_end);
-            let in_5_utr = self.is_in_5_utr(var_start, var_end, transcript);
-            let in_3_utr = self.is_in_3_utr(var_start, var_end, transcript);
+            // Which regions the variant *reaches*, not which region it starts
+            // in. A variant may span the CDS/UTR boundary, and then it belongs
+            // to both: VEP reports the pair, `stop_lost&3_prime_UTR_variant`.
+            //
+            // Testing only `var_start` - and choosing one branch from the
+            // result - made the answer depend on the strand, because the
+            // genomic start of a reverse-strand variant is its *last* base in
+            // transcript order. A delins over FOXL2's stop codon came back as
+            // `3_prime_UTR_variant` alone, MODIFIER where VEP says HIGH, and
+            // the mirror case on the forward strand lost `start_lost` the same
+            // way (#100). Each region is now its own additive test.
+            let hits_coding =
+                in_exon && self.is_in_coding_region(var_start, var_end, coding_start, coding_end);
+            let hits_5_utr = in_exon && self.overlaps_5_utr(var_start, var_end, transcript);
+            let hits_3_utr = in_exon && self.overlaps_3_utr(var_start, var_end, transcript);
 
-            if in_5_utr && in_exon {
+            if hits_5_utr {
                 consequences.push(Consequence::FivePrimeUtrVariant);
-            } else if in_3_utr && in_exon {
+            }
+            if hits_3_utr {
                 consequences.push(Consequence::ThreePrimeUtrVariant);
-            } else if in_coding_region && in_exon {
+            }
+            if hits_coding {
                 // Coding exonic variant - determine coding consequence
                 let coding_conseq = self.predict_coding_consequence(
-                    ref_allele, alt_allele, transcript, cds_start, cds_end,
+                    ref_allele, alt_allele, transcript, cds_start, cds_end, cdna_start, cdna_end,
                 );
                 if let Some((conseq, aa, cdn)) = coding_conseq {
                     consequences.push(conseq);
@@ -421,7 +434,11 @@ impl ConsequencePredictor {
                 } else {
                     consequences.push(Consequence::CodingSequenceVariant);
                 }
-            } else if in_intron && !is_essential_splice {
+            }
+            // An exonic region term already describes the variant, so the
+            // intron term stays reserved for a variant that reached no exonic
+            // region at all - the condition the `else if` chain used to encode.
+            if !(hits_5_utr || hits_3_utr || hits_coding) && in_intron && !is_essential_splice {
                 // VEP excludes intron_variant for positions at splice donor/acceptor sites
                 consequences.push(Consequence::IntronVariant);
             }
@@ -491,6 +508,9 @@ impl ConsequencePredictor {
     }
 
     /// Predict the coding consequence (missense, synonymous, frameshift, etc.)
+    // Each argument is an independent coordinate or allele; grouping them into
+    // a struct would only move the argument list to the call site.
+    #[allow(clippy::too_many_arguments)]
     fn predict_coding_consequence(
         &self,
         ref_allele: &Allele,
@@ -498,7 +518,38 @@ impl ConsequencePredictor {
         transcript: &Transcript,
         cds_start: Option<u64>,
         cds_end: Option<u64>,
+        cdna_start: Option<u64>,
+        cdna_end: Option<u64>,
     ) -> Option<(Consequence, DisplayPair, DisplayPair)> {
+        // A variant reaching past either end of the CDS is not a codon edit:
+        // the bases falling in the UTR belong to no codon, and the frame
+        // arithmetic below would count them anyway - which is how a delins
+        // over FOXL2's stop codon came back `frameshift_variant` on the
+        // forward strand and never reached this function at all on the reverse
+        // one. VEP reaches the same conclusion structurally: `cds_start` /
+        // `cds_end` are undefined when that end of the variant maps outside
+        // the coding region, and `frameshift` returns 0 unless both are
+        // defined, so the term comes from its start/stop codon predicates.
+        //
+        // Test the cDNA spans rather than `cds_start.is_none()`: a CDS
+        // coordinate is also None for a flank that falls in an intron, and an
+        // indel at an exon edge is an ordinary indel.
+        let reaches_past_cds = match (
+            cdna_start,
+            cdna_end,
+            transcript.cdna_coding_start,
+            transcript.cdna_coding_end,
+        ) {
+            (Some(s), Some(e), Some(coding_s), Some(coding_e)) => {
+                s.min(e) < coding_s || s.max(e) > coding_e
+            }
+            _ => false,
+        };
+        if reaches_past_cds {
+            return self.predict_cds_boundary_consequence(
+                ref_allele, alt_allele, transcript, cdna_start, cdna_end,
+            );
+        }
         let cds_pos_start = cds_start?;
 
         let ref_len = ref_allele.len();
@@ -672,6 +723,172 @@ impl ConsequencePredictor {
         } else {
             None
         }
+    }
+
+    /// Consequence for a coding variant that reaches past one end of the CDS.
+    ///
+    /// Such a variant almost always touches the initiator or the terminator:
+    /// reaching past `cdna_coding_start` while still overlapping the CDS means
+    /// covering part of `[cdna_coding_start, cdna_coding_start + 2]`, and the
+    /// same holds at the other end. So the question is usually only whether
+    /// that codon survives the change.
+    ///
+    /// It is not a guarantee, because the overlap that put us here is measured
+    /// in genomic space and can be satisfied by intronic bases alone. Returning
+    /// `None` then is correct rather than merely safe: the caller falls back to
+    /// `coding_sequence_variant`, which is what a coding change nobody can
+    /// resolve any further is.
+    ///
+    /// The amino-acid and codon pair is deliberately left unset. A variant of
+    /// this shape has no single replaced codon to name - part of it is not in
+    /// the CDS at all - and the alternative is inventing one: the forward-strand
+    /// case used to reach the frameshift formatter and report
+    /// `p.Tyr175TerfsTer1` for a change that does not shift any frame.
+    fn predict_cds_boundary_consequence(
+        &self,
+        ref_allele: &Allele,
+        alt_allele: &Allele,
+        transcript: &Transcript,
+        cdna_start: Option<u64>,
+        cdna_end: Option<u64>,
+    ) -> Option<(Consequence, DisplayPair, DisplayPair)> {
+        let coding_start = transcript.cdna_coding_start?;
+        let coding_end = transcript.cdna_coding_end?;
+        let (s, e) = (cdna_start?, cdna_end?);
+        let (cdna_lo, cdna_hi) = (s.min(e), s.max(e));
+        if coding_end < coding_start + 2 {
+            return None; // no room for a codon at either end
+        }
+
+        // VEP's `_overlaps_stop_codon` / `_overlaps_start_codon`: a cDNA-space
+        // overlap with the three bases of the terminator or the initiator. A
+        // `cds_end_NF` / `cds_start_NF` transcript is one whose annotation does
+        // not claim to carry that codon, so neither term is available for it -
+        // VEP checks the same two flags before either predicate.
+        let flagged = |flag: &str| transcript.flags.iter().any(|f| f == flag);
+        let overlaps_stop =
+            cdna_lo <= coding_end && cdna_hi >= coding_end - 2 && !flagged("cds_end_NF");
+        // A non-zero start phase says the annotated CDS begins part-way through
+        // a codon, so this transcript has no complete initiator to lose and the
+        // three bases at `cdna_coding_start` are not one. Without this, every
+        // length-changing variant reaching that end of such a transcript would
+        // be `start_lost`, because `is_start` can never hold there.
+        let start_codon_known = !flagged("cds_start_NF") && transcript.codon_table_start_phase == 0;
+        let overlaps_start =
+            cdna_lo <= coding_start + 2 && cdna_hi >= coding_start && start_codon_known;
+
+        // A variant that swallows the whole CDS destroys both codons; report
+        // the more severe of the two terms, which is `stop_lost`.
+        if overlaps_stop {
+            let still_a_stop = self
+                .edited_codon(transcript, cdna_lo, cdna_hi, alt_allele, coding_end - 2)
+                .map(|codon| self.codon_table_for(transcript).translate(&codon) == b'*');
+            return Some(match still_a_stop {
+                Some(true) => (Consequence::StopRetainedVariant, None, None),
+                // Either the terminator now reads as something else, or the
+                // edited transcript no longer reaches the position it sat at.
+                // Both mean the annotated stop is gone from where it was.
+                _ => (Consequence::StopLost, None, None),
+            });
+        }
+
+        if overlaps_start {
+            // The initiator is not decided by re-reading its codon, and the
+            // asymmetry with the terminator above is VEP's, not an oversight.
+            // Past the stop codon the 3' UTR simply supplies the next bases and
+            // translation runs on, so whatever now sits at that offset *is* the
+            // terminator. An initiator instead has to be the first ATG in its
+            // context, so `_ins_del_start_altered` spares a change only when it
+            // leaves the 5' UTR byte-identical *and* still finds ATG at the
+            // coding start; a length change reaching across the junction fails
+            // that by construction, and VEP calls it `start_lost`.
+            //
+            // Reading the codon alone is too permissive here. PLA2G6's coding
+            // sequence begins `ATGGATGTCA`, and a `c.-2_3delins` brings its
+            // second in-frame ATG onto the coding start: the codon still reads
+            // ATG while the CDS has lost four bases.
+            //
+            // Read the length change off the alleles, not off the cDNA span:
+            // an insertion's span is its two flanking bases while it deletes
+            // nothing, and a variant spanning an intron has more reference
+            // bases than cDNA positions. VEP's `increase_length` /
+            // `decrease_length` are likewise properties of the allele pair.
+            if ref_allele.len() != alt_allele.len() {
+                return Some((Consequence::StartLost, None, None));
+            }
+            // A same-length change cannot shift the frame, so the codon it
+            // leaves at the coding start is the whole question.
+            let still_a_start = self
+                .edited_codon(transcript, cdna_lo, cdna_hi, alt_allele, coding_start)
+                .map(|codon| CodonTable::is_start(&codon));
+            if still_a_start != Some(true) {
+                return Some((Consequence::StartLost, None, None));
+            }
+        }
+
+        None
+    }
+
+    /// The three bases at cDNA position `codon_start` *after* `alt_allele`
+    /// replaces `[cdna_lo, cdna_hi]`, in transcript orientation.
+    ///
+    /// VEP decides whether an indel took the terminator or the initiator away
+    /// by editing the transcript's own sequence and re-reading one codon at a
+    /// fixed offset (`_ins_del_stop_altered`, `_ins_del_start_altered`) rather
+    /// than by arithmetic on the variant's length, and it has to: length
+    /// arithmetic cannot tell a delins that removes the stop codon from one
+    /// that happens to rebuild it, and those are `stop_lost` and
+    /// `stop_retained_variant` respectively.
+    ///
+    /// Read the codon in place instead of materialising the edited sequence.
+    /// This runs inside the per-variant loop and the sequence being edited is
+    /// the whole transcript, so a copy here would be a copy per variant.
+    ///
+    /// `None` when the run loaded no sequences, or when the edited cDNA is too
+    /// short to reach the codon.
+    fn edited_codon(
+        &self,
+        transcript: &Transcript,
+        cdna_lo: u64,
+        cdna_hi: u64,
+        alt_allele: &Allele,
+        codon_start: u64,
+    ) -> Option<[u8; 3]> {
+        let seq = transcript.spliced_seq.as_deref()?.as_bytes();
+        let alt: &[u8] = match alt_allele {
+            Allele::Sequence(bases) => bases,
+            Allele::Deletion => &[],
+            // `*` and the non-variant placeholders assert no alternate
+            // sequence, and a symbolic `<DEL>`/`<DUP>` names one without
+            // spelling it, so neither has an edited codon to read. Structural
+            // alleles are the SV predictor's job.
+            Allele::Missing | Allele::Symbolic(_) => return None,
+        };
+        let alt_len = alt.len() as u64;
+
+        let mut codon = [0u8; 3];
+        for (i, slot) in codon.iter_mut().enumerate() {
+            let pos = codon_start + i as u64; // 1-based, in the *edited* cDNA
+            let base = if pos < cdna_lo {
+                *seq.get((pos - 1) as usize)?
+            } else if pos < cdna_lo + alt_len {
+                // Inside the replacement. The alternate bases arrive in
+                // genomic order, so a reverse-strand transcript reads them
+                // reverse-complemented, not merely complemented in place.
+                let offset = (pos - cdna_lo) as usize;
+                match transcript.strand {
+                    Strand::Forward => alt[offset],
+                    Strand::Reverse => complement(alt[alt.len() - 1 - offset]),
+                }
+            } else {
+                // Past the replacement, so the next original base is the one
+                // after the replaced span rather than the one at `pos`.
+                let original = cdna_hi + (pos - (cdna_lo + alt_len)) + 1;
+                *seq.get((original - 1) as usize)?
+            };
+            *slot = base.to_ascii_uppercase();
+        }
+        Some(codon)
     }
 
     /// Compute amino acids and codons affected by an indel variant.
@@ -982,35 +1199,65 @@ impl ConsequencePredictor {
         var_start <= coding_end && var_end >= coding_start
     }
 
-    fn is_in_5_utr(&self, var_start: u64, _var_end: u64, transcript: &Transcript) -> bool {
-        let coding_start = match transcript.coding_region_start {
-            Some(s) => s,
-            None => return false,
+    /// Does the variant's span reach the untranslated region on the low
+    /// genomic side of the coding region - `[transcript.start, cds_start - 1]`?
+    ///
+    /// Insertions widen the span by the base on either side of the insertion
+    /// point, which is what makes an insertion sitting exactly on the coding
+    /// boundary a UTR variant. VEP carries the same rule as the two special
+    /// cases at the top of `_before_coding` / `_after_coding`.
+    ///
+    /// The span tested is genomic, so it includes any intron lying between the
+    /// transcript's edge and the coding region, and a variant whose only bases
+    /// there are intronic still counts. That is VEP's rule rather than an
+    /// oversight - `_before_coding` and `_after_coding` are plain `overlap`
+    /// calls against the same genomic interval, gated only on the variant
+    /// touching an exon somewhere - and matching it keeps the UTR terms
+    /// comparable with VEP's. It can only add a MODIFIER term next to a
+    /// correctly-derived one, never change the reported impact.
+    fn reaches_low_side_utr(&self, var_start: u64, var_end: u64, transcript: &Transcript) -> bool {
+        let Some(coding_start) = transcript.coding_region_start else {
+            return false;
         };
-        let coding_end = match transcript.coding_region_end {
-            Some(e) => e,
-            None => return false,
-        };
+        if coding_start <= transcript.start {
+            return false; // no UTR on this side
+        }
+        let (lo, hi) = (var_start.min(var_end), var_start.max(var_end));
+        lo < coding_start && hi >= transcript.start
+    }
 
+    /// The same test on the high genomic side - `[cds_end + 1, transcript.end]`.
+    fn reaches_high_side_utr(&self, var_start: u64, var_end: u64, transcript: &Transcript) -> bool {
+        let Some(coding_end) = transcript.coding_region_end else {
+            return false;
+        };
+        if coding_end >= transcript.end {
+            return false; // no UTR on this side
+        }
+        let (lo, hi) = (var_start.min(var_end), var_start.max(var_end));
+        hi > coding_end && lo <= transcript.end
+    }
+
+    /// Does the variant's span reach the 5' UTR? Which genomic side that is
+    /// depends on the strand; the overlap test itself does not.
+    fn overlaps_5_utr(&self, var_start: u64, var_end: u64, transcript: &Transcript) -> bool {
+        if transcript.coding_region_start.is_none() || transcript.coding_region_end.is_none() {
+            return false;
+        }
         match transcript.strand {
-            Strand::Forward => var_start < coding_start && var_start >= transcript.start,
-            Strand::Reverse => var_start > coding_end && var_start <= transcript.end,
+            Strand::Forward => self.reaches_low_side_utr(var_start, var_end, transcript),
+            Strand::Reverse => self.reaches_high_side_utr(var_start, var_end, transcript),
         }
     }
 
-    fn is_in_3_utr(&self, var_start: u64, _var_end: u64, transcript: &Transcript) -> bool {
-        let coding_start = match transcript.coding_region_start {
-            Some(s) => s,
-            None => return false,
-        };
-        let coding_end = match transcript.coding_region_end {
-            Some(e) => e,
-            None => return false,
-        };
-
+    /// Does the variant's span reach the 3' UTR?
+    fn overlaps_3_utr(&self, var_start: u64, var_end: u64, transcript: &Transcript) -> bool {
+        if transcript.coding_region_start.is_none() || transcript.coding_region_end.is_none() {
+            return false;
+        }
         match transcript.strand {
-            Strand::Forward => var_start > coding_end && var_start <= transcript.end,
-            Strand::Reverse => var_start < coding_start && var_start >= transcript.start,
+            Strand::Forward => self.reaches_high_side_utr(var_start, var_end, transcript),
+            Strand::Reverse => self.reaches_low_side_utr(var_start, var_end, transcript),
         }
     }
 }
@@ -1641,5 +1888,469 @@ mod tests {
 
         let tc = &result.transcript_consequences[0];
         assert_eq!(tc.allele_consequences.len(), 2);
+    }
+
+    // ---- variants spanning either end of the CDS (#100) ----
+
+    /// A single-exon transcript carrying its own sequence, so the terminator
+    /// and initiator tests can be decided rather than guessed.
+    ///
+    /// cDNA position `p` sits at genomic `999 + p` on the forward strand and
+    /// `1201 - p` on the reverse one. The layout either way:
+    ///
+    ///   cDNA   1..10    5' UTR
+    ///   cDNA  11..40    CDS - `ATG`, eight `GCT`, `TAA`
+    ///   cDNA  41..201   3' UTR - `CC`, then `TGA`, then filler
+    ///
+    /// The `TGA` three bases into the 3' UTR is deliberate: it lands on the old
+    /// terminator's offset after exactly five cDNA bases are removed, which is
+    /// what separates `stop_lost` from `stop_retained_variant` below.
+    fn make_boundary_transcript(strand: Strand) -> Transcript {
+        let five_utr = "C".repeat(10);
+        let cds = format!("ATG{}TAA", "GCT".repeat(8));
+        let three_utr = format!("CCTGA{}", "G".repeat(156));
+        let spliced = format!("{five_utr}{cds}{three_utr}");
+        assert_eq!(spliced.len(), 201);
+
+        let (coding_region_start, coding_region_end) = match strand {
+            // CDS is cDNA 11..40
+            Strand::Forward => (1010, 1039),
+            Strand::Reverse => (1161, 1190),
+        };
+
+        Transcript {
+            stable_id: "ENST_BOUND".into(),
+            version: None,
+            gene: Gene {
+                stable_id: "ENSG_BOUND".into(),
+                symbol: Some("BOUNDGENE".into()),
+                symbol_source: Some("HGNC".into()),
+                hgnc_id: None,
+                biotype: "protein_coding".into(),
+                chromosome: "chr1".into(),
+                start: 1000,
+                end: 1200,
+                strand,
+            },
+            biotype: "protein_coding".into(),
+            chromosome: "chr1".into(),
+            start: 1000,
+            end: 1200,
+            strand,
+            exons: vec![Exon {
+                stable_id: "E1".into(),
+                start: 1000,
+                end: 1200,
+                strand,
+                phase: -1,
+                end_phase: -1,
+                rank: 1,
+            }],
+            translation: Some(Translation {
+                stable_id: "ENSP_BOUND".into(),
+                genomic_start: coding_region_start,
+                genomic_end: coding_region_end,
+                start_exon_rank: 1,
+                start_exon_offset: 10,
+                end_exon_rank: 1,
+                end_exon_offset: 40,
+            }),
+            cdna_coding_start: Some(11),
+            cdna_coding_end: Some(40),
+            coding_region_start: Some(coding_region_start),
+            coding_region_end: Some(coding_region_end),
+            spliced_seq: Some(spliced),
+            translateable_seq: Some(cds),
+            peptide: None,
+            canonical: true,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: Some(1),
+            appris: None,
+            ccds: None,
+            protein_id: Some("ENSP_BOUND".into()),
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
+        }
+    }
+
+    /// Genomic span of a cDNA range on the given strand, as `(start, end)`.
+    fn genomic_span(strand: Strand, cdna_lo: u64, cdna_hi: u64) -> (u64, u64) {
+        match strand {
+            Strand::Forward => (999 + cdna_lo, 999 + cdna_hi),
+            Strand::Reverse => (1201 - cdna_hi, 1201 - cdna_lo),
+        }
+    }
+
+    fn consequences_for(
+        strand: Strand,
+        cdna_lo: u64,
+        cdna_hi: u64,
+        ref_allele: &Allele,
+        alt_allele: &Allele,
+    ) -> Vec<Consequence> {
+        let predictor = ConsequencePredictor::default();
+        let tr = make_boundary_transcript(strand);
+        let (g_start, g_end) = genomic_span(strand, cdna_lo, cdna_hi);
+        let pos = GenomicPosition::new("chr1", g_start, g_end, Strand::Forward);
+        let result = predictor.predict(
+            &pos,
+            ref_allele,
+            std::slice::from_ref(alt_allele),
+            &[&tr],
+            None,
+        );
+        result.transcript_consequences[0].allele_consequences[0]
+            .consequences
+            .clone()
+    }
+
+    /// The reported case: a delins over the terminator and on into the 3' UTR
+    /// is `stop_lost&3_prime_UTR_variant`, on either strand.
+    ///
+    /// It used to depend on the strand. The region was chosen from the
+    /// variant's genomic *start*, which on the reverse strand is its last base
+    /// in transcript order, so FOXL2's `c.1127_*4delinsCG` matched the 3' UTR
+    /// first and never reached the coding branch at all - MODIFIER where VEP
+    /// says HIGH. On the forward strand the same shape matched the coding
+    /// branch first and lost the UTR term instead.
+    #[test]
+    fn delins_over_the_stop_codon_is_stop_lost_on_either_strand() {
+        for strand in [Strand::Forward, Strand::Reverse] {
+            // cDNA 38..44: the whole terminator plus four 3' UTR bases.
+            let got = consequences_for(
+                strand,
+                38,
+                44,
+                &Allele::from_str("TAACCTG"),
+                &Allele::from_str("AC"),
+            );
+            assert!(
+                got.contains(&Consequence::StopLost),
+                "{strand:?}: expected stop_lost, got {got:?}"
+            );
+            assert!(
+                got.contains(&Consequence::ThreePrimeUtrVariant),
+                "{strand:?}: expected the 3'UTR term alongside it, got {got:?}"
+            );
+            assert_eq!(Consequence::worst_impact(&got), Some(Impact::High));
+        }
+    }
+
+    /// A deletion reaching past the terminator is `stop_retained_variant` when
+    /// the bases that move up into its place still read as a stop, and
+    /// `stop_lost` when they do not. One base of difference decides it, which
+    /// is why the codon is re-read from the sequence rather than inferred from
+    /// the variant's length.
+    #[test]
+    fn a_deletion_past_the_stop_codon_distinguishes_lost_from_retained() {
+        for strand in [Strand::Forward, Strand::Reverse] {
+            // Removing cDNA 38..42 slides the 3' UTR's `TGA` onto the
+            // terminator's offset: still a stop.
+            let retained = consequences_for(
+                strand,
+                38,
+                42,
+                &Allele::from_str("TAACC"),
+                &Allele::Deletion,
+            );
+            assert!(
+                retained.contains(&Consequence::StopRetainedVariant),
+                "{strand:?}: expected stop_retained_variant, got {retained:?}"
+            );
+            assert!(!retained.contains(&Consequence::StopLost));
+
+            // One base less, and `CTG` lands there instead: the stop is gone.
+            let lost =
+                consequences_for(strand, 38, 41, &Allele::from_str("TAAC"), &Allele::Deletion);
+            assert!(
+                lost.contains(&Consequence::StopLost),
+                "{strand:?}: expected stop_lost, got {lost:?}"
+            );
+            assert!(!lost.contains(&Consequence::StopRetainedVariant));
+        }
+    }
+
+    /// The mirror case at the other end of the CDS, which had the same bug with
+    /// the strands swapped: a length change reaching across the initiator is
+    /// `start_lost&5_prime_UTR_variant`.
+    #[test]
+    fn delins_over_the_start_codon_is_start_lost_on_either_strand() {
+        for strand in [Strand::Forward, Strand::Reverse] {
+            // cDNA 9..13: two 5' UTR bases and the first three of the CDS.
+            let got = consequences_for(
+                strand,
+                9,
+                13,
+                &Allele::from_str("CCATG"),
+                &Allele::from_str("TT"),
+            );
+            assert!(
+                got.contains(&Consequence::StartLost),
+                "{strand:?}: expected start_lost, got {got:?}"
+            );
+            assert!(
+                got.contains(&Consequence::FivePrimeUtrVariant),
+                "{strand:?}: expected the 5'UTR term alongside it, got {got:?}"
+            );
+            assert_eq!(Consequence::worst_impact(&got), Some(Impact::High));
+        }
+    }
+
+    /// A length change across the initiator is `start_lost` even when an ATG
+    /// still happens to land on the coding start, because the reading frame
+    /// behind it has moved. PLA2G6's coding sequence begins `ATGGATGTCA`, so a
+    /// `c.-2_3delins` there leaves its second in-frame ATG at the coding start
+    /// while the CDS is four bases shorter.
+    #[test]
+    fn start_lost_does_not_depend_on_the_codon_that_lands_at_the_coding_start() {
+        // Deleting cDNA 9..13 leaves cDNA 14 (`GCT`'s `T`) onward at the coding
+        // start; insert `ATG` so an initiator sits there again.
+        for strand in [Strand::Forward, Strand::Reverse] {
+            let got = consequences_for(
+                strand,
+                9,
+                13,
+                &Allele::from_str("CCATG"),
+                &Allele::from_str("ATG"),
+            );
+            assert!(
+                got.contains(&Consequence::StartLost),
+                "{strand:?}: expected start_lost despite an ATG at the coding start, got {got:?}"
+            );
+        }
+    }
+
+    /// A variant that stays inside one region keeps exactly the term it had, on
+    /// both strands - the additive region tests must not add a second one.
+    #[test]
+    fn variants_inside_a_single_region_gain_no_extra_term() {
+        for strand in [Strand::Forward, Strand::Reverse] {
+            // Wholly in the 3' UTR.
+            let utr3 =
+                consequences_for(strand, 60, 62, &Allele::from_str("GGG"), &Allele::Deletion);
+            assert_eq!(
+                utr3,
+                vec![Consequence::ThreePrimeUtrVariant],
+                "{strand:?}: 3'UTR deletion"
+            );
+
+            // Wholly in the 5' UTR.
+            let utr5 = consequences_for(strand, 3, 5, &Allele::from_str("CCC"), &Allele::Deletion);
+            assert_eq!(
+                utr5,
+                vec![Consequence::FivePrimeUtrVariant],
+                "{strand:?}: 5'UTR deletion"
+            );
+
+            // Wholly inside the CDS, clear of both terminator and initiator.
+            let cds = consequences_for(strand, 20, 22, &Allele::from_str("TGC"), &Allele::Deletion);
+            assert_eq!(
+                cds,
+                vec![Consequence::InframeDeletion],
+                "{strand:?}: in-CDS deletion"
+            );
+        }
+    }
+
+    /// A transcript whose annotation does not claim to carry the terminator
+    /// cannot lose it. VEP checks `cds_end_NF` before its stop predicates and
+    /// `cds_start_NF` before its start ones.
+    #[test]
+    fn a_cds_end_nf_transcript_does_not_report_stop_lost() {
+        let predictor = ConsequencePredictor::default();
+        let mut tr = make_boundary_transcript(Strand::Forward);
+        tr.flags = vec!["cds_end_NF".to_string()];
+        let (g_start, g_end) = genomic_span(Strand::Forward, 38, 44);
+        let pos = GenomicPosition::new("chr1", g_start, g_end, Strand::Forward);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("TAACCTG"),
+            &[Allele::from_str("AC")],
+            &[&tr],
+            None,
+        );
+        let got = &result.transcript_consequences[0].allele_consequences[0].consequences;
+        assert!(
+            !got.contains(&Consequence::StopLost),
+            "cds_end_NF transcript should not report stop_lost, got {got:?}"
+        );
+        assert!(got.contains(&Consequence::ThreePrimeUtrVariant));
+    }
+
+    /// The codon at `codon_start` read the obvious way: materialise the whole
+    /// edited cDNA, then slice. `edited_codon` must agree with this in every
+    /// case; the only reason it does not work this way is that the sequence
+    /// being edited is the whole transcript and the loop runs per variant.
+    fn naive_edited_codon(
+        seq: &str,
+        strand: Strand,
+        cdna_lo: u64,
+        cdna_hi: u64,
+        alt: &Allele,
+        codon_start: u64,
+    ) -> Option<[u8; 3]> {
+        let bytes = seq.as_bytes();
+        let alt_tx: Vec<u8> = match alt {
+            Allele::Sequence(b) => match strand {
+                Strand::Forward => b.clone(),
+                Strand::Reverse => b.iter().rev().map(|&x| complement(x)).collect(),
+            },
+            Allele::Deletion => Vec::new(),
+            _ => return None,
+        };
+        let lo = (cdna_lo - 1) as usize;
+        let hi = cdna_hi as usize; // exclusive
+        if hi > bytes.len() || lo > hi {
+            return None;
+        }
+        let mut edited: Vec<u8> = Vec::with_capacity(bytes.len());
+        edited.extend_from_slice(&bytes[..lo]);
+        edited.extend_from_slice(&alt_tx);
+        edited.extend_from_slice(&bytes[hi..]);
+
+        let start = (codon_start - 1) as usize;
+        if start + 3 > edited.len() {
+            return None;
+        }
+        let mut out = [0u8; 3];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = edited[start + i].to_ascii_uppercase();
+        }
+        Some(out)
+    }
+
+    /// `edited_codon` reads a codon out of the edited cDNA without building it.
+    /// Check it against the build-it-and-slice version over a wide sweep of
+    /// shapes, on both strands, including the ones the boundary path never
+    /// generates - the arithmetic should not depend on that.
+    #[test]
+    fn edited_codon_agrees_with_building_the_edited_sequence() {
+        let predictor = ConsequencePredictor::default();
+        // A deterministic xorshift, so a failure is reproducible.
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+
+        let bases = *b"ACGT";
+        let mut checked = 0usize;
+        for strand in [Strand::Forward, Strand::Reverse] {
+            let mut tr = make_boundary_transcript(strand);
+            let seq = tr.spliced_seq.clone().unwrap();
+            let seq_len = seq.len() as u64;
+
+            for _ in 0..4_000 {
+                let lo = 1 + next() % (seq_len - 1);
+                let span = next() % 12; // 0..11 extra bases
+                let hi = (lo + span).min(seq_len);
+                let alt_len = (next() % 6) as usize; // 0 => a pure deletion
+                let alt = if alt_len == 0 {
+                    Allele::Deletion
+                } else {
+                    Allele::Sequence((0..alt_len).map(|_| bases[(next() % 4) as usize]).collect())
+                };
+                let codon_start = 1 + next() % (seq_len - 2);
+
+                let got = predictor.edited_codon(&tr, lo, hi, &alt, codon_start);
+                let want = naive_edited_codon(&seq, strand, lo, hi, &alt, codon_start);
+                assert_eq!(
+                    got, want,
+                    "{strand:?}: lo={lo} hi={hi} alt={alt:?} codon_start={codon_start}"
+                );
+                checked += 1;
+            }
+
+            // And with no sequence loaded there is nothing to read.
+            tr.spliced_seq = None;
+            assert_eq!(
+                predictor.edited_codon(&tr, 10, 12, &Allele::Deletion, 11),
+                None,
+                "a transcript with no sequence has no edited codon"
+            );
+        }
+        assert_eq!(checked, 8_000);
+    }
+
+    /// A CDS annotated as beginning part-way through a codon has no complete
+    /// initiator, so nothing at its start can be `start_lost`. Without the
+    /// phase guard every length-changing variant reaching that end would be,
+    /// because the three bases there never read as ATG.
+    #[test]
+    fn a_phase_offset_transcript_does_not_report_start_lost() {
+        let predictor = ConsequencePredictor::default();
+        let mut tr = make_boundary_transcript(Strand::Forward);
+        tr.codon_table_start_phase = 2;
+        let (g_start, g_end) = genomic_span(Strand::Forward, 9, 13);
+        let pos = GenomicPosition::new("chr1", g_start, g_end, Strand::Forward);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("CCATG"),
+            &[Allele::from_str("TT")],
+            &[&tr],
+            None,
+        );
+        let got = &result.transcript_consequences[0].allele_consequences[0].consequences;
+        assert!(
+            !got.contains(&Consequence::StartLost),
+            "a phase-offset CDS has no initiator to lose, got {got:?}"
+        );
+        // The same transcript with a complete initiator does report it, so the
+        // guard is what makes the difference and not the variant.
+        let tr0 = make_boundary_transcript(Strand::Forward);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("CCATG"),
+            &[Allele::from_str("TT")],
+            &[&tr0],
+            None,
+        );
+        assert!(result.transcript_consequences[0].allele_consequences[0]
+            .consequences
+            .contains(&Consequence::StartLost));
+    }
+
+    /// An insertion sitting exactly on either coding boundary is a UTR variant
+    /// and nothing more. Its span is the two bases it sits between, so it never
+    /// deletes a codon, and the boundary path must not claim one was lost.
+    #[test]
+    fn an_insertion_on_a_coding_boundary_reports_only_the_utr_term() {
+        let predictor = ConsequencePredictor::default();
+        for strand in [Strand::Forward, Strand::Reverse] {
+            let tr = make_boundary_transcript(strand);
+            // The initiator is cDNA 11 and the terminator ends at cDNA 40.
+            for (cdna_flank, forbidden) in
+                [(11u64, Consequence::StartLost), (41, Consequence::StopLost)]
+            {
+                let genomic = match strand {
+                    Strand::Forward => 999 + cdna_flank,
+                    Strand::Reverse => 1201 - cdna_flank,
+                };
+                // Ensembl's zero-length interval: end = start - 1.
+                let pos = GenomicPosition::new("chr1", genomic, genomic - 1, Strand::Forward);
+                let result = predictor.predict(
+                    &pos,
+                    &Allele::Deletion,
+                    &[Allele::from_str("TTT")],
+                    &[&tr],
+                    None,
+                );
+                let got = &result.transcript_consequences[0].allele_consequences[0].consequences;
+                assert!(
+                    !got.contains(&forbidden),
+                    "{strand:?} insertion at cDNA {cdna_flank}: unexpected {forbidden:?} in {got:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/fastvep-hgvs/src/coding.rs
+++ b/crates/fastvep-hgvs/src/coding.rs
@@ -1,5 +1,56 @@
 use fastvep_core::Allele;
 
+/// Format one cDNA position as an HGVS `c.` coordinate.
+///
+/// Three numbering schemes meet on a coding transcript: `-N` counting back from
+/// the initiator, `N` inside the CDS, `*N` counting on from the terminator.
+/// Which one applies is a property of the *position*, not of the variant, and
+/// deciding it per variant is what let a span that crosses a boundary be
+/// numbered in the wrong scheme: a delins over FOXL2's stop codon came out
+/// `c.1127_1135`, naming four bases past the end of an 1131-base CDS, where
+/// VEP writes `c.1127_*4` (#100).
+///
+/// `start_phase` is Ensembl's offset for a CDS whose first codon is incomplete,
+/// and applies only inside the CDS - there is no position 0, so the 5' UTR
+/// numbering has neither the `+ 1` nor the phase.
+fn cds_coord(
+    cdna_pos: u64,
+    coding_start: u64,
+    coding_end: Option<u64>,
+    start_phase: u64,
+) -> String {
+    if cdna_pos < coding_start {
+        return format!("{}", cdna_pos as i64 - coding_start as i64);
+    }
+    if let Some(coding_end) = coding_end {
+        if cdna_pos > coding_end {
+            return format!("*{}", cdna_pos - coding_end);
+        }
+    }
+    format!(
+        "{}",
+        cdna_pos as i64 - coding_start as i64 + 1 + start_phase as i64
+    )
+}
+
+/// Format a cDNA span as an HGVS `c.` coordinate or coordinate range,
+/// collapsing a single-position span to one coordinate.
+fn cds_span(
+    cdna_start: u64,
+    cdna_end: u64,
+    coding_start: u64,
+    coding_end: Option<u64>,
+    start_phase: u64,
+) -> String {
+    let start = cds_coord(cdna_start, coding_start, coding_end, start_phase);
+    let end = cds_coord(cdna_end, coding_start, coding_end, start_phase);
+    if start == end {
+        start
+    } else {
+        format!("{}_{}", start, end)
+    }
+}
+
 /// Generate HGVSc (coding DNA) notation.
 ///
 /// Uses the transcript ID as the reference and cDNA position numbering.
@@ -47,38 +98,7 @@ pub fn hgvsc_with_seq(
 ) -> Option<String> {
     let prefix = format!("{}:c.", transcript_id);
 
-    // Convert cDNA position to CDS position (relative to ATG)
-    // For 5'UTR (before ATG): position = cdna - coding_start (negative, no +1)
-    // For coding region: position = cdna - coding_start + 1 + start_phase (1-based)
-    // start_phase accounts for incomplete start codons (Ensembl convention)
-    let cds_pos_start = if (cdna_start as i64) < (coding_start as i64) {
-        cdna_start as i64 - coding_start as i64 // 5'UTR: no phase
-    } else {
-        cdna_start as i64 - coding_start as i64 + 1 + start_phase as i64 // CDS: with phase
-    };
-    let cds_pos_end = if (cdna_end as i64) < (coding_start as i64) {
-        cdna_end as i64 - coding_start as i64
-    } else {
-        cdna_end as i64 - coding_start as i64 + 1 + start_phase as i64
-    };
-
-    let pos_str = if cds_pos_start < 0 {
-        // 5' UTR: negative positions
-        format!("{}", cds_pos_start)
-    } else if coding_end.is_some_and(|ce| cdna_start > ce) {
-        // 3' UTR: c.*N notation
-        let utr_offset_start = cdna_start - coding_end.unwrap();
-        if cdna_start == cdna_end {
-            format!("*{}", utr_offset_start)
-        } else {
-            let utr_offset_end = cdna_end - coding_end.unwrap();
-            format!("*{}_*{}", utr_offset_start, utr_offset_end)
-        }
-    } else if cds_pos_start == cds_pos_end {
-        format!("{}", cds_pos_start)
-    } else {
-        format!("{}_{}", cds_pos_start, cds_pos_end)
-    };
+    let pos_str = cds_span(cdna_start, cdna_end, coding_start, coding_end, start_phase);
 
     let notation = match (ref_allele, alt_allele) {
         // SNV
@@ -91,8 +111,7 @@ pub fn hgvsc_with_seq(
             )
         }
         // Deletion — apply HGVS 3' shifting in repetitive regions
-        (Allele::Sequence(ref_bases), Allele::Deletion) => {
-            let del_len = ref_bases.len();
+        (Allele::Sequence(_), Allele::Deletion) => {
             // Try 3' shifting if we have the transcript sequence
             let (shifted_start, shifted_end) = if let Some(seq) = spliced_seq {
                 let seq_bytes = seq.as_bytes();
@@ -109,54 +128,19 @@ pub fn hgvsc_with_seq(
             } else {
                 (cdna_start, cdna_end)
             };
-            // Recompute positions for shifted coordinates, with UTR awareness
-            let shifted_pos = if coding_end.is_some_and(|ce| shifted_start > ce) {
-                // 3'UTR deletion
-                let utr_s = shifted_start - coding_end.unwrap();
-                if del_len == 1 {
-                    format!("*{}", utr_s)
-                } else {
-                    let utr_e = shifted_end - coding_end.unwrap();
-                    format!("*{}_*{}", utr_s, utr_e)
-                }
-            } else if (shifted_start as i64) < (coding_start as i64) {
-                // 5'UTR deletion
-                let cds_s = shifted_start as i64 - coding_start as i64;
-                if del_len == 1 {
-                    format!("{}", cds_s)
-                } else {
-                    let cds_e = shifted_end as i64 - coding_start as i64;
-                    if coding_end.is_some_and(|ce| shifted_end > ce) {
-                        // Spans into 3'UTR
-                        let utr_e = shifted_end - coding_end.unwrap();
-                        format!("{}_*{}", cds_s, utr_e)
-                    } else {
-                        format!("{}_{}", cds_s, cds_e)
-                    }
-                }
-            } else {
-                let cds_s = shifted_start as i64 - coding_start as i64 + 1;
-                if del_len == 1 {
-                    format!("{}", cds_s)
-                } else {
-                    if coding_end.is_some_and(|ce| shifted_end > ce) {
-                        // Spans from CDS into 3'UTR
-                        let utr_e = shifted_end - coding_end.unwrap();
-                        format!("{}_*{}", cds_s, utr_e)
-                    } else {
-                        let cds_e = shifted_end as i64 - coding_start as i64 + 1;
-                        format!("{}_{}", cds_s, cds_e)
-                    }
-                }
-            };
+            let shifted_pos = cds_span(
+                shifted_start,
+                shifted_end,
+                coding_start,
+                coding_end,
+                start_phase,
+            );
             format!("{}{}del", prefix, shifted_pos)
         }
         // Insertion — normalize coordinates: ensure ins_before < ins_after
         (Allele::Deletion, Allele::Sequence(alt_bases)) => {
             let ins_before_cdna = cdna_start.min(cdna_end); // base before insertion
             let ins_after_cdna = cdna_start.max(cdna_end); // base after insertion
-            let ins_before_cds = cds_pos_start.min(cds_pos_end);
-            let ins_after_cds = cds_pos_start.max(cds_pos_end);
 
             // Check for duplication: if inserted bases match the preceding OR following sequence
             let is_dup = if let Some(seq) = spliced_seq {
@@ -193,42 +177,27 @@ pub fn hgvsc_with_seq(
                 false
             };
 
-            // Position of the base before insertion in CDS or UTR coordinates
-            let ins_pos_str = if coding_end.is_some_and(|ce| ins_before_cdna > ce) {
-                // 3'UTR: both flanking positions are in 3'UTR
-                let utr_before = ins_before_cdna - coding_end.unwrap();
-                let utr_after = ins_after_cdna - coding_end.unwrap();
-                if is_dup {
-                    let ins_len = alt_bases.len() as u64;
-                    if ins_len == 1 {
-                        format!("*{}", utr_before)
-                    } else {
-                        format!("*{}_*{}", utr_before - ins_len + 1, utr_before)
-                    }
-                } else {
-                    format!("*{}_*{}", utr_before, utr_after)
-                }
-            } else if ins_before_cds < 0 {
-                // 5'UTR insertion
-                if is_dup {
-                    let ins_len = alt_bases.len() as i64;
-                    if ins_len == 1 {
-                        format!("{}", ins_before_cds)
-                    } else {
-                        format!("{}_{}", ins_before_cds - ins_len + 1, ins_before_cds)
-                    }
-                } else {
-                    format!("{}_{}", ins_before_cds, ins_after_cds)
-                }
-            } else if is_dup {
-                let ins_len = alt_bases.len() as i64;
-                if ins_len == 1 {
-                    format!("{}", ins_before_cds)
-                } else {
-                    format!("{}_{}", ins_before_cds - ins_len + 1, ins_before_cds)
-                }
+            // A duplication is written over the duplicated bases, which end at
+            // the base before the insertion point. A plain insertion is written
+            // over the two bases it sits between, and those two can straddle
+            // the end of the CDS, so both spans go through the same numbering.
+            let ins_pos_str = if is_dup {
+                let ins_len = alt_bases.len() as u64;
+                cds_span(
+                    ins_before_cdna.saturating_sub(ins_len.saturating_sub(1)),
+                    ins_before_cdna,
+                    coding_start,
+                    coding_end,
+                    start_phase,
+                )
             } else {
-                format!("{}_{}", ins_before_cds, ins_after_cds)
+                cds_span(
+                    ins_before_cdna,
+                    ins_after_cdna,
+                    coding_start,
+                    coding_end,
+                    start_phase,
+                )
             };
 
             if is_dup {
@@ -723,5 +692,135 @@ mod tests {
             &Allele::Sequence(b"G".to_vec()),
         );
         assert_eq!(result, Some("ENST00000472807.5:n.100A>G".to_string()));
+    }
+
+    // ---- spans that cross a CDS boundary (#100) ----
+
+    /// A span that starts inside the CDS and ends past the terminator numbers
+    /// each end in its own scheme.
+    ///
+    /// It used to number both ends as CDS positions, so FOXL2's
+    /// `c.1127_*4delinsCG` came out `c.1127_1135` - four bases past the end of
+    /// an 1131-base CDS, a coordinate the transcript does not have.
+    #[test]
+    fn a_delins_reaching_past_the_terminator_numbers_its_end_from_the_stop() {
+        // CDS is cDNA 51..1181 (1131 bases). cDNA 1177..1185 spans c.1127
+        // to four bases into the 3' UTR.
+        let result = hgvsc(
+            "ENST00000648323.1",
+            1177,
+            1185,
+            &Allele::Sequence(b"GCTCTCAGA".to_vec()),
+            &Allele::Sequence(b"CG".to_vec()),
+            51,
+            Some(1181),
+        );
+        assert_eq!(
+            result,
+            Some("ENST00000648323.1:c.1127_*4delinsCG".to_string())
+        );
+    }
+
+    /// The mirror at the other end: a span starting in the 5' UTR keeps its end
+    /// coordinate, which used to be dropped entirely (`c.-4delinsTT`).
+    #[test]
+    fn a_delins_reaching_out_of_the_five_prime_utr_keeps_both_coordinates() {
+        // CDS starts at cDNA 149. cDNA 145..153 spans c.-4 to c.5.
+        let result = hgvsc(
+            "ENST00000383165.4",
+            145,
+            153,
+            &Allele::Sequence(b"GGAGATGAC".to_vec()),
+            &Allele::Sequence(b"TT".to_vec()),
+            149,
+            Some(676),
+        );
+        assert_eq!(result, Some("ENST00000383165.4:c.-4_5delinsTT".to_string()));
+    }
+
+    /// A deletion whose end falls inside the CDS numbers that end as a CDS
+    /// position. The 5' UTR branch used to reuse its own formula for both ends,
+    /// leaving the end one too low - `c.-9_1del` for a span ending at c.2.
+    #[test]
+    fn a_deletion_from_the_five_prime_utr_into_the_cds_numbers_its_end_in_the_cds() {
+        // CDS starts at cDNA 11; cDNA 2..12 spans c.-9 to c.2.
+        let result = hgvsc(
+            "ENST00000001",
+            2,
+            12,
+            &Allele::Sequence(b"CCCATACCTCG".to_vec()),
+            &Allele::Deletion,
+            11,
+            Some(100),
+        );
+        assert_eq!(result, Some("ENST00000001:c.-9_2del".to_string()));
+    }
+
+    /// There is no `c.0`, so a span reaching back across the initiator has to
+    /// skip it. `c.-1_1` names two positions where three bases were changed.
+    #[test]
+    fn a_span_across_the_initiator_skips_the_nonexistent_position_zero() {
+        // CDS starts at cDNA 11; cDNA 9..11 spans c.-2, c.-1, c.1.
+        let result = hgvsc(
+            "ENST00000001",
+            9,
+            11,
+            &Allele::Sequence(b"CCA".to_vec()),
+            &Allele::Deletion,
+            11,
+            Some(100),
+        );
+        assert_eq!(result, Some("ENST00000001:c.-2_1del".to_string()));
+    }
+
+    /// The last base of the CDS is a CDS position, not `*0`. The 3' UTR branch
+    /// used to reach that coordinate by arithmetic and emit `c.*0_*1`.
+    #[test]
+    fn the_last_cds_base_is_never_numbered_star_zero() {
+        // CDS is cDNA 11..40; cDNA 40..41 straddles the terminator's last base
+        // and the first 3' UTR base.
+        let result = hgvsc(
+            "ENST00000001",
+            40,
+            41,
+            &Allele::Deletion,
+            &Allele::Sequence(b"AC".to_vec()),
+            11,
+            Some(40),
+        );
+        assert_eq!(result, Some("ENST00000001:c.30_*1insAC".to_string()));
+    }
+
+    /// A CDS position carries Ensembl's phase offset for an incomplete first
+    /// codon. Deletions used to skip it while every other path applied it, so
+    /// the same base was `c.716` as a substitution and `c.715` as a deletion.
+    #[test]
+    fn a_deletion_carries_the_same_phase_offset_as_a_substitution() {
+        let args = (100u64, 100u64, 51u64, Some(1000u64), 2u64);
+        let (cdna_s, cdna_e, coding_start, coding_end, phase) = args;
+        let sub = hgvsc_with_seq(
+            "ENST00000001",
+            cdna_s,
+            cdna_e,
+            &Allele::Sequence(b"G".to_vec()),
+            &Allele::Sequence(b"A".to_vec()),
+            coding_start,
+            coding_end,
+            None,
+            phase,
+        );
+        let del = hgvsc_with_seq(
+            "ENST00000001",
+            cdna_s,
+            cdna_e,
+            &Allele::Sequence(b"G".to_vec()),
+            &Allele::Deletion,
+            coding_start,
+            coding_end,
+            None,
+            phase,
+        );
+        assert_eq!(sub, Some("ENST00000001:c.52G>A".to_string()));
+        assert_eq!(del, Some("ENST00000001:c.52del".to_string()));
     }
 }

--- a/crates/fastvep-sa/src/chunk.rs
+++ b/crates/fastvep-sa/src/chunk.rs
@@ -6,6 +6,93 @@
 use crate::fields::{Field, FieldType};
 use crate::kmer16::{LongVariant, OtherVariant};
 
+/// The JSON-blob payloads of a chunk: one buffer holding every row's text, plus
+/// the offsets that delimit the rows.
+///
+/// These were a `Vec<String>` - one heap allocation and one copy per row. The
+/// cost is paid per *stored* row, not per queried one, and a chunk holds every
+/// row in its megabase of the genome. For a sparse source that is a handful; for
+/// the densest ones it is the whole neighbourhood. SpliceAI scores three
+/// alternates at essentially every position of a gene body, which puts on the
+/// order of a million records in one chunk, so a single lookup allocated a
+/// million strings, copied the entire decompressed blob into them, read one, and
+/// dropped the rest (#101). Measured on a 3M-row-per-chunk source, 300 scattered
+/// queries took 5.9s and 3.8 GB of resident memory.
+///
+/// Indexing the buffer instead costs eight bytes a row and no allocation, and
+/// the text is kept exactly as it was decompressed, so what a query returns is
+/// byte-for-byte what it returned before.
+#[derive(Debug, Default, Clone)]
+pub struct JsonBlobs {
+    text: String,
+    /// `(start, end)` byte offsets into `text`, one per row.
+    ///
+    /// `u32` is sound because `reader_v2::MAX_JSON_BLOB_DECOMPRESSED` rejects a
+    /// chunk blob well before 4 GiB, and that check runs before this is built.
+    rows: Vec<(u32, u32)>,
+}
+
+impl JsonBlobs {
+    /// Index the newline-separated rows of a decompressed blob entry.
+    ///
+    /// Row boundaries come from [`str::lines`], so a `\r\n` archive is split the
+    /// same way the `Vec<String>` build split it.
+    pub fn from_text(text: String) -> Self {
+        debug_assert!(
+            text.len() <= u32::MAX as usize,
+            "blob buffer exceeds the u32 offsets this type stores"
+        );
+        let base = text.as_ptr() as usize;
+        let rows: Vec<(u32, u32)> = text
+            .lines()
+            .map(|line| {
+                // `lines()` yields subslices of `text`, so the difference is an
+                // offset into it. Integers only, so the borrow ends here.
+                let start = line.as_ptr() as usize - base;
+                (start as u32, (start + line.len()) as u32)
+            })
+            .collect();
+        Self { text, rows }
+    }
+
+    /// Build from rows already in hand, for callers and tests that have them
+    /// separated rather than as one buffer.
+    pub fn from_rows<I, S>(rows: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut text = String::new();
+        for (i, row) in rows.into_iter().enumerate() {
+            if i > 0 {
+                text.push('\n');
+            }
+            text.push_str(row.as_ref());
+        }
+        Self::from_text(text)
+    }
+
+    /// Number of rows.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// The blob for one row, borrowed out of the buffer.
+    pub fn get(&self, idx: usize) -> Option<&str> {
+        let &(start, end) = self.rows.get(idx)?;
+        self.text.get(start as usize..end as usize)
+    }
+
+    /// Resident footprint, for the chunk cache's byte budget.
+    pub fn heap_bytes(&self) -> usize {
+        self.text.len() + self.rows.len() * std::mem::size_of::<(u32, u32)>()
+    }
+}
+
 /// A loaded genomic chunk (~1MB region) with sorted variant keys and values.
 pub struct Chunk {
     /// Sorted Var32-encoded variant keys for binary search.
@@ -25,7 +112,7 @@ pub struct Chunk {
     /// non-JsonBlob fields when indexing into this array.
     pub values: Vec<Vec<u32>>,
     /// Optional JSON blob strings for JsonBlob fields.
-    pub json_blobs: Option<Vec<String>>,
+    pub json_blobs: Option<JsonBlobs>,
 }
 
 impl Chunk {
@@ -114,17 +201,17 @@ impl Chunk {
 
         for (fi, field) in fields.iter().enumerate() {
             if field.ftype == FieldType::JsonBlob {
-                if let Some(ref blobs) = self.json_blobs {
-                    if idx < blobs.len() && !blobs[idx].is_empty() {
+                if let Some(blob) = self.json_blobs.as_ref().and_then(|b| b.get(idx)) {
+                    if !blob.is_empty() {
                         // An empty alias marks a whole-record blob (see
                         // `writer_v2::raw_json_blob_fields`): the stored blob is
                         // the complete record object, so emit it verbatim rather
                         // than nesting it under a key. Such sources carry this
                         // as their sole field, so returning here is correct.
                         if field.alias.is_empty() {
-                            return blobs[idx].clone();
+                            return blob.to_string();
                         }
-                        parts.push(format!("\"{}\":{}", field.alias, blobs[idx]));
+                        parts.push(format!("\"{}\":{}", field.alias, blob));
                     }
                 }
                 continue;
@@ -270,7 +357,7 @@ mod tests {
         chunk.var32s = vec![var32::encode(100, b"A", b"G").unwrap()];
         // Two non-JsonBlob columns, in field order: AF then AC.
         chunk.values = vec![vec![1234], vec![42]];
-        chunk.json_blobs = Some(vec![r#"{"k":1}"#.to_string()]);
+        chunk.json_blobs = Some(JsonBlobs::from_rows([r#"{"k":1}"#]));
 
         let json = chunk.reconstruct_json(0, &fields, &[]);
         assert!(json.contains("\"af\":"), "missing af in: {}", json);
@@ -300,7 +387,7 @@ mod tests {
         let mut chunk = Chunk::empty();
         chunk.var32s = vec![var32::encode(100, b"A", b"G").unwrap()];
         let blob = r#"{"significance":["Pathogenic"],"reviewStatus":"criteria_provided"}"#;
-        chunk.json_blobs = Some(vec![blob.to_string()]);
+        chunk.json_blobs = Some(JsonBlobs::from_rows([blob]));
 
         let json = chunk.reconstruct_json(0, &fields, &[]);
         assert_eq!(json, blob, "whole-record blob must round-trip verbatim");

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -20,7 +20,7 @@
 //! before the first variant was annotated. They are now resolved lazily, on the
 //! first read of each entry, when the page is about to be touched anyway.
 
-use crate::chunk::{delta_decode, Chunk};
+use crate::chunk::{delta_decode, Chunk, JsonBlobs};
 use crate::fields::{Field, FieldType};
 use crate::kmer16::{LongVariant, OtherVariant};
 use crate::var32;
@@ -42,6 +42,11 @@ use std::sync::{Arc, Mutex, OnceLock};
 /// Hard cap on a per-chunk zstd-decompressed JSON blob (256 MiB). Defends
 /// against zstd bombs in maliciously crafted .osa2 files.
 const MAX_JSON_BLOB_DECOMPRESSED: usize = 256 * 1024 * 1024;
+
+/// `JsonBlobs` delimits its rows with `u32` offsets into the decompressed
+/// buffer, and this cap is what keeps that in range. Tie the two together here
+/// so raising the cap past 4 GiB cannot silently truncate them.
+const _: () = assert!(MAX_JSON_BLOB_DECOMPRESSED <= u32::MAX as usize);
 
 /// Soft cap on cached chunk *entries*; the byte budget is the real gate.
 const CHUNK_CACHE_MAX_ENTRIES: usize = 4096;
@@ -79,11 +84,7 @@ fn chunk_bytes(c: &Chunk) -> usize {
         .iter()
         .map(|col| col.len() * std::mem::size_of::<u32>())
         .sum();
-    let blobs: usize = c.json_blobs.as_ref().map_or(0, |b| {
-        b.iter()
-            .map(|s| s.len() + std::mem::size_of::<String>())
-            .sum()
-    });
+    let blobs: usize = c.json_blobs.as_ref().map_or(0, JsonBlobs::heap_bytes);
     v32.saturating_add(longs)
         .saturating_add(others)
         .saturating_add(vals)
@@ -450,8 +451,7 @@ impl Osa2Reader {
                         MAX_JSON_BLOB_DECOMPRESSED
                     );
                 }
-                let text = String::from_utf8(decompressed)?;
-                Some(text.lines().map(|l| l.to_string()).collect())
+                Some(JsonBlobs::from_text(String::from_utf8(decompressed)?))
             }
             None => None,
         };

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -51,6 +51,11 @@ const _: () = assert!(MAX_JSON_BLOB_DECOMPRESSED <= u32::MAX as usize);
 /// Soft cap on cached chunk *entries*; the byte budget is the real gate.
 const CHUNK_CACHE_MAX_ENTRIES: usize = 4096;
 
+/// How many distinct failing chunks a reader remembers. One entry is a key and
+/// a shared message, so this is kilobytes; the point of the cap is only that a
+/// wholly unreadable archive cannot grow the map without bound.
+const MAX_REMEMBERED_CHUNK_FAILURES: usize = 1 << 16;
+
 /// Monotonic id per reader so chunks are namespaced in the shared cache
 /// (two shards can share a `chunk_id` without colliding). Never reused.
 static NEXT_READER_ID: AtomicU64 = AtomicU64::new(0);
@@ -202,6 +207,17 @@ pub struct Osa2Reader {
     /// `chrom_aliases`, which allocates a `Vec<String>`, on every query of every
     /// variant.
     chrom_lookup: HashMap<String, String>,
+    /// Chunks whose build failed, and why.
+    ///
+    /// A chunk that cannot be decompressed now cannot be decompressed later
+    /// either, but every variant in its genomic width asked again - and each
+    /// attempt paid the full decompression before failing. One unreadable
+    /// megabase was enough to make a run look hung rather than slow: 200,000
+    /// variants over three such chunks did not finish in ten minutes (#101).
+    ///
+    /// Bounded by `MAX_REMEMBERED_CHUNK_FAILURES`; past that the verdict simply
+    /// is not remembered, which is slow but still correct.
+    failed_chunks: Mutex<HashMap<ChunkKey, Arc<str>>>,
 }
 
 impl Osa2Reader {
@@ -315,6 +331,7 @@ impl Osa2Reader {
             entries,
             reader_id: NEXT_READER_ID.fetch_add(1, Ordering::Relaxed),
             local_cache: local_budget.map(|b| Mutex::new(ChunkCache::new(b))),
+            failed_chunks: Mutex::new(HashMap::new()),
             chunk_load_count: AtomicU64::new(0),
             header_read_count,
             metadata,
@@ -330,6 +347,17 @@ impl Osa2Reader {
     /// by benchmarks/tests to detect chunk-cache thrashing.
     pub fn chunk_load_count(&self) -> u64 {
         self.chunk_load_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of distinct chunks this reader has found unreadable. Each is
+    /// attempted once and the verdict remembered, so this is also the number of
+    /// failed build attempts - a run whose supplementary annotations came back
+    /// thin can tell a database problem from a genuine absence of records.
+    pub fn chunk_failure_count(&self) -> u64 {
+        self.failed_chunks
+            .lock()
+            .map(|f| f.len() as u64)
+            .unwrap_or(0)
     }
 
     /// Number of ZIP entries in the archive. Startup-cost diagnostic (issue
@@ -487,8 +515,26 @@ impl Osa2Reader {
             }
         }
 
+        // A chunk already known to be unreadable is not retried. Without this
+        // the failure costs a full decompression per variant rather than once.
+        if let Ok(failed) = self.failed_chunks.lock() {
+            if let Some(why) = failed.get(&key) {
+                return Err(anyhow::anyhow!("{}", why));
+            }
+        }
+
         // Build without holding the lock (lock-free mmap reads + inflate).
-        let chunk = Arc::new(self.build_chunk(chrom, chunk_id)?);
+        let chunk = match self.build_chunk(chrom, chunk_id) {
+            Ok(chunk) => Arc::new(chunk),
+            Err(e) => {
+                if let Ok(mut failed) = self.failed_chunks.lock() {
+                    if failed.len() < MAX_REMEMBERED_CHUNK_FAILURES {
+                        failed.insert(key, Arc::from(e.to_string().as_str()));
+                    }
+                }
+                return Err(e);
+            }
+        };
         self.chunk_load_count.fetch_add(1, Ordering::Relaxed);
         let bytes = chunk_bytes(&chunk);
 

--- a/crates/fastvep-sa/src/reader_v2.rs
+++ b/crates/fastvep-sa/src/reader_v2.rs
@@ -41,6 +41,12 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 /// Hard cap on a per-chunk zstd-decompressed JSON blob (256 MiB). Defends
 /// against zstd bombs in maliciously crafted .osa2 files.
+///
+/// A legitimate file can reach it too, which is the more likely reason to see
+/// it: a chunk holds every record in its genomic width, and a blob-encoded
+/// source that scores nearly every base puts hundreds of megabytes of JSON in
+/// one megabase. That is a chunk-width problem rather than a bomb, so the error
+/// says which of the two it is looking at and what to do about it.
 const MAX_JSON_BLOB_DECOMPRESSED: usize = 256 * 1024 * 1024;
 
 /// `JsonBlobs` delimits its rows with `u32` offsets into the decompressed
@@ -474,9 +480,23 @@ impl Osa2Reader {
                     .take(MAX_JSON_BLOB_DECOMPRESSED as u64 + 1)
                     .read_to_end(&mut decompressed)?;
                 if decompressed.len() > MAX_JSON_BLOB_DECOMPRESSED {
+                    // Name the chunk and the remedy. Every lookup in this
+                    // megabase fails while this holds, so a user who only sees
+                    // the limit has no way to tell a too-wide chunk from a
+                    // corrupt file (#101).
+                    let width = 1u64 << self.metadata.chunk_bits;
                     anyhow::bail!(
-                        "JSON blob decompressed size exceeds limit ({} bytes)",
-                        MAX_JSON_BLOB_DECOMPRESSED
+                        "{}: the JSON blobs for chunk {}/{} decompress past the {} MiB limit. \
+                         This chunk spans {} bases, and one record cannot be read without \
+                         decompressing all of them, so every lookup in it fails. Rebuild the \
+                         database with narrower chunks - `fastvep sa-convert --chunk-bits 16` \
+                         for a source this dense, or `fastvep sa-build --format osa2` if the \
+                         source has a column-oriented encoder.",
+                        self.sa_metadata.name,
+                        chrom,
+                        chunk_id,
+                        MAX_JSON_BLOB_DECOMPRESSED / (1024 * 1024),
+                        width,
                     );
                 }
                 Some(JsonBlobs::from_text(String::from_utf8(decompressed)?))

--- a/crates/fastvep-sa/tests/blob_chunk_allocations.rs
+++ b/crates/fastvep-sa/tests/blob_chunk_allocations.rs
@@ -1,0 +1,136 @@
+//! Pins the cost of loading a JSON-blob chunk to the chunk, not to its rows.
+//!
+//! A chunk holds every record in its genomic width, and reading one of them
+//! used to build a `String` per row - one heap allocation and one copy each,
+//! paid on the way to returning a single record. For the blob-encoded form of a
+//! source that scores nearly every base that is hundreds of thousands of
+//! allocations per lookup (#101).
+//!
+//! This file installs a counting global allocator, so it deliberately holds
+//! exactly ONE test: `cargo test` runs the tests in a binary concurrently, and a
+//! second test allocating on another thread would be counted here.
+
+use fastvep_cache::annotation::AnnotationProvider;
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2Writer};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn allocations_during<F: FnOnce()>(f: F) -> usize {
+    let before = ALLOCS.load(Ordering::Relaxed);
+    f();
+    ALLOCS.load(Ordering::Relaxed) - before
+}
+
+/// A whole-record blob field: empty alias, so `reconstruct_json` returns the
+/// stored object verbatim. This is what `sa-convert` writes.
+fn whole_record_blob_field() -> Vec<Field> {
+    vec![Field {
+        field: String::new(),
+        alias: String::new(),
+        ftype: FieldType::JsonBlob,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+const ROWS: u32 = 20_000;
+
+#[test]
+fn loading_a_blob_chunk_does_not_allocate_per_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("blobs.osa2");
+
+    // Every record lands in chunk 0, so one lookup loads all ROWS of them.
+    let records: Vec<Osa2Record> = (0..ROWS)
+        .map(|i| Osa2Record {
+            chrom: "chr1".into(),
+            position: 1_000 + i,
+            ref_allele: b"A".to_vec(),
+            alt_allele: b"G".to_vec(),
+            values: Vec::new(),
+            json_blob: Some(format!("{{\"score\":{i},\"symbol\":\"GENE{i}\"}}")),
+        })
+        .collect();
+    Osa2Writer::new(
+        Osa2Metadata {
+            format_version: 2,
+            name: "Blobs".into(),
+            version: "1".into(),
+            assembly: "GRCh38".into(),
+            json_key: "blobs".into(),
+            match_by_allele: true,
+            is_array: false,
+            is_positional: false,
+            chunk_bits: 20,
+            description: "test".into(),
+        },
+        whole_record_blob_field(),
+    )
+    .write_all(std::fs::File::create(&path).unwrap(), &records)
+    .unwrap();
+
+    let reader = Osa2Reader::open(&path).unwrap();
+
+    // The very first lookup is the one that builds the chunk, so measure it
+    // before anything has warmed the cache.
+    let mut answer = None;
+    let allocs = allocations_during(|| {
+        answer = reader.annotate_position("chr1", 1_777, "A", "G").unwrap();
+    });
+    assert!(answer.is_some(), "the record should have been found");
+
+    // The chunk is built from a fixed number of buffers - the ZIP entries, the
+    // decompressed blob, and its offsets - so the count must not scale with
+    // ROWS. Measured at 77; the budget is loose because the point of the
+    // assertion is the shape of the growth, not the constant. A `String` per row
+    // would put this above ROWS.
+    assert!(
+        allocs < ROWS as usize / 10,
+        "building a {ROWS}-row blob chunk took {allocs} allocations; \
+         that scales with the row count rather than the chunk"
+    );
+
+    // And every row still reads back byte-for-byte what was stored - indexing
+    // the buffer must delimit the rows exactly as splitting it did.
+    for probe in [0u32, 1, ROWS / 2, ROWS - 1] {
+        let got = reader
+            .annotate_position("chr1", (1_000 + probe) as u64, "A", "G")
+            .unwrap()
+            .expect("row should be present");
+        let json = match got {
+            fastvep_cache::annotation::AnnotationValue::Json(j) => j,
+            other => panic!("expected a JSON value for row {probe}, got {other:?}"),
+        };
+        assert_eq!(
+            json,
+            format!("{{\"score\":{probe},\"symbol\":\"GENE{probe}\"}}"),
+            "row {probe} did not round-trip"
+        );
+    }
+}

--- a/crates/fastvep-sa/tests/chunk_width_does_not_change_answers.rs
+++ b/crates/fastvep-sa/tests/chunk_width_does_not_change_answers.rs
@@ -1,0 +1,170 @@
+//! Chunk width is a storage decision, never an answer-changing one.
+//!
+//! `chunk_bits` sets how much of the genome one chunk covers, and it is what
+//! makes a blob-encoded dense source usable: the default 1 Mb puts so many
+//! records in one chunk that a query has to decompress hundreds of megabytes of
+//! JSON to read one of them, and past the limit every lookup in that megabase
+//! fails outright (#101). The remedy is to convert such a source with narrower
+//! chunks, which is only safe advice if narrowing them cannot change what a
+//! query returns.
+//!
+//! It reaches further than the blob path. The width also decides the position
+//! bits of every Var32 key, which is what a short-variant lookup binary-searches
+//! on, so writer and reader have to agree about it through the file's metadata
+//! rather than by assumption.
+
+use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue};
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2Writer};
+
+fn metadata(chunk_bits: u32) -> Osa2Metadata {
+    Osa2Metadata {
+        format_version: 2,
+        name: "Widths".into(),
+        version: "1".into(),
+        assembly: "GRCh38".into(),
+        json_key: "widths".into(),
+        match_by_allele: true,
+        is_array: false,
+        is_positional: false,
+        chunk_bits,
+        description: "test".into(),
+    }
+}
+
+/// One whole-record JSON blob, the encoding `sa-convert` produces.
+fn blob_field() -> Vec<Field> {
+    vec![Field {
+        field: String::new(),
+        alias: String::new(),
+        ftype: FieldType::JsonBlob,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+/// Records spread over several megabases and deliberately sitting on chunk
+/// boundaries, with the allele shapes that take each of the reader's three
+/// lookup paths: 2-bit packable short variants, long ones, and non-ACGT ones.
+fn records() -> Vec<Osa2Record> {
+    let mut out = Vec::new();
+    let mut push = |chrom: &str, pos: u32, r: &[u8], a: &[u8], tag: &str| {
+        out.push(Osa2Record {
+            chrom: chrom.into(),
+            position: pos,
+            ref_allele: r.to_vec(),
+            alt_allele: a.to_vec(),
+            values: Vec::new(),
+            json_blob: Some(format!("{{\"tag\":\"{tag}\",\"pos\":{pos}}}")),
+        });
+    };
+    // Every power-of-two boundary between 2^14 and 2^20 is a chunk edge for one
+    // of the widths under test, so include the bases either side of each.
+    let mut positions: Vec<u32> = Vec::new();
+    for bits in 14..=20u32 {
+        let w = 1u32 << bits;
+        for mult in 1..=3u32 {
+            let edge = w * mult;
+            positions.extend([edge.saturating_sub(1), edge, edge + 1]);
+        }
+    }
+    positions.extend([1, 2, 1_000, 500_000, 3_000_000, 4_194_303]);
+    positions.sort_unstable();
+    positions.dedup();
+
+    for (i, &p) in positions.iter().enumerate() {
+        for chrom in ["chr1", "chr2"] {
+            match i % 3 {
+                0 => push(chrom, p, b"A", b"G", "short"),
+                1 => push(chrom, p, b"ACGTACGT", b"T", "long"),
+                _ => push(chrom, p, b"N", b"A", "nonacgt"),
+            }
+        }
+    }
+    out.sort_by(|a, b| a.chrom.cmp(&b.chrom).then(a.position.cmp(&b.position)));
+    out
+}
+
+#[test]
+fn every_chunk_width_answers_identically() {
+    let dir = tempfile::tempdir().unwrap();
+    let recs = records();
+    assert!(recs.len() > 100, "need a meaningful record set");
+
+    // Ask about every stored record, plus positions that are absent, so a miss
+    // has to stay a miss at every width too.
+    let mut queries: Vec<(String, u64, Vec<u8>, Vec<u8>)> = recs
+        .iter()
+        .map(|r| {
+            (
+                r.chrom.clone(),
+                r.position as u64,
+                r.ref_allele.clone(),
+                r.alt_allele.clone(),
+            )
+        })
+        .collect();
+    for r in &recs {
+        queries.push((
+            r.chrom.clone(),
+            r.position as u64 + 7,
+            b"A".to_vec(),
+            b"C".to_vec(),
+        ));
+        queries.push((
+            r.chrom.clone(),
+            r.position as u64,
+            b"A".to_vec(),
+            b"TTTT".to_vec(),
+        ));
+    }
+
+    let mut baseline: Option<Vec<Option<String>>> = None;
+    for chunk_bits in [20u32, 18, 16, 14, 12, 8, 1] {
+        let path = dir.path().join(format!("w{chunk_bits}.osa2"));
+        Osa2Writer::new(metadata(chunk_bits), blob_field())
+            .write_all(std::fs::File::create(&path).unwrap(), &recs)
+            .unwrap();
+        let reader = Osa2Reader::open(&path).unwrap();
+
+        let answers: Vec<Option<String>> = queries
+            .iter()
+            .map(|(c, p, r, a)| {
+                let got = reader
+                    .annotate_position(
+                        c,
+                        *p,
+                        std::str::from_utf8(r).unwrap(),
+                        std::str::from_utf8(a).unwrap(),
+                    )
+                    .unwrap_or_else(|e| panic!("chunk_bits {chunk_bits}: lookup failed: {e}"));
+                got.map(|v| match v {
+                    AnnotationValue::Json(j) | AnnotationValue::Positional(j) => j,
+                    AnnotationValue::Interval(v) => v.join(","),
+                })
+            })
+            .collect();
+
+        // The record set must actually be found, or the comparison is vacuous.
+        let hits = answers.iter().filter(|a| a.is_some()).count();
+        assert!(
+            hits >= recs.len(),
+            "chunk_bits {chunk_bits}: only {hits} hits for {} records",
+            recs.len()
+        );
+
+        match &baseline {
+            None => baseline = Some(answers),
+            Some(want) => {
+                assert_eq!(
+                    &answers, want,
+                    "chunk_bits {chunk_bits} answered differently from the 1 Mb layout"
+                );
+            }
+        }
+    }
+}

--- a/crates/fastvep-sa/tests/failed_chunk_is_not_retried.rs
+++ b/crates/fastvep-sa/tests/failed_chunk_is_not_retried.rs
@@ -1,0 +1,135 @@
+//! A chunk that cannot be built is attempted once, not once per variant.
+//!
+//! Every lookup in a chunk's genomic width asked for the chunk, and a chunk
+//! whose blobs fail to decompress paid the full decompression before failing
+//! each time. One unreadable megabase of a dense database was enough to make a
+//! run look hung rather than slow: 200,000 variants over three such chunks did
+//! not finish in ten minutes, where remembering the verdict finishes in
+//! seconds (#101).
+
+use fastvep_cache::annotation::AnnotationProvider;
+use fastvep_sa::fields::{Field, FieldType};
+use fastvep_sa::reader_v2::Osa2Reader;
+use fastvep_sa::writer_v2::{Osa2Metadata, Osa2Record, Osa2Writer};
+
+fn blob_field() -> Vec<Field> {
+    vec![Field {
+        field: String::new(),
+        alias: String::new(),
+        ftype: FieldType::JsonBlob,
+        multiplier: 1,
+        zigzag: false,
+        missing_value: u32::MAX,
+        missing_string: ".".into(),
+        description: String::new(),
+    }]
+}
+
+/// Corrupt the payload of one ZIP entry in place, leaving every offset and
+/// length in the archive untouched so the reader still finds the entry and only
+/// fails once it tries to decompress it.
+///
+/// A local file header is: 4-byte signature, 22 bytes of fixed fields, then a
+/// 2-byte name length and a 2-byte extra-field length, then the name, the extra
+/// field, and the data.
+fn corrupt_entry_payload(bytes: &mut [u8], name: &str) -> bool {
+    let sig = b"PK\x03\x04";
+    let name_bytes = name.as_bytes();
+    let mut i = 0;
+    while i + 30 + name_bytes.len() <= bytes.len() {
+        if &bytes[i..i + 4] == sig {
+            let name_len = u16::from_le_bytes([bytes[i + 26], bytes[i + 27]]) as usize;
+            let extra_len = u16::from_le_bytes([bytes[i + 28], bytes[i + 29]]) as usize;
+            let name_start = i + 30;
+            if name_len == name_bytes.len()
+                && &bytes[name_start..name_start + name_len] == name_bytes
+            {
+                let data = name_start + name_len + extra_len;
+                // Flip enough leading bytes that neither a zstd frame header
+                // nor a deflate stream can be read out of them.
+                for b in bytes.iter_mut().skip(data).take(16) {
+                    *b ^= 0xFF;
+                }
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+#[test]
+fn an_unreadable_chunk_is_attempted_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("blobs.osa2");
+
+    // 64 records, all in chunk 0 of chr1.
+    let records: Vec<Osa2Record> = (0..64u32)
+        .map(|i| Osa2Record {
+            chrom: "chr1".into(),
+            position: 1_000 + i,
+            ref_allele: b"A".to_vec(),
+            alt_allele: b"G".to_vec(),
+            values: Vec::new(),
+            json_blob: Some(format!("{{\"score\":{i}}}")),
+        })
+        .collect();
+    Osa2Writer::new(
+        Osa2Metadata {
+            format_version: 2,
+            name: "Blobs".into(),
+            version: "1".into(),
+            assembly: "GRCh38".into(),
+            json_key: "blobs".into(),
+            match_by_allele: true,
+            is_array: false,
+            is_positional: false,
+            chunk_bits: 20,
+            description: "test".into(),
+        },
+        blob_field(),
+    )
+    .write_all(std::fs::File::create(&path).unwrap(), &records)
+    .unwrap();
+
+    // Sanity: intact, the record reads back.
+    {
+        let reader = Osa2Reader::open(&path).unwrap();
+        assert!(reader
+            .annotate_position("chr1", 1_010, "A", "G")
+            .unwrap()
+            .is_some());
+        assert_eq!(reader.chunk_failure_count(), 0);
+    }
+
+    let mut bytes = std::fs::read(&path).unwrap();
+    assert!(
+        corrupt_entry_payload(&mut bytes, "fastsa/chr1/0/json_blobs.zst"),
+        "the blob entry should be present to corrupt"
+    );
+    let broken = dir.path().join("broken.osa2");
+    std::fs::write(&broken, &bytes).unwrap();
+
+    let reader = Osa2Reader::open(&broken).unwrap();
+    let mut errors = 0;
+    for i in 0..500u32 {
+        // Every one of these lands in the same unreadable chunk.
+        if reader
+            .annotate_position("chr1", (1_000 + i % 64) as u64, "A", "G")
+            .is_err()
+        {
+            errors += 1;
+        }
+    }
+
+    // Every lookup must still report the failure - it is not a miss.
+    assert_eq!(errors, 500, "each lookup in a broken chunk must report it");
+    // But the chunk itself is only ever attempted once.
+    assert_eq!(
+        reader.chunk_failure_count(),
+        1,
+        "the failed chunk should be remembered, not rebuilt per lookup"
+    );
+    // And nothing was cached as a successful load.
+    assert_eq!(reader.chunk_load_count(), 0);
+}

--- a/docs/SUPPLEMENTARY_ANNOTATIONS.md
+++ b/docs/SUPPLEMENTARY_ANNOTATIONS.md
@@ -209,6 +209,55 @@ column-oriented sources it is not, so if you still have the upstream release
 prefer `sa-build --format osa2` to get the column layout. Which of the two ends
 up smaller is data-dependent, so compare if size matters.
 
+#### Chunk width for dense sources (`--chunk-bits`)
+
+A chunk is the unit a query loads, and it covers a fixed genomic width -- 2^20
+bases, 1 Mb, by default.
+A blob-encoded chunk stores its records' JSON one after another in a single
+compressed stream, so reading one record decompresses the whole chunk's worth.
+
+That is cheap for the sparse sources.
+dbSNP, ClinVar, COSMIC and REVEL put kilobytes in a megabase, and the wide chunk
+is what keeps them compact.
+It is not cheap for a source that scores nearly every base.
+SpliceAI carries three alternates at essentially every position of a gene body,
+which is hundreds of megabytes of JSON in a single 1 Mb chunk: queries slow to a
+crawl, and past 256 MiB the chunk exceeds the blob decompression limit outright,
+at which point *every* lookup in that megabase fails.
+
+Pass `--chunk-bits 16` (65 kb) when converting such a source:
+
+```bash
+fastvep sa-convert -i old/spliceai.osa -o new/spliceai --chunk-bits 16
+```
+
+Measured on a source built to SpliceAI's density, 300 scattered queries:
+
+| `--chunk-bits` | file size | 300 queries | records annotated |
+|---|---:|---:|---:|
+| 20 (default) | 0.26 MB | 9.7 s | 5 / 300 |
+| 18 | 0.27 MB | 0.83 s | 300 / 300 |
+| 16 | 0.29 MB | 0.51 s | 300 / 300 |
+| 14 | 0.35 MB | 0.47 s | 300 / 300 |
+
+For comparison, the same queries against the native column encoding took 0.41 s,
+so a converted database at `--chunk-bits 16` is close to it.
+
+Do not lower it for the sparse sources: narrower chunks mean more of them, and
+real ClinVar grows from 40.9 MB to 53.6 MB (and from 7,566 to 54,911 archive
+entries) between 20 and 16.
+`chunk_bits` is recorded per file, so a database converted at any width is read
+correctly without telling the reader anything.
+
+A run that hits the limit now says so, once per source, rather than returning
+records with the column quietly absent:
+
+```
+warning: spliceAI could not be read for 295 variant lookup(s); those variants
+carry no spliceAI annotation, which is not the same as having none. First error:
+SpliceAI: the JSON blobs for chunk chr1/1 decompress past the 256 MiB limit ...
+```
+
 `sa-convert` refuses `.osi` and `.oga` inputs with an explanation rather than
 failing obscurely: v2 is a variant-level container and has no equivalent form
 for interval- or gene-keyed data.


### PR DESCRIPTION
Closes #100. Closes #101.

Seven commits in two parts. Both issues were reported against `f162f9f`, and
both turned out to be a case of fastVEP returning something that looks like an
answer: a MODIFIER where VEP says HIGH, and a missing column where the database
had a record.

VEP is not runnable in this environment, so rather than assert its behaviour I
read the release/115 source of `VariationEffect.pm` and
`BaseTranscriptVariation.pm` and worked from the predicates themselves. Every
claim below is measured on real files - Ensembl GRCh38.115 (509,650 transcripts,
234,024 coding sequences, the same counts the reporter saw), 673,660 ClinVar
2-star variants, the 4,048,342-variant GIAB HG002 genome, and the repository's
174-file supplementary database.

---

## Part 1 - the #100 fix (`047eccd`, `28eedf9`, `47ad87f`)

A delins over FOXL2's stop codon was `3_prime_UTR_variant`, MODIFIER, where VEP
reports `stop_lost&3_prime_UTR_variant`, HIGH.

The UTR and coding tests were an `else if` chain, and both UTR predicates read
`var_start` alone - their second parameter was named `_var_end`. So which branch
a boundary-spanning variant took depended on which of its ends was lower in
genomic coordinates, which is to say on the strand. FOXL2 is on the reverse
strand (CDS 138945592-138946722), so the variant's genomic start is its *last*
base in transcript order and lands in the 3' UTR; the chain matched there and
the coding branch never ran.

**The mirror case was as severe and had not been reported.** On the forward
strand a delins across the initiator matches the 5' UTR first, so a variant that
destroys FOXL2NB's start codon came back `5_prime_UTR_variant`, MODIFIER.

Three defects, each its own commit:

1. **The region terms are additive and span-based.** That is what VEP does -
   `_before_coding` / `_after_coding` are plain `overlap` calls and its
   predicates are independent, which is why it emits the pair. A variant inside
   one region is unaffected; a test pins that.
2. **The coding term is derived differently when the variant reaches past the
   CDS.** Such a variant is not a codon edit, and the frame arithmetic counted
   the UTR bases anyway - which is how the forward-strand case came back
   `frameshift_variant`. The terminator and initiator are decided by re-reading
   one codon out of the transcript's own sequence, as VEP's
   `_ins_del_stop_altered` does, because length arithmetic cannot tell a delins
   that removes the stop codon from one that rebuilds it. `edited_codon` reads
   that codon in place rather than materialising the edited sequence, since the
   sequence is the whole transcript and this runs in the per-variant loop.
3. **HGVSc numbers each end of a span in the scheme its own position uses.**
   `c.1127_1135` named four bases past the end of an 1131-base CDS; VEP writes
   `c.1127_*4`. One helper now answers per position, replacing three copies of
   the decision that had drifted apart.
4. **A minus-strand allele is reverse-complemented, not complemented in place.**
   Identical for one base, which is why it survived - a reverse-strand `ACG` was
   written `delinsTGC` where the transcript reads `CGT`. It also made the
   duplication check compare wrongly-ordered bases, so 21,116 entries were
   written as an insertion where the correct bases are a `dup`.

### What this changes in the output

On the FOXL2 case, character-for-character what the issue quotes from VEP:
`Consequence=stop_lost&3_prime_UTR_variant`, `IMPACT=HIGH`,
`HGVSc=ENST00000648323.1:c.1127_*4delinsCG`.

Over **673,660 ClinVar 2-star variants**:

| | |
|---|---:|
| CSQ entries that recover a HIGH impact | **551** |
| entries whose impact drops | 25 |
| HGVSc entries changed | 49,585 |

The 551 are in MUTYH, ALK, MSH6, MLH1, APC, ATM, VHL, MET, SETD2, DICER1 and
others. **All 25 drops are `stop_retained_variant`** replacing
`frameshift_variant` or `inframe_deletion`, because the bases moving up into the
terminator's place still read as a stop - MSH2 `TAA`->`TAG`, ACADM `TAG`->`TAG`.
Every one was checked against the GFF3 and FASTA by a script that does not use
this code: 25/25 correct.

Every one of the 49,585 HGVSc changes classifies into a deliberate fix. Folding
the three numbering copies into one also fixed three defects the deletion arm
carried, all confirmed over the same set:

- Deletions skipped Ensembl's start-phase offset while every other path applied
  it, so the same base on PEX10-209 was `c.716G>A` as a substitution and
  `c.715del` as a deletion - and `CDS_position` said 716 for both. 5,216 entries.
- A deletion from the 5' UTR into the CDS numbered its end one too low. 350.
- Spans at a boundary produced coordinates that do not exist: `c.*0_*1dup`, and
  `c.-1_1dup` for three bases across the initiator, where `c.0` is not a
  position.

Over the **4,048,342-variant GIAB HG002 genome**, 61 CSQ entries change,
134,311 HGVSc entries change, **none unclassified**, and the 16 impact drops are
the same `stop_retained_variant` shape - also all 16 verified independently.

Runtime is unchanged: interleaved three-run A/B on the ClinVar set, master mean
20.93 s against 20.87 s, with a per-run spread of 18.9-23.8 s.

---

## Part 2 - the #101 fix (`966f6de`, `d272c28`, `79b20c8`, `a916f6b`)

Answering the questions in the issue: **yes, ~33 s for 290 queries is a real
problem and not the expected cost of blob encoding; #76 does not cover it; and
rebuilding does help, but the actual fault was worse than slowness.**

Reproduced on a source built to SpliceAI's density (three alternates at every
position over 3 Mb, converted with `sa-convert`): 300 scattered queries took
9.7 s and returned **5 SpliceAI annotations out of 300, with no diagnostic**.

A chunk covers 1 Mb and stores its records' JSON in one compressed stream, so
reading one record decompresses all of them. At SpliceAI's density that exceeds
the 256 MiB decompression limit, and the resulting error was discarded: both
per-variant loops wrote `if let Ok(Some(ann))`, which drops an `Err` exactly as
it drops a `None`. The other 295 variants read as "no score here", which for a
splice predictor is a clinically meaningful difference.

Four commits:

1. **A failed lookup is reported, not dropped.** Counted per source, with the
   first message, summarised once after the progress meter - the loop runs
   millions of times and one broken chunk fails all of them.
2. **A chunk's JSON blobs are indexed, not copied row by row.** The column was a
   `Vec<String>`, one allocation and one copy per stored row. 20,000-row chunk:
   20,000+ allocations to 77, pinned by a counting-allocator budget. *This was
   not the cause* - removing it did not move the runtime, which is how the real
   cause came to light - and it is kept on its own merits.
3. **An unreadable chunk is attempted once, not once per variant.** This is the
   scaling in the issue. 200,000 variants over three such chunks did not finish
   in ten minutes; remembering the verdict finishes in **2.2 s**. This is the
   most likely reading of the 11,419-variant run cut off at a 15-minute timeout.
4. **`sa-convert --chunk-bits` sets the chunk width**, and the error names the
   remedy.

### Measurements

300 scattered queries against the dense source:

| `--chunk-bits` | file size | 300 queries | annotated |
|---|---:|---:|---:|
| 20 (default) | 0.26 MB | 9.7 s | 5 / 300 |
| 18 | 0.27 MB | 0.83 s | 300 / 300 |
| 16 | 0.29 MB | 0.51 s | 300 / 300 |
| 14 | 0.35 MB | 0.47 s | 300 / 300 |

The native column encoding takes 0.41 s on the same queries, so a converted
database at 16 is close to it.

**The default stays 20**, because narrowing is not free for the sparse sources:
real ClinVar grows 40.9 MB -> 53.6 MB and 7,566 -> 54,911 archive entries
between 20 and 16. `chunk_bits` is recorded per file, so existing databases are
still read correctly and only a reconversion changes anything.

### Chunk width must never change an answer

That is the whole basis for recommending `--chunk-bits 16`, so it is tested two
ways. A test writes the same records at seven widths from 20 down to 1,
deliberately on the power-of-two boundaries and across all three lookup paths
(short, long, non-ACGT - the width also sets the position bits of every Var32
key), and requires identical answers. And on real data: **40,000 chr1 ClinVar
variants against real SpliceAI, ClinVar and REVEL databases give byte-identical
annotations from the v1 `.osa`, from `.osa2` at width 20, and at width 16**
(34,451 SpliceAI annotations each).

### No regression to the supplementary path

30,000 real ClinVar variants against the repository's 174-file database - both
`.osa` and `.osa2`, blob and column encodings, seven sources: **every
supplementary annotation byte-identical to master.**

---

## Checks

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and
`cargo test --workspace` all clean; **973 tests pass**, 18 of them new. Every one
of the seven commits builds on its own.

Two pre-existing things found along the way and deliberately left out of scope:
`sa_cache_budget_bytes` documents the `FASTVEP_SA_CACHE_BYTES` override as
clamped when the code returns it unclamped, and HGVSp for an in-frame delins is
still the placeholder `p.…delinsXaa` with an empty `Codons`.
