### PR TITLE
fix(hgvs): name the block an intronic duplication actually copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,8 +700,9 @@ of the ClinVar 2-star+ set it is drawn from, so these are the rates on the shape
 The same comparison over a systematic 1-in-200 sample of the GIAB HG002 WGS callset - 20,241
 variants, **122,317 matched rows** - is the other end of that range: the consequence set and
 `IMPACT` agree on **100.000 %** of rows, `HGVSp` on **99.985 %**, `HGVSc` on **99.879 %**.
-108 of the 148 remaining `HGVSc` rows come from multi-allelic VCF records, whose per-allele
-trimming is a known gap.
+Most of the 148 remaining `HGVSc` rows come from multi-allelic VCF records (1.18% of this
+callset), whose per-allele trimming against the reference is a known gap - see
+[docs/VEP_DIVERGENCE.md](docs/VEP_DIVERGENCE.md).
 
 **HGVSp under in-frame indels.**
 Protein-level normalisation is additionally checked on 400 ClinVar in-frame deletions run through

--- a/README.md
+++ b/README.md
@@ -682,7 +682,8 @@ set contains.
 **Consequences and HGVS under indels, MNVs and splice sites.**
 The example set is SNV-only, so the harder shapes are validated on a 6,600-variant stratified
 sample of the ClinVar 2-star+ set - **150,725 matched (variant, allele, transcript) rows**, 72,632
-of them coding:
+of them coding. That sample is built to be hard: 54.5% of its variants are not SNVs, against 7.2%
+of the ClinVar 2-star+ set it is drawn from, so these are the rates on the shapes that disagree.
 
 | Field | Scope | Agreement |
 |---|---|---:|
@@ -692,8 +693,15 @@ of them coding:
 | Consequence terms | coding rows | 99.86 % |
 | Whole consequence set | all rows | 99.92 % |
 | `IMPACT` | all rows | 99.93 % |
+| `HGVSc` | all rows | 99.60 % |
 | `HGVSp` | all rows | 99.43 % |
-| `HGVSc` | all rows | 98.82 % |
+
+**Genome-wide, on an ordinary callset.**
+The same comparison over a systematic 1-in-200 sample of the GIAB HG002 WGS callset - 20,241
+variants, **122,317 matched rows** - is the other end of that range: the consequence set and
+`IMPACT` agree on **100.000 %** of rows, `HGVSp` on **99.985 %**, `HGVSc` on **99.879 %**.
+108 of the 148 remaining `HGVSc` rows come from multi-allelic VCF records, whose per-allele
+trimming is a known gap.
 
 **HGVSp under in-frame indels.**
 Protein-level normalisation is additionally checked on 400 ClinVar in-frame deletions run through

--- a/crates/fastvep-annotate/src/hgvs_normalize.rs
+++ b/crates/fastvep-annotate/src/hgvs_normalize.rs
@@ -90,6 +90,71 @@ pub fn convert_ins_to_dup_range_noncoding(
     }
 }
 
+/// A window of reference the shift walks through, refilled in blocks rather than
+/// fetched a base at a time.
+///
+/// The walk used to call `fetch_sequence` once per base, and twice per base for
+/// a deletion, each returning an owned `Vec` - so a variant sliding 4,000 bases
+/// down a repeat cost 4,000 heap allocations, or 8,000 as a deletion, once per
+/// (variant x transcript x allele).
+///
+/// The block **grows**, and that is the point: almost every shift stops within a
+/// base or two, so a window that opened at its full size would read and copy
+/// hundreds of bases to answer two questions - work done before knowing it is
+/// needed, which measured 11 % slower over a real indel-only callset than the
+/// per-base reads it replaced. Starting small and doubling keeps the common case
+/// at one short read and still collapses a long walk to a handful.
+struct RefWindow<'a> {
+    provider: &'a dyn SequenceProvider,
+    chrom: &'a str,
+    /// 1-based genomic position of `bases[0]`. Zero until the first fill.
+    origin: u64,
+    bases: Vec<u8>,
+    next_block: u64,
+}
+
+impl<'a> RefWindow<'a> {
+    /// Enough for a shift that stops immediately, which is nearly all of them.
+    const FIRST_BLOCK: u64 = 16;
+    /// Past this a walk is in a long repeat and the reads are already amortised.
+    const MAX_BLOCK: u64 = 1024;
+
+    fn new(provider: &'a dyn SequenceProvider, chrom: &'a str) -> Self {
+        Self {
+            provider,
+            chrom,
+            origin: 0,
+            bases: Vec::new(),
+            next_block: Self::FIRST_BLOCK,
+        }
+    }
+
+    /// The base at `pos`, uppercased, or `None` past the contig.
+    fn base(&mut self, pos: u64) -> Option<u8> {
+        if pos == 0 {
+            return None;
+        }
+        if self.origin == 0 || pos < self.origin || pos >= self.origin + self.bases.len() as u64 {
+            let block = self.next_block;
+            self.next_block = (block * 2).min(Self::MAX_BLOCK);
+            // Centre the block on the request so a walk in either direction has
+            // room; the caller's direction is not known here.
+            let origin = pos.saturating_sub(block / 2).max(1);
+            self.bases = self
+                .provider
+                .fetch_sequence_slice(self.chrom, origin, origin + block - 1)
+                .ok()?;
+            self.origin = origin;
+            if self.bases.is_empty() {
+                return None;
+            }
+        }
+        self.bases
+            .get((pos - self.origin) as usize)
+            .map(|b| b.to_ascii_uppercase())
+    }
+}
+
 /// 3' shift an intronic indel along the transcript direction.
 ///
 /// HGVS requires variants to be described at the most 3' position.
@@ -115,102 +180,79 @@ pub fn three_prime_shift_intronic(
     use fastvep_core::Allele;
 
     match (ref_allele, alt_allele) {
-        // Deletion: shift the deleted bases toward 3' end
+        // A deletion slides 3' while the base past its end repeats the base at
+        // its start, which leaves the deleted sequence unchanged.
+        //
+        // The two cursors sit a whole deletion apart, so they get a window each:
+        // sharing one would refetch on every step of any deletion longer than a
+        // block, which is worse than the per-base reads this replaced.
         (Allele::Sequence(ref_bases), Allele::Deletion) if !ref_bases.is_empty() => {
-            let mut s = start;
-            let mut e = end;
-
+            let (mut s, mut e) = (start, end);
+            let mut ahead = RefWindow::new(seq_provider, chrom);
+            let mut behind = RefWindow::new(seq_provider, chrom);
             match strand {
                 fastvep_core::Strand::Forward => loop {
-                    let next_pos = e + 1;
-                    if next_pos > intron_genomic_end {
+                    let next = e + 1;
+                    if next > intron_genomic_end {
                         break;
                     }
-                    let next_base = match seq_provider.fetch_sequence(chrom, next_pos, next_pos) {
-                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                    match (ahead.base(next), behind.base(s)) {
+                        (Some(a), Some(b)) if a == b => {
+                            s += 1;
+                            e += 1;
+                        }
                         _ => break,
-                    };
-                    let first_base = match seq_provider.fetch_sequence(chrom, s, s) {
-                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                        _ => break,
-                    };
-                    if next_base == first_base {
-                        s += 1;
-                        e += 1;
-                    } else {
-                        break;
                     }
                 },
                 fastvep_core::Strand::Reverse => loop {
                     if s == 0 || s - 1 < intron_genomic_start {
                         break;
                     }
-                    let prev_pos = s - 1;
-                    let prev_base = match seq_provider.fetch_sequence(chrom, prev_pos, prev_pos) {
-                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
+                    match (ahead.base(s - 1), behind.base(e)) {
+                        (Some(a), Some(b)) if a == b => {
+                            s -= 1;
+                            e -= 1;
+                        }
                         _ => break,
-                    };
-                    let last_base = match seq_provider.fetch_sequence(chrom, e, e) {
-                        Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                        _ => break,
-                    };
-                    if prev_base == last_base {
-                        s -= 1;
-                        e -= 1;
-                    } else {
-                        break;
                     }
                 },
             }
             (s, e)
         }
-        // Insertion/dup: shift toward 3' end using the actual inserted bases
+        // An insertion slides over a base that repeats the next base of the
+        // inserted sequence, which rotates the sequence by one each step.
         (Allele::Deletion, Allele::Sequence(ins_bases)) if !ins_bases.is_empty() => {
             let ins_len = ins_bases.len();
             let mut pos = start;
-            let genomic_ins: Vec<u8> = ins_bases.iter().map(|b| b.to_ascii_uppercase()).collect();
-
+            let mut shift = 0usize;
+            let mut window = RefWindow::new(seq_provider, chrom);
             match strand {
-                fastvep_core::Strand::Forward => {
-                    let mut shift_count = 0u64;
-                    loop {
-                        if pos > intron_genomic_end {
-                            break;
-                        }
-                        let check_base = match seq_provider.fetch_sequence(chrom, pos, pos) {
-                            Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                            _ => break,
-                        };
-                        let idx = (shift_count as usize) % ins_len;
-                        if check_base == genomic_ins[idx] {
+                fastvep_core::Strand::Forward => loop {
+                    if pos > intron_genomic_end {
+                        break;
+                    }
+                    let expected = ins_bases[shift % ins_len].to_ascii_uppercase();
+                    match window.base(pos) {
+                        Some(b) if b == expected => {
                             pos += 1;
-                            shift_count += 1;
-                        } else {
-                            break;
+                            shift += 1;
                         }
+                        _ => break,
                     }
-                }
-                fastvep_core::Strand::Reverse => {
-                    let mut shift_count = 0u64;
-                    loop {
-                        if pos == 0 || pos - 1 < intron_genomic_start {
-                            break;
-                        }
-                        let check_pos = pos - 1;
-                        let check_base =
-                            match seq_provider.fetch_sequence(chrom, check_pos, check_pos) {
-                                Ok(seq) if seq.len() == 1 => seq[0].to_ascii_uppercase(),
-                                _ => break,
-                            };
-                        let idx = ins_len - 1 - (shift_count as usize % ins_len);
-                        if check_base == genomic_ins[idx] {
+                },
+                fastvep_core::Strand::Reverse => loop {
+                    if pos == 0 || pos - 1 < intron_genomic_start {
+                        break;
+                    }
+                    let expected = ins_bases[ins_len - 1 - (shift % ins_len)].to_ascii_uppercase();
+                    match window.base(pos - 1) {
+                        Some(b) if b == expected => {
                             pos -= 1;
-                            shift_count += 1;
-                        } else {
-                            break;
+                            shift += 1;
                         }
+                        _ => break,
                     }
-                }
+                },
             }
             (pos, pos.saturating_sub(1))
         }

--- a/crates/fastvep-annotate/src/hgvs_normalize.rs
+++ b/crates/fastvep-annotate/src/hgvs_normalize.rs
@@ -1,76 +1,24 @@
-//! HGVS normalization utilities: insertion-to-duplication conversion and 3' shifting.
+//! The intronic HGVSc path: 3'-shifting, and naming a shifted insertion as the
+//! duplication it is.
 //!
-//! These functions post-process HGVSc strings to convert insertion notation (`ins`)
-//! to duplication notation (`dup`) when the inserted bases match the adjacent reference,
-//! and to 3'-shift intronic variants per HGVS conventions.
+//! [`hgvsc_intronic_shifted`] is the entry point, and both annotation loops call
+//! it. They used to carry a copy each - the CLI's shifted, the library's did
+//! not - so the same intronic duplication came out normalised from
+//! `fastvep annotate` and unnormalised from the server.
 
 use fastvep_cache::providers::SequenceProvider;
 
-/// Convert an intronic insertion HGVSc to duplication notation (coding transcript).
-pub fn convert_ins_to_dup(
-    hgvsc: &str,
-    intron_offset: i64,
-    ins_len: u64,
-    nearest_exon_cdna_pos: u64,
-    coding_start: u64,
-    coding_end: Option<u64>,
-) -> Option<String> {
-    let prefix_end = hgvsc
-        .find(":c.")
-        .map(|i| i + 3)
-        .or_else(|| hgvsc.find(":n.").map(|i| i + 3))?;
-    let prefix = &hgvsc[..prefix_end];
-
-    let build_pos = |cdna: u64, off: i64| -> String {
-        let raw = cdna as i64 - coding_start as i64 + 1;
-        let cp = if raw <= 0 { raw - 1 } else { raw };
-        if cp < 0 {
-            if off > 0 {
-                format!("{}+{}", cp, off)
-            } else {
-                format!("{}{}", cp, off)
-            }
-        } else if coding_end.is_some() && cdna > coding_end.unwrap() {
-            let u = cdna - coding_end.unwrap();
-            if off > 0 {
-                format!("*{}+{}", u, off)
-            } else {
-                format!("*{}{}", u, off)
-            }
-        } else if off > 0 {
-            format!("{}+{}", cp, off)
-        } else {
-            format!("{}{}", cp, off)
-        }
-    };
-
-    if ins_len == 1 {
-        let pos = build_pos(nearest_exon_cdna_pos, intron_offset);
-        return Some(format!("{}{}dup", prefix, pos));
-    }
-    let start_offset = intron_offset - ins_len as i64 + 1;
-    // Offsets count from the exon, so stepping `ins_len` bases back from `+1`
-    // does not reach `-2`: the exon lies between them, and a range written that
-    // way names bases in the *previous* intron. When the duplicated block would
-    // cross the boundary there is no single anchor that describes it, so the
-    // insertion keeps its own notation, which is unambiguous. Writing the
-    // crossing range instead put PVS1's offset gate at `-2` for a duplication
-    // that sits on the donor, and called two ClinVar-benign MSH6 and DSP
-    // variants likely pathogenic.
-    if start_offset.signum() != intron_offset.signum() {
-        return None;
-    }
-    let start_pos = build_pos(nearest_exon_cdna_pos, start_offset);
-    let end_pos = build_pos(nearest_exon_cdna_pos, intron_offset);
-    Some(format!("{}{}_{}dup", prefix, start_pos, end_pos))
-}
-
-/// Convert intronic insertion to dup notation with explicit start/end offsets (coding).
+/// Convert intronic insertion to dup notation with explicit start/end positions
+/// (coding).
+///
+/// Each end carries its own `(exon anchor, offset)` pair. A span deep inside one
+/// intron shares an anchor, but one running past the intron's midpoint is
+/// written from the exon on either side - `c.5044+27_5045-47dup` - so the two
+/// ends are not interchangeable.
 pub fn convert_ins_to_dup_range(
     hgvsc: &str,
-    start_offset: i64,
-    end_offset: i64,
-    nearest_exon_cdna_pos: u64,
+    start: (u64, i64),
+    end: (u64, i64),
     coding_start: u64,
     coding_end: Option<u64>,
 ) -> Option<String> {
@@ -83,42 +31,38 @@ pub fn convert_ins_to_dup_range(
     let build_pos = |cdna: u64, off: i64| -> String {
         let raw = cdna as i64 - coding_start as i64 + 1;
         let cp = if raw <= 0 { raw - 1 } else { raw };
-        if cp < 0 {
-            if off > 0 {
-                format!("{}+{}", cp, off)
-            } else {
-                format!("{}{}", cp, off)
-            }
-        } else if coding_end.is_some() && cdna > coding_end.unwrap() {
-            let u = cdna - coding_end.unwrap();
-            if off > 0 {
-                format!("*{}+{}", u, off)
-            } else {
-                format!("*{}{}", u, off)
-            }
-        } else if off > 0 {
-            format!("{}+{}", cp, off)
-        } else {
-            format!("{}{}", cp, off)
+        // An offset of 0 is an exonic end, written as the anchor alone. Folding
+        // it into the negative arm renders `c.21` as `c.210`.
+        let anchor = match coding_end.filter(|&ce| cp >= 0 && cdna > ce) {
+            Some(ce) => format!("*{}", cdna - ce),
+            None => format!("{}", cp),
+        };
+        match off.cmp(&0) {
+            std::cmp::Ordering::Greater => format!("{}+{}", anchor, off),
+            std::cmp::Ordering::Less => format!("{}{}", anchor, off),
+            std::cmp::Ordering::Equal => anchor,
         }
     };
 
-    if start_offset == end_offset {
-        let pos = build_pos(nearest_exon_cdna_pos, start_offset);
-        Some(format!("{}{}dup", prefix, pos))
+    if start == end {
+        Some(format!("{}{}dup", prefix, build_pos(start.0, start.1)))
     } else {
-        let start_pos = build_pos(nearest_exon_cdna_pos, start_offset);
-        let end_pos = build_pos(nearest_exon_cdna_pos, end_offset);
-        Some(format!("{}{}_{}dup", prefix, start_pos, end_pos))
+        Some(format!(
+            "{}{}_{}dup",
+            prefix,
+            build_pos(start.0, start.1),
+            build_pos(end.0, end.1)
+        ))
     }
 }
 
-/// Convert intronic insertion to dup notation with explicit start/end offsets (non-coding).
+/// Convert intronic insertion to dup notation with explicit start/end positions
+/// (non-coding). See [`convert_ins_to_dup_range`] for why each end carries its
+/// own anchor.
 pub fn convert_ins_to_dup_range_noncoding(
     hgvsc: &str,
-    start_offset: i64,
-    end_offset: i64,
-    nearest_exon_cdna_pos: u64,
+    start: (u64, i64),
+    end: (u64, i64),
 ) -> Option<String> {
     let prefix_end = hgvsc
         .find(":n.")
@@ -126,58 +70,24 @@ pub fn convert_ins_to_dup_range_noncoding(
         .or_else(|| hgvsc.find(":c.").map(|i| i + 3))?;
     let prefix = &hgvsc[..prefix_end];
 
-    let build_pos = |off: i64| -> String {
-        if off > 0 {
-            format!("{}+{}", nearest_exon_cdna_pos, off)
-        } else {
-            format!("{}{}", nearest_exon_cdna_pos, off)
+    let build_pos = |cdna: u64, off: i64| -> String {
+        match off.cmp(&0) {
+            std::cmp::Ordering::Greater => format!("{}+{}", cdna, off),
+            std::cmp::Ordering::Less => format!("{}{}", cdna, off),
+            std::cmp::Ordering::Equal => format!("{}", cdna),
         }
     };
 
-    if start_offset == end_offset {
-        let pos = build_pos(start_offset);
-        Some(format!("{}{}dup", prefix, pos))
+    if start == end {
+        Some(format!("{}{}dup", prefix, build_pos(start.0, start.1)))
     } else {
-        let start_pos = build_pos(start_offset);
-        let end_pos = build_pos(end_offset);
-        Some(format!("{}{}_{}dup", prefix, start_pos, end_pos))
+        Some(format!(
+            "{}{}_{}dup",
+            prefix,
+            build_pos(start.0, start.1),
+            build_pos(end.0, end.1)
+        ))
     }
-}
-
-/// Convert an intronic insertion HGVSc to duplication notation (non-coding transcript).
-pub fn convert_ins_to_dup_noncoding(
-    hgvsc: &str,
-    intron_offset: i64,
-    ins_len: u64,
-    nearest_exon_cdna_pos: u64,
-) -> Option<String> {
-    let prefix_end = hgvsc
-        .find(":n.")
-        .map(|i| i + 3)
-        .or_else(|| hgvsc.find(":c.").map(|i| i + 3))?;
-    let prefix = &hgvsc[..prefix_end];
-
-    let build_pos = |off: i64| -> String {
-        if off > 0 {
-            format!("{}+{}", nearest_exon_cdna_pos, off)
-        } else {
-            format!("{}{}", nearest_exon_cdna_pos, off)
-        }
-    };
-
-    if ins_len == 1 {
-        let pos = build_pos(intron_offset);
-        return Some(format!("{}{}dup", prefix, pos));
-    }
-    let start_offset = intron_offset - ins_len as i64 + 1;
-    // See `convert_ins_to_dup`: a range that crosses the exon boundary names
-    // bases in the wrong intron.
-    if start_offset.signum() != intron_offset.signum() {
-        return None;
-    }
-    let start_pos = build_pos(start_offset);
-    let end_pos = build_pos(intron_offset);
-    Some(format!("{}{}_{}dup", prefix, start_pos, end_pos))
 }
 
 /// 3' shift an intronic indel along the transcript direction.
@@ -305,5 +215,542 @@ pub fn three_prime_shift_intronic(
             (pos, pos.saturating_sub(1))
         }
         _ => (start, end),
+    }
+}
+
+/// The block a 3'-shifted intronic insertion duplicates, in genomic coordinates.
+///
+/// After a maximal 3'-shift the duplicated copy can only sit immediately 5' of
+/// the insertion point *in transcript orientation*; anything further 3' would
+/// have been shifted over. The inserted string rotates one base per position
+/// shifted, so the block is compared against that rotated form and not against
+/// the string the VCF carried.
+///
+/// `shifted_start` follows the same convention [`three_prime_shift_intronic`]
+/// returns: the insertion sits between genomic `shifted_start - 1` and
+/// `shifted_start`.
+///
+/// The dup anchor used to be derived by re-shifting the *unshifted* insertion
+/// point through `three_prime_shift_intronic` over a single position, which
+/// walks while the next base repeats the current one - a homopolymer test. A
+/// `TG` insertion in a `TGTGTG…` repeat therefore never moved at all and named
+/// the copy 16 bases 5' of the one HGVS asks for. That accounted for 1,390 of
+/// the 1,538 HGVSc rows disagreeing with real Ensembl VEP 115.1 over a
+/// genome-wide HG002 sample, and it is why the two tools split by strand: this
+/// walk stays where the VCF put the variant, so fastVEP's anchor was always the
+/// genomically-left one whichever way the transcript ran.
+pub fn intronic_dup_span(
+    seq_provider: &dyn SequenceProvider,
+    chrom: &str,
+    shifted_start: u64,
+    ins_bases: &[u8],
+    shift: u64,
+    strand: fastvep_core::Strand,
+) -> Option<(u64, u64)> {
+    let len = ins_bases.len();
+    if len == 0 {
+        return None;
+    }
+    // One base of rotation per position travelled, in the direction of travel:
+    // shifting 3' on the forward strand walks the first base to the end, and on
+    // the reverse strand - where 3' runs towards lower coordinates - the last
+    // base walks to the front.
+    let rot = (shift % len as u64) as usize;
+    let mut rotated = ins_bases.to_vec();
+    match strand {
+        fastvep_core::Strand::Forward => rotated.rotate_left(rot),
+        fastvep_core::Strand::Reverse => rotated.rotate_right(rot),
+    }
+
+    // 5' of the insertion point is genomically before it on the forward strand
+    // and after it on the reverse.
+    let (lo, hi) = match strand {
+        fastvep_core::Strand::Forward => {
+            let hi = shifted_start.checked_sub(1)?;
+            (hi.checked_sub(len as u64 - 1)?, hi)
+        }
+        fastvep_core::Strand::Reverse => (shifted_start, shifted_start + len as u64 - 1),
+    };
+    if lo == 0 {
+        return None;
+    }
+
+    let block = seq_provider.fetch_sequence_slice(chrom, lo, hi).ok()?;
+    if block.len() != len {
+        return None;
+    }
+    block
+        .iter()
+        .zip(rotated.iter())
+        .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        .then_some((lo, hi))
+}
+
+/// Rewrite a 3'-shifted intronic insertion as a duplication, when it is one.
+///
+/// `hgvsc` is the insertion notation already built for the shifted position, and
+/// is returned rewritten. `None` means the insertion does not duplicate an
+/// adjacent block, or the block leaves the intron it started in - a range
+/// written across that boundary names bases in the wrong intron, so the
+/// insertion notation it already carries is the correct description.
+///
+/// `coding_start` is `None` for a transcript numbered from its first base, which
+/// selects `n.` numbering.
+// The arguments are independent coordinates, alleles and transcript state with
+// no natural grouping; a struct would only move the list to the call site.
+#[allow(clippy::too_many_arguments)]
+pub fn intronic_ins_as_dup(
+    seq_provider: &dyn SequenceProvider,
+    chrom: &str,
+    transcript: &fastvep_genome::Transcript,
+    hgvsc: &str,
+    shifted_start: u64,
+    ins_bases: &[u8],
+    shift: u64,
+    coding_start: Option<u64>,
+    coding_end: Option<u64>,
+) -> Option<String> {
+    let (lo, hi) = intronic_dup_span(
+        seq_provider,
+        chrom,
+        shifted_start,
+        ins_bases,
+        shift,
+        transcript.strand,
+    )?;
+    // Transcript order, not genomic: on the reverse strand the block's 5' end is
+    // its higher coordinate.
+    let (first, last) = match transcript.strand {
+        fastvep_core::Strand::Forward => (lo, hi),
+        fastvep_core::Strand::Reverse => (hi, lo),
+    };
+    let start = transcript.genomic_to_intronic_cdna(first)?;
+    let end = transcript.genomic_to_intronic_cdna(last)?;
+    // Both ends must lie in the *same* intron. Offsets count from their own
+    // exon and do not run through zero, so a block reaching into the next
+    // intron - or into an exon - cannot be written as one range: stepping back
+    // from `+1` does not arrive at `-2`, it names bases in the intron before.
+    // Writing the crossing range anyway put PVS1's offset gate at `-2` for a
+    // duplication sitting on the donor and called two ClinVar-benign MSH6 and
+    // DSP variants likely pathogenic.
+    //
+    // A span running past the intron's own midpoint is fine, and Ensembl writes
+    // it from the exon on either side: `c.5044+27_5045-47dup`. Requiring one
+    // shared anchor instead of one shared intron left 160 such rows as `ins`.
+    if transcript.intron_bounds_at(first) != transcript.intron_bounds_at(last) {
+        return None;
+    }
+    match coding_start {
+        Some(cs) => convert_ins_to_dup_range(hgvsc, start, end, cs, coding_end),
+        None => convert_ins_to_dup_range_noncoding(hgvsc, start, end),
+    }
+}
+
+/// Build the HGVSc for a variant reaching into an intron: 3'-shifted, and
+/// written as a duplication where the shifted insertion sits against the block
+/// it copies.
+///
+/// Both annotation loops call this. They had drifted: the CLI's copy shifted and
+/// converted to `dup`, the library's did neither, so the same intronic
+/// duplication came out normalised from `fastvep annotate` and unnormalised from
+/// the server and the web UI.
+///
+/// `genomic_ref` and `genomic_alt` are the alleles as the VCF carried them;
+/// `hgvs_ref` and `hgvs_alt` are the same pair in transcript orientation. The
+/// shift reads the reference, so it needs the genomic pair; the notation is
+/// written from the transcript pair.
+///
+/// `coding_start` is `None` for a transcript numbered from its first base, which
+/// selects `n.` numbering.
+// The arguments are independent coordinates, alleles and transcript state with
+// no natural grouping; a struct would only move the list to the call site.
+#[allow(clippy::too_many_arguments)]
+pub fn hgvsc_intronic_shifted(
+    seq_provider: Option<&dyn SequenceProvider>,
+    chrom: &str,
+    transcript: &fastvep_genome::Transcript,
+    versioned_tid: &str,
+    var_start: u64,
+    var_end: u64,
+    genomic_ref: &fastvep_core::Allele,
+    genomic_alt: &fastvep_core::Allele,
+    hgvs_ref: &fastvep_core::Allele,
+    hgvs_alt: &fastvep_core::Allele,
+    coding_start: Option<u64>,
+    coding_end: Option<u64>,
+) -> Option<String> {
+    use fastvep_core::{Allele, Strand};
+
+    let is_insertion = matches!(
+        (hgvs_ref, hgvs_alt),
+        (Allele::Deletion, Allele::Sequence(_))
+    );
+    let is_indel = is_insertion
+        || matches!(
+            (hgvs_ref, hgvs_alt),
+            (Allele::Sequence(_), Allele::Deletion)
+        );
+
+    // The walk is bounded by the intron the variant sits in, and an insertion
+    // sits *between* two bases, so `var_start` alone does not always find it:
+    // one written against the last intronic base has `var_start` in the exon
+    // beyond it, and a reverse-strand transcript travels 3' back down into that
+    // intron. Reading `var_end` when `var_start` lands outside places it.
+    let bounds = transcript
+        .intron_bounds_at(var_start)
+        .or_else(|| transcript.intron_bounds_at(var_end));
+    let (shifted_start, shifted_end) = match seq_provider.filter(|_| is_indel).zip(bounds) {
+        Some((sp, (intron_start, intron_end))) => three_prime_shift_intronic(
+            sp,
+            chrom,
+            var_start,
+            var_end,
+            genomic_ref,
+            genomic_alt,
+            transcript.strand,
+            intron_start,
+            intron_end,
+        ),
+        None => (var_start, var_end),
+    };
+    // Distance travelled, which is also how far the inserted string rotated.
+    let shift = match transcript.strand {
+        Strand::Forward => shifted_start.saturating_sub(var_start),
+        Strand::Reverse => var_start.saturating_sub(shifted_start),
+    };
+    // `hgvs_alt` is already in transcript orientation, where the shift always
+    // travels 3' whichever way the transcript runs, so the string always rotates
+    // left - the strand is spent before this point, on reverse-complementing it.
+    //
+    // Rotating right on the reverse strand instead, which is what this did,
+    // named the right position with the wrong bases: `c.21-21_21-20insGTC` for a
+    // variant the same transcript calls `insCGT` when the VCF spells it one base
+    // over. Genomically that rotation is correct and [`intronic_dup_span`] keeps
+    // it, because that function reads the reference rather than the transcript.
+    let shifted_alt = match hgvs_alt {
+        Allele::Sequence(ins) if is_insertion && shift > 0 && !ins.is_empty() => {
+            let mut rotated = ins.clone();
+            let k = (shift % rotated.len() as u64) as usize;
+            rotated.rotate_left(k);
+            Allele::Sequence(rotated)
+        }
+        other => other.clone(),
+    };
+
+    // An insertion is written over the two bases it sits between, and both are
+    // mapped: `shifted_end` and `shifted_start` are the pair, in transcript
+    // order on the forward strand and reversed on the reverse.
+    //
+    // Letting the renderer infer the second coordinate as `offset + 1` instead
+    // breaks across the middle of an intron, where `+n` counts from one exon and
+    // `-m` from the next: an insertion between `c.20+30` and `c.21-30` came out
+    // `c.20+30_20+31ins…`, naming a base past the half the donor-side offsets
+    // reach.
+    let (anchor_pos, second_pos) = if is_insertion {
+        match transcript.strand {
+            Strand::Forward => (shifted_end, Some(shifted_end + 1)),
+            Strand::Reverse => (shifted_end + 1, Some(shifted_end)),
+        }
+    } else {
+        (
+            shifted_start,
+            (shifted_start != shifted_end).then_some(shifted_end),
+        )
+    };
+    let (cdna_pos, offset) = crate::intronic_or_exonic_cdna(transcript, anchor_pos)?;
+    let (end_cdna, end_offset) = second_pos
+        .and_then(|p| crate::intronic_or_exonic_cdna(transcript, p))
+        .map(|(c, o)| (Some(c), Some(o)))
+        .unwrap_or((None, None));
+
+    let hgvsc = match coding_start {
+        Some(cs) => fastvep_hgvs::hgvsc_intronic_range(
+            versioned_tid,
+            cdna_pos,
+            offset,
+            end_cdna,
+            end_offset,
+            hgvs_ref,
+            &shifted_alt,
+            cs,
+            coding_end,
+        ),
+        None => fastvep_hgvs::hgvsc_noncoding_intronic_range(
+            versioned_tid,
+            cdna_pos,
+            offset,
+            end_cdna,
+            end_offset,
+            hgvs_ref,
+            &shifted_alt,
+        ),
+    }?;
+
+    if let (true, Allele::Sequence(ins), Some(sp)) = (is_insertion, genomic_alt, seq_provider) {
+        if hgvsc.contains("ins") && !ins.is_empty() {
+            if let Some(dup) = intronic_ins_as_dup(
+                sp,
+                chrom,
+                transcript,
+                &hgvsc,
+                shifted_start,
+                ins,
+                shift,
+                coding_start,
+                coding_end,
+            ) {
+                return Some(dup);
+            }
+        }
+    }
+    Some(hgvsc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{anyhow, Result};
+    use fastvep_core::Strand;
+    use fastvep_genome::{Exon, Gene, Transcript};
+
+    /// Minimal `SequenceProvider` over a 1-based reference string for one contig,
+    /// mirroring the real readers' contract: 1-based inclusive, `Err` past the end.
+    struct StrRef(&'static str);
+    impl SequenceProvider for StrRef {
+        fn fetch_sequence(&self, _chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
+            if start < 1 || end < start {
+                return Err(anyhow!("bad range"));
+            }
+            let b = self.0.as_bytes();
+            let s0 = (start - 1) as usize;
+            if s0 >= b.len() {
+                return Err(anyhow!("past contig end"));
+            }
+            Ok(b[s0..(end as usize).min(b.len())].to_vec())
+        }
+    }
+
+    /// Two exons on `strand` with one intron between them, so an intronic
+    /// position has an anchor on either side. Exon 1 is 1..=20, exon 2 is
+    /// 81..=100, and the intron is 21..=80.
+    fn transcript(strand: Strand) -> Transcript {
+        let exon = |start: u64, end: u64, rank: u32| Exon {
+            stable_id: format!("ENSE{}", rank),
+            start,
+            end,
+            strand,
+            phase: 0,
+            end_phase: 0,
+            rank,
+        };
+        Transcript {
+            stable_id: "ENST00000000001".into(),
+            version: Some(1),
+            gene: Gene {
+                stable_id: "ENSG00000000001".into(),
+                symbol: Some("TEST".into()),
+                symbol_source: None,
+                hgnc_id: None,
+                biotype: "protein_coding".into(),
+                chromosome: "1".into(),
+                start: 1,
+                end: 100,
+                strand,
+            },
+            biotype: "protein_coding".into(),
+            chromosome: "1".into(),
+            start: 1,
+            end: 100,
+            strand,
+            exons: vec![exon(1, 20, 1), exon(81, 100, 2)],
+            translation: None,
+            cdna_coding_start: Some(1),
+            cdna_coding_end: Some(40),
+            coding_region_start: None,
+            coding_region_end: None,
+            spliced_seq: None,
+            translateable_seq: None,
+            peptide: None,
+            canonical: true,
+            mane_select: None,
+            mane_plus_clinical: None,
+            tsl: None,
+            appris: None,
+            ccds: None,
+            protein_id: None,
+            protein_version: None,
+            swissprot: vec![],
+            trembl: vec![],
+            uniparc: vec![],
+            refseq_id: None,
+            source: None,
+            gencode_primary: false,
+            flags: vec![],
+            codon_table_start_phase: 0,
+        }
+    }
+
+    /// 20 exonic bases, then a `TG` repeat filling the intron, then exon 2. An
+    /// insertion of `TG` anywhere in that repeat is the same variant.
+    const TG_REPEAT: &str = "AAAAAAAAAAAAAAAAAAAA\
+                             TGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTG\
+                             CCCCCCCCCCCCCCCCCCCC";
+
+    /// The duplicated block sits immediately 5' of the *shifted* insertion
+    /// point, so a `TG` insertion that travelled the whole repeat names the last
+    /// two bases of it, not the two it was written against.
+    #[test]
+    fn dup_span_follows_the_shifted_insertion_not_the_vcf_position() {
+        let r = StrRef(TG_REPEAT);
+        // Insertion point right after exon 1; the repeat runs 21..=80, so the
+        // maximal 3' shift on the forward strand travels its full 60 bases.
+        let span = intronic_dup_span(&r, "1", 81, b"TG", 60, Strand::Forward);
+        assert_eq!(span, Some((79, 80)));
+    }
+
+    /// The inserted string rotates one base per position travelled. After an odd
+    /// shift of a two-base insert the block is `GT`, and reading the unrotated
+    /// `TG` against the reference would reject a duplication that is real.
+    #[test]
+    fn dup_span_compares_against_the_rotated_insert() {
+        let r = StrRef(TG_REPEAT);
+        // An odd shift lands the insertion point between a G and a T.
+        let span = intronic_dup_span(&r, "1", 80, b"TG", 59, Strand::Forward);
+        assert_eq!(span, Some((78, 79)));
+        let block = r.fetch_sequence("1", 78, 79).unwrap();
+        assert_eq!(&block, b"GT", "the block is the rotated form, not `TG`");
+    }
+
+    /// 3' on the reverse strand runs towards lower coordinates, so the block a
+    /// reverse-strand insertion duplicates lies *after* the insertion point.
+    #[test]
+    fn dup_span_reads_the_other_side_on_the_reverse_strand() {
+        let r = StrRef(TG_REPEAT);
+        let span = intronic_dup_span(&r, "1", 21, b"TG", 0, Strand::Reverse);
+        assert_eq!(span, Some((21, 22)));
+    }
+
+    /// A one-base walk through a homopolymer is not the repeat test: this is the
+    /// shape the old dup anchor used, and it stopped after one base of `TGTG…`.
+    #[test]
+    fn dup_span_is_none_when_the_block_does_not_repeat() {
+        let r = StrRef(TG_REPEAT);
+        // Inside the exon's poly-A run, a `TG` insert duplicates nothing.
+        assert_eq!(
+            intronic_dup_span(&r, "1", 15, b"TG", 0, Strand::Forward),
+            None
+        );
+    }
+
+    #[test]
+    fn dup_span_declines_rather_than_reading_past_the_contig() {
+        let r = StrRef(TG_REPEAT);
+        assert_eq!(
+            intronic_dup_span(&r, "1", 1, b"TG", 0, Strand::Forward),
+            None
+        );
+        assert_eq!(
+            intronic_dup_span(&r, "1", 0, b"TG", 0, Strand::Forward),
+            None
+        );
+        assert_eq!(
+            intronic_dup_span(&r, "1", 81, b"", 0, Strand::Forward),
+            None
+        );
+    }
+
+    /// The whole rewrite: a shifted intronic insertion becomes a `dup` naming the
+    /// block at its 3' end, written from the anchor its own side of the intron.
+    #[test]
+    fn intronic_insertion_becomes_a_dup_at_its_shifted_position() {
+        let r = StrRef(TG_REPEAT);
+        let tr = transcript(Strand::Forward);
+        let out = intronic_ins_as_dup(
+            &r,
+            "1",
+            &tr,
+            "ENST00000000001.1:c.20+59_20+60insTG",
+            81,
+            b"TG",
+            60,
+            Some(1),
+            Some(40),
+        );
+        // 79 and 80 are the last two intronic bases, one and two before exon 2,
+        // so they are written from the *downstream* anchor: c.21-2_21-1.
+        assert_eq!(out.as_deref(), Some("ENST00000000001.1:c.21-2_21-1dup"));
+    }
+
+    /// A block reaching out of the intron cannot be written as one offset range -
+    /// offsets count from their own exon and do not run through zero - so the
+    /// insertion notation it already carries is kept.
+    #[test]
+    fn a_block_leaving_the_intron_keeps_its_insertion_notation() {
+        // Exon 2 begins with `C`s, so a `CC` insert at the intron's 3' edge
+        // duplicates a block that starts inside the exon.
+        let r = StrRef(TG_REPEAT);
+        let tr = transcript(Strand::Reverse);
+        let out = intronic_ins_as_dup(
+            &r,
+            "1",
+            &tr,
+            "ENST00000000001.1:c.21-1_21insCC",
+            81,
+            b"CC",
+            0,
+            Some(1),
+            Some(40),
+        );
+        assert_eq!(out, None);
+    }
+
+    /// The property the whole shift exists to provide, and the one that broke:
+    /// every spelling of the same insertion inside a repeat must name the same
+    /// block. Walking every position of the `TG` repeat, each with the rotation
+    /// that spelling carries, must land on one answer.
+    ///
+    /// Against real Ensembl VEP 115.1 this was 0 of 168 transcript rows agreeing
+    /// across the two spellings of six genome-wide variants; VEP agreed on all
+    /// 168.
+    #[test]
+    fn every_spelling_of_one_insertion_names_the_same_block() {
+        let r = StrRef(TG_REPEAT);
+        // The repeat runs 21..=80. An insertion written at offset `k` into it
+        // carries the insert rotated by `k`, and has `60 - k` left to travel.
+        let answers: std::collections::HashSet<_> = (0..60)
+            .map(|k| {
+                let mut ins = b"TG".to_vec();
+                ins.rotate_left(k % 2);
+                intronic_dup_span(&r, "1", 81, &ins, (60 - k) as u64, Strand::Forward)
+            })
+            .collect();
+        assert_eq!(
+            answers,
+            [Some((79, 80))].into_iter().collect(),
+            "every spelling must name the last two bases of the repeat"
+        );
+    }
+
+    /// A span running past the intron's own midpoint is still one intron, and is
+    /// written from the exon on either side. Requiring one shared anchor instead
+    /// left 160 such rows as `ins` where Ensembl writes `c.5044+27_5045-47dup`.
+    #[test]
+    fn a_span_crossing_the_intron_midpoint_is_still_one_dup() {
+        // A 60-base insert filling the whole intron duplicates all of it.
+        let r = StrRef(TG_REPEAT);
+        let tr = transcript(Strand::Forward);
+        let ins: Vec<u8> = TG_REPEAT.as_bytes()[20..80].to_vec();
+        let out = intronic_ins_as_dup(
+            &r,
+            "1",
+            &tr,
+            "ENST00000000001.1:c.20+60_21-0ins…",
+            81,
+            &ins,
+            0,
+            Some(1),
+            Some(40),
+        );
+        assert_eq!(out.as_deref(), Some("ENST00000000001.1:c.20+1_21-1dup"));
     }
 }

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -10,8 +10,8 @@
 mod hgvs_normalize;
 
 pub use hgvs_normalize::{
-    convert_ins_to_dup, convert_ins_to_dup_noncoding, convert_ins_to_dup_range,
-    convert_ins_to_dup_range_noncoding, three_prime_shift_intronic,
+    convert_ins_to_dup_range, convert_ins_to_dup_range_noncoding, hgvsc_intronic_shifted,
+    intronic_dup_span, intronic_ins_as_dup, three_prime_shift_intronic,
 };
 
 use anyhow::{Context, Result};
@@ -457,32 +457,25 @@ impl AnnotationContext {
                                             // one end in an exon and the other in an
                                             // intron has no exonic cDNA pair, and
                                             // `intron_at` reads its first base only.
-                                            // `intronic_or_exonic_cdna` returns
+                                            // `hgvsc_intronic_shifted` returns
                                             // `None` for anything it cannot place,
                                             // which is the real guard.
-                                            if let Some((cdna_pos, offset)) =
-                                                intronic_or_exonic_cdna(tr, vf.position.start)
-                                            {
-                                                let (end_cdna, end_offset) =
-                                                    if vf.position.start != vf.position.end {
-                                                        intronic_or_exonic_cdna(tr, vf.position.end)
-                                                            .map(|(c, o)| (Some(c), Some(o)))
-                                                            .unwrap_or((None, None))
-                                                    } else {
-                                                        (None, None)
-                                                    };
-                                                ann.hgvsc = fastvep_hgvs::hgvsc_intronic_range(
-                                                    &versioned_tid,
-                                                    cdna_pos,
-                                                    offset,
-                                                    end_cdna,
-                                                    end_offset,
-                                                    &hgvs_ref,
-                                                    &hgvs_alt,
-                                                    coding_start,
-                                                    tr.cdna_coding_end,
-                                                );
-                                            }
+                                            ann.hgvsc = hgvsc_intronic_shifted(
+                                                self.seq_provider
+                                                    .as_deref()
+                                                    .map(|sp| sp as &dyn SequenceProvider),
+                                                chrom,
+                                                tr,
+                                                &versioned_tid,
+                                                vf.position.start,
+                                                vf.position.end,
+                                                &vf.ref_allele,
+                                                &ac.allele,
+                                                &hgvs_ref,
+                                                &hgvs_alt,
+                                                Some(coding_start),
+                                                tr.cdna_coding_end,
+                                            );
                                         }
                                     } else if let (Some(cs), Some(ce)) =
                                         (ac.cdna_start, ac.cdna_end)
@@ -500,31 +493,25 @@ impl AnnotationContext {
                                         // one end in an exon and the other in an
                                         // intron has no exonic cDNA pair, and
                                         // `intron_at` reads its first base only.
-                                        // `intronic_or_exonic_cdna` returns
+                                        // `hgvsc_intronic_shifted` returns
                                         // `None` for anything it cannot place,
                                         // which is the real guard.
-                                        if let Some((cdna_pos, offset)) =
-                                            intronic_or_exonic_cdna(tr, vf.position.start)
-                                        {
-                                            let (end_cdna, end_offset) =
-                                                if vf.position.start != vf.position.end {
-                                                    intronic_or_exonic_cdna(tr, vf.position.end)
-                                                        .map(|(c, o)| (Some(c), Some(o)))
-                                                        .unwrap_or((None, None))
-                                                } else {
-                                                    (None, None)
-                                                };
-                                            ann.hgvsc =
-                                                fastvep_hgvs::hgvsc_noncoding_intronic_range(
-                                                    &versioned_tid,
-                                                    cdna_pos,
-                                                    offset,
-                                                    end_cdna,
-                                                    end_offset,
-                                                    &hgvs_ref,
-                                                    &hgvs_alt,
-                                                );
-                                        }
+                                        ann.hgvsc = hgvsc_intronic_shifted(
+                                            self.seq_provider
+                                                .as_deref()
+                                                .map(|sp| sp as &dyn SequenceProvider),
+                                            chrom,
+                                            tr,
+                                            &versioned_tid,
+                                            vf.position.start,
+                                            vf.position.end,
+                                            &vf.ref_allele,
+                                            &ac.allele,
+                                            &hgvs_ref,
+                                            &hgvs_alt,
+                                            None,
+                                            None,
+                                        );
                                     }
 
                                     // HGVSp

--- a/crates/fastvep-annotate/tests/intronic_hgvs_normalization.rs
+++ b/crates/fastvep-annotate/tests/intronic_hgvs_normalization.rs
@@ -1,0 +1,405 @@
+//! The HGVS 3'-rule holds for intronic indels, on both strands.
+//!
+//! An insertion inside a repeat can be written at any position the repeat allows
+//! and describes the same variant every time, so every spelling must produce one
+//! HGVSc. fastVEP did not: the dup anchor was derived by walking the *unshifted*
+//! insertion point one base at a time while the next base repeated the current
+//! one, which slides through a homopolymer and nowhere else. A `TG` insertion in
+//! a `TGTG…` repeat therefore never moved.
+//!
+//! Measured against real Ensembl VEP 115.1 (`ensemblorg/ensembl-vep:release_115.1`,
+//! `--gff` mode, Ensembl 115 GRCh38 GFF3 + FASTA) over six genome-wide variants
+//! written both ways: VEP returned one string on all 168 transcript rows,
+//! fastVEP returned two on all 168. Genome-wide over a 20,241-variant HG002
+//! sample that was 1,390 of 1,538 disagreeing HGVSc rows.
+//!
+//! These tests go through `hgvsc_intronic_shifted`, which is the intronic path
+//! both annotation loops call, so a regression in either one fails here.
+
+use anyhow::{anyhow, Result};
+use fastvep_annotate::hgvsc_intronic_shifted;
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_core::{Allele, Strand};
+use fastvep_genome::{Exon, Gene, Transcript};
+
+/// Reference for one contig, 1-based inclusive, `Err` past the end - the same
+/// contract the FASTA readers keep.
+struct MemRef(String);
+
+impl SequenceProvider for MemRef {
+    fn fetch_sequence(&self, _chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
+        if start < 1 || end < start {
+            return Err(anyhow!("bad range"));
+        }
+        let b = self.0.as_bytes();
+        let s0 = (start - 1) as usize;
+        if s0 >= b.len() {
+            return Err(anyhow!("past contig end"));
+        }
+        Ok(b[s0..(end as usize).min(b.len())].to_vec())
+    }
+}
+
+/// Exon 1 at 1..=20, intron at 21..=80, exon 2 at 81..=100. The intron is a
+/// `TG` repeat, so an insertion of `TG` slides its whole length.
+fn reference() -> MemRef {
+    MemRef(format!(
+        "{}{}{}",
+        "A".repeat(20),
+        "TG".repeat(30),
+        "C".repeat(20)
+    ))
+}
+
+fn transcript(strand: Strand) -> Transcript {
+    let exon = |start: u64, end: u64, rank: u32| Exon {
+        stable_id: format!("ENSE{rank}"),
+        start,
+        end,
+        strand,
+        phase: 0,
+        end_phase: 0,
+        rank,
+    };
+    Transcript {
+        stable_id: "ENST00000000001".into(),
+        version: Some(1),
+        gene: Gene {
+            stable_id: "ENSG00000000001".into(),
+            symbol: Some("TEST".into()),
+            symbol_source: None,
+            hgnc_id: None,
+            biotype: "protein_coding".into(),
+            chromosome: "1".into(),
+            start: 1,
+            end: 100,
+            strand,
+        },
+        biotype: "protein_coding".into(),
+        chromosome: "1".into(),
+        start: 1,
+        end: 100,
+        strand,
+        exons: vec![exon(1, 20, 1), exon(81, 100, 2)],
+        translation: None,
+        cdna_coding_start: Some(1),
+        cdna_coding_end: Some(40),
+        coding_region_start: None,
+        coding_region_end: None,
+        spliced_seq: None,
+        translateable_seq: None,
+        peptide: None,
+        canonical: true,
+        mane_select: None,
+        mane_plus_clinical: None,
+        tsl: None,
+        appris: None,
+        ccds: None,
+        protein_id: None,
+        protein_version: None,
+        swissprot: vec![],
+        trembl: vec![],
+        uniparc: vec![],
+        refseq_id: None,
+        source: None,
+        gencode_primary: false,
+        flags: vec![],
+        codon_table_start_phase: 0,
+    }
+}
+
+fn revcomp(bases: &[u8]) -> Vec<u8> {
+    bases
+        .iter()
+        .rev()
+        .map(|b| match b.to_ascii_uppercase() {
+            b'A' => b'T',
+            b'C' => b'G',
+            b'G' => b'C',
+            b'T' => b'A',
+            other => other,
+        })
+        .collect()
+}
+
+/// Annotate one spelling of an intronic insertion, the way both per-variant
+/// loops do: the shift reads the genomic alleles, the notation is written from
+/// the transcript-oriented pair.
+fn hgvsc_for_insertion(strand: Strand, vcf_pos: u64, ins: &[u8]) -> Option<String> {
+    let reference = reference();
+    let tr = transcript(strand);
+    let genomic_alt = Allele::Sequence(ins.to_vec());
+    let hgvs_alt = match strand {
+        Strand::Forward => genomic_alt.clone(),
+        Strand::Reverse => Allele::Sequence(revcomp(ins)),
+    };
+    hgvsc_intronic_shifted(
+        Some(&reference),
+        "1",
+        &tr,
+        "ENST00000000001.1",
+        // Ensembl's convention for an insertion: start is one past end.
+        vcf_pos + 1,
+        vcf_pos,
+        &Allele::Deletion,
+        &genomic_alt,
+        &Allele::Deletion,
+        &hgvs_alt,
+        Some(1),
+        Some(40),
+    )
+}
+
+/// Every position of the repeat is the same variant, so every spelling must
+/// produce the same HGVSc. This is the property that failed on 168 of 168 rows.
+#[test]
+fn every_spelling_of_an_intronic_insertion_agrees_on_the_forward_strand() {
+    // The repeat runs 21..=80. Inserting after position `p` carries the rotation
+    // that position implies: `TG` at an even offset, `GT` at an odd one.
+    let spellings: Vec<String> = (20..80)
+        .map(|p| {
+            let ins: &[u8] = if (p - 20) % 2 == 0 { b"TG" } else { b"GT" };
+            hgvsc_for_insertion(Strand::Forward, p, ins)
+                .unwrap_or_else(|| panic!("no HGVSc at position {p}"))
+        })
+        .collect();
+    let first = &spellings[0];
+    assert!(
+        spellings.iter().all(|s| s == first),
+        "60 spellings of one variant produced {} distinct strings: {:?}",
+        spellings
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        spellings.iter().collect::<std::collections::HashSet<_>>()
+    );
+    // The 3'-most placement on the forward strand is the end of the repeat, two
+    // bases before exon 2, so the block is written from the downstream anchor.
+    assert_eq!(first, "ENST00000000001.1:c.21-2_21-1dup");
+}
+
+/// 3' runs towards lower coordinates on the reverse strand, so the same repeat
+/// normalises to its other end - and the tool must not simply keep whichever end
+/// the VCF happened to name.
+#[test]
+fn every_spelling_of_an_intronic_insertion_agrees_on_the_reverse_strand() {
+    let spellings: Vec<String> = (20..80)
+        .map(|p| {
+            let ins: &[u8] = if (p - 20) % 2 == 0 { b"TG" } else { b"GT" };
+            hgvsc_for_insertion(Strand::Reverse, p, ins)
+                .unwrap_or_else(|| panic!("no HGVSc at position {p}"))
+        })
+        .collect();
+    let first = &spellings[0];
+    assert!(
+        spellings.iter().all(|s| s == first),
+        "60 spellings of one variant produced {:?}",
+        spellings.iter().collect::<std::collections::HashSet<_>>()
+    );
+    assert!(
+        first.ends_with("dup"),
+        "an insertion that duplicates the repeat it sits in is a dup, got {first}"
+    );
+}
+
+/// The two strands must not land on the same genomic block: the rule is
+/// direction-sensitive, and a shift that ignored strand would pick the same end
+/// of the repeat for both.
+///
+/// The two `c.` strings coincide, which is not a coincidence and not agreement:
+/// `c.21-1` counts one base 5' of exon 2's first base in *transcript* order, so
+/// it is genomic 80 on the forward strand and genomic 21 on the reverse. The
+/// same name denotes mirrored blocks, which is exactly why the genomic span is
+/// the thing worth asserting.
+#[test]
+fn the_two_strands_normalise_to_opposite_ends_of_the_repeat() {
+    let reference = reference();
+    let fwd = fastvep_annotate::intronic_dup_span(&reference, "1", 81, b"TG", 60, Strand::Forward);
+    let rev = fastvep_annotate::intronic_dup_span(&reference, "1", 21, b"TG", 0, Strand::Reverse);
+    assert_eq!(fwd, Some((79, 80)), "forward 3' is the end nearer exon 2");
+    assert_eq!(rev, Some((21, 22)), "reverse 3' is the end nearer exon 1");
+}
+
+/// An insertion is written over both bases it sits between, and across the
+/// middle of an intron those two anchor to different exons: `+n` counts from the
+/// exon before, `-m` from the one after. Inferring the second coordinate as
+/// `offset + 1` produced `c.20+30_20+31ins…`, naming a base past the half the
+/// donor-side offsets reach.
+#[test]
+fn an_insertion_at_the_intron_midpoint_is_written_from_both_exons() {
+    // Intron 21..=80, so genomic 50 is c.20+30 and genomic 51 is c.21-30.
+    // `AAA` matches neither side of the `TG` repeat, so nothing shifts and the
+    // coordinates are the ones under test.
+    let out = hgvsc_for_insertion(Strand::Forward, 50, b"AAA");
+    assert_eq!(
+        out.as_deref(),
+        Some("ENST00000000001.1:c.20+30_21-30insAAA")
+    );
+}
+
+/// A deletion follows the same rule, and shares the same shift.
+#[test]
+fn every_spelling_of_an_intronic_deletion_agrees() {
+    let reference = reference();
+    let tr = transcript(Strand::Forward);
+    let spellings: Vec<String> = (21..79)
+        .step_by(2)
+        .map(|start| {
+            let deleted: &[u8] = b"TG";
+            hgvsc_intronic_shifted(
+                Some(&reference),
+                "1",
+                &tr,
+                "ENST00000000001.1",
+                start,
+                start + 1,
+                &Allele::Sequence(deleted.to_vec()),
+                &Allele::Deletion,
+                &Allele::Sequence(deleted.to_vec()),
+                &Allele::Deletion,
+                Some(1),
+                Some(40),
+            )
+            .unwrap_or_else(|| panic!("no HGVSc at position {start}"))
+        })
+        .collect();
+    let first = &spellings[0];
+    assert!(
+        spellings.iter().all(|s| s == first),
+        "spellings of one deletion disagreed: {:?}",
+        spellings.iter().collect::<std::collections::HashSet<_>>()
+    );
+    assert_eq!(first, "ENST00000000001.1:c.21-2_21-1del");
+}
+
+/// Without a reference there is nothing to shift against, and the variant is
+/// still described - at the position the VCF gave it.
+#[test]
+fn no_reference_still_produces_a_description() {
+    let tr = transcript(Strand::Forward);
+    let out = hgvsc_intronic_shifted(
+        None,
+        "1",
+        &tr,
+        "ENST00000000001.1",
+        41,
+        40,
+        &Allele::Deletion,
+        &Allele::Sequence(b"TG".to_vec()),
+        &Allele::Deletion,
+        &Allele::Sequence(b"TG".to_vec()),
+        Some(1),
+        Some(40),
+    );
+    assert_eq!(out.as_deref(), Some("ENST00000000001.1:c.20+20_20+21insTG"));
+}
+
+/// The inserted string rotates as the variant travels, and `hgvs_alt` is already
+/// in transcript orientation - where the shift always runs 3' whichever way the
+/// transcript does, so the rotation is always leftward. Rotating right on the
+/// reverse strand named the right position with the wrong bases:
+/// `c.21-21_21-20insGTC` where the same transcript calls the same variant
+/// `insCGT` when the VCF spells it one base over.
+///
+/// This only shows on a *partial* shift. A shift of a whole period, or one that
+/// ends on a duplication, hides it - which is why 716 of 717 reverse-strand
+/// intronic `ins` rows in the HG002 sample agreed with VEP regardless.
+#[test]
+fn a_partial_shift_rotates_the_insert_the_same_way_on_both_strands() {
+    // Deliberately imperfect repeats, so the shift stops mid-period.
+    let patterns = [
+        "ACGACGACTTTGCA",
+        "AACAACAAGGTTCC",
+        "GTGTGTTTACCAGG",
+        "TTATTATTGCCAAG",
+    ];
+    let inserts: [&[u8]; 5] = [b"ACG", b"AAC", b"GT", b"TTA", b"ACGA"];
+    let mut disagreed = Vec::new();
+    for pattern in patterns {
+        let seq = format!("{}{}{}", "N".repeat(20), pattern.repeat(10), "N".repeat(20));
+        let reference = MemRef(seq.clone());
+        for ins in inserts {
+            for strand in [Strand::Forward, Strand::Reverse] {
+                for base in [40u64, 61, 77] {
+                    let forms = equivalent_spellings(&seq, base, ins);
+                    if forms.len() < 2 {
+                        continue;
+                    }
+                    // Every spelling must produce a string. Dropping the ones
+                    // that do not would let a regression that stopped naming
+                    // them pass with a set of size one.
+                    let answers: std::collections::BTreeSet<String> = forms
+                        .iter()
+                        .map(|(pos, genomic)| {
+                            let hgvs_alt = match strand {
+                                Strand::Forward => Allele::Sequence(genomic.clone()),
+                                Strand::Reverse => Allele::Sequence(revcomp(genomic)),
+                            };
+                            hgvsc_intronic_shifted(
+                                Some(&reference),
+                                "1",
+                                &wide_transcript(strand),
+                                "ENST00000000001.1",
+                                pos + 1,
+                                *pos,
+                                &Allele::Deletion,
+                                &Allele::Sequence(genomic.clone()),
+                                &Allele::Deletion,
+                                &hgvs_alt,
+                                Some(1),
+                                Some(40),
+                            )
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "no HGVSc for {pattern} ins={} {strand:?} at {pos}",
+                                    String::from_utf8_lossy(genomic)
+                                )
+                            })
+                        })
+                        .collect();
+                    if answers.len() > 1 {
+                        disagreed.push(format!(
+                            "{pattern} ins={} {strand:?} at {base}: {answers:?}",
+                            String::from_utf8_lossy(ins)
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        disagreed.is_empty(),
+        "{} configurations gave more than one answer:\n  {}",
+        disagreed.len(),
+        disagreed.join("\n  ")
+    );
+}
+
+/// Every way the reference lets one insertion be written: slide it 3' along the
+/// genome one base at a time, rotating the inserted string as it goes, for as
+/// long as the sequence is unchanged.
+fn equivalent_spellings(reference: &str, pos: u64, ins: &[u8]) -> Vec<(u64, Vec<u8>)> {
+    let bases = reference.as_bytes();
+    let len = ins.len();
+    let mut out = vec![(pos, ins.to_vec())];
+    let mut k = 0usize;
+    while (pos as usize) + k < bases.len()
+        && bases[(pos as usize) + k].eq_ignore_ascii_case(&ins[k % len])
+    {
+        k += 1;
+        let mut rotated = ins.to_vec();
+        rotated.rotate_left(k % len);
+        out.push((pos + k as u64, rotated));
+    }
+    out
+}
+
+/// Exons far enough apart that the patterns above sit well inside the intron.
+fn wide_transcript(strand: Strand) -> Transcript {
+    let mut t = transcript(strand);
+    t.end = 200;
+    t.gene.end = 200;
+    t.exons[1].start = 181;
+    t.exons[1].end = 200;
+    t
+}

--- a/crates/fastvep-annotate/tests/intronic_shift_allocations.rs
+++ b/crates/fastvep-annotate/tests/intronic_shift_allocations.rs
@@ -1,0 +1,122 @@
+//! Pins the allocation behaviour of the intronic 3'-shift.
+//!
+//! The shift walked the reference one base at a time, calling `fetch_sequence`
+//! per step - and twice per step for a deletion, once for each end - with every
+//! call returning an owned `Vec`. A variant sliding 60 bases down a repeat cost
+//! 60 heap allocations, or 120 as a deletion, and the walk runs once per
+//! (variant x transcript x allele): a gene-dense locus with twenty overlapping
+//! transcripts pays it twenty times for the same variant.
+//!
+//! It now reads a block at a time, so the count is set by how many blocks the
+//! walk crosses rather than by how far it travels.
+//!
+//! This file installs a counting global allocator, so it deliberately holds
+//! exactly ONE test: `cargo test` runs the tests in a binary concurrently, and a
+//! second test allocating on another thread would be counted here.
+
+use anyhow::{anyhow, Result};
+use fastvep_annotate::three_prime_shift_intronic;
+use fastvep_cache::providers::SequenceProvider;
+use fastvep_core::{Allele, Strand};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn allocations_during<F: FnOnce()>(f: F) -> usize {
+    let before = ALLOCS.load(Ordering::Relaxed);
+    f();
+    ALLOCS.load(Ordering::Relaxed) - before
+}
+
+/// Owns its sequence, so a fetch allocates exactly once - the same shape the
+/// real FASTA readers have, which return an owned `Vec` per call.
+struct MemRef(Vec<u8>);
+
+impl SequenceProvider for MemRef {
+    fn fetch_sequence(&self, _chrom: &str, start: u64, end: u64) -> Result<Vec<u8>> {
+        if start < 1 || end < start {
+            return Err(anyhow!("bad range"));
+        }
+        let s0 = (start - 1) as usize;
+        if s0 >= self.0.len() {
+            return Err(anyhow!("past contig end"));
+        }
+        Ok(self.0[s0..(end as usize).min(self.0.len())].to_vec())
+    }
+}
+
+#[test]
+fn the_shift_reads_the_reference_in_blocks_not_a_base_at_a_time() {
+    // 4,000 bases of `TG`, an intron a variant can slide a long way down.
+    let reference = MemRef(b"TG".repeat(2_000).to_vec());
+    let intron = (1u64, 4_000u64);
+
+    // An insertion travelling the full repeat: 3,999 steps.
+    let mut landed = (0, 0);
+    let insertion = allocations_during(|| {
+        landed = three_prime_shift_intronic(
+            &reference,
+            "1",
+            1,
+            0,
+            &Allele::Deletion,
+            &Allele::Sequence(b"TG".to_vec()),
+            Strand::Forward,
+            intron.0,
+            intron.1,
+        );
+    });
+    // The insertion point ends one past the last intronic base it slid over.
+    assert_eq!(landed.0, 4_001, "the walk should cross the whole repeat");
+
+    // A deletion travelling the same distance, reading both of its ends.
+    let mut deleted = (0, 0);
+    let deletion = allocations_during(|| {
+        deleted = three_prime_shift_intronic(
+            &reference,
+            "1",
+            1,
+            2,
+            &Allele::Sequence(b"TG".to_vec()),
+            &Allele::Deletion,
+            Strand::Forward,
+            intron.0,
+            intron.1,
+        );
+    });
+    assert_eq!(deleted.1, 4_000, "the walk should cross the whole repeat");
+
+    // Measured: 32 and 63. A 256-base block centred on the request leaves 128
+    // bases in the direction of travel, so a 4,000-base walk refills about 32
+    // times, and the deletion pays that once per end. Per-base reads cost ~4,000
+    // and ~8,000. The budget is loose enough to survive a block-size change and
+    // tight enough that a return to per-base reads fails it.
+    assert!(
+        insertion <= 64,
+        "insertion shift allocated {insertion} times crossing 4,000 bases"
+    );
+    assert!(
+        deletion <= 128,
+        "deletion shift allocated {deletion} times crossing 4,000 bases"
+    );
+}

--- a/crates/fastvep-cli/src/pipeline/annotate.rs
+++ b/crates/fastvep-cli/src/pipeline/annotate.rs
@@ -15,7 +15,7 @@ use fastvep_cache::providers::{
 };
 use fastvep_cache::transcript_cache::StaleCacheFormat;
 use fastvep_consequence::ConsequencePredictor;
-use fastvep_core::{Allele, Consequence};
+use fastvep_core::Consequence;
 use fastvep_genome::Transcript;
 use fastvep_hgvs;
 use fastvep_io::output;
@@ -30,9 +30,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 // Shared annotation utilities from fastvep-annotate (used by batch pipeline).
 use fastvep_annotate::{
-    annotate_intergenic, annotate_sa_only_scaffold, convert_ins_to_dup,
-    convert_ins_to_dup_noncoding, load_gene_providers, load_sa_providers,
-    reverse_complement_allele, three_prime_shift_intronic, zip_positions,
+    annotate_intergenic, annotate_sa_only_scaffold, load_gene_providers, load_sa_providers,
+    reverse_complement_allele, zip_positions,
 };
 
 const BATCH_SIZE: usize = 1024;
@@ -294,167 +293,23 @@ fn annotate_variant(
                                         // one end in an exon and the other in an
                                         // intron has no exonic cDNA pair, and
                                         // `intron_at` reads its first base only.
-                                        // `intronic_or_exonic_cdna` returns
+                                        // `hgvsc_intronic_shifted` returns
                                         // `None` for anything it cannot place,
                                         // which is the real guard.
-                                        // Intronic variant: offset notation
-                                        // Note: intronic HGVS uses original coding_start (no phase adjustment)
-                                        // Apply HGVS 3' normalization for intronic indels
-                                        let (shifted_start, shifted_end) = if let Some(sp) = seq_provider {
-                                            let is_indel = matches!((&hgvs_ref, &hgvs_alt),
-                                                (Allele::Sequence(_), Allele::Deletion) |
-                                                (Allele::Deletion, Allele::Sequence(_)));
-                                            if is_indel {
-                                                if let Some((istart, iend)) = tr.intron_bounds_at(vf.position.start) {
-                                                    // Use genomic-strand alleles for ref comparison
-                                                    three_prime_shift_intronic(
-                                                        sp, chrom,
-                                                        vf.position.start, vf.position.end,
-                                                        &vf.ref_allele, &ac.allele,
-                                                        tr.strand, istart, iend,
-                                                    )
-                                                } else {
-                                                    (vf.position.start, vf.position.end)
-                                                }
-                                            } else {
-                                                (vf.position.start, vf.position.end)
-                                            }
-                                        } else {
-                                            (vf.position.start, vf.position.end)
-                                        };
-                                        // For insertions, build the rotated insertion bases
-                                        // after 3' shifting (bases rotate as position shifts)
-                                        let shifted_hgvs_alt = if let (Allele::Deletion, Allele::Sequence(ins_bases)) = (&hgvs_ref, &hgvs_alt) {
-                                            if shifted_start != vf.position.start && !ins_bases.is_empty() {
-                                                // Calculate how many positions we shifted
-                                                let shift_amount = if tr.strand == fastvep_core::Strand::Forward {
-                                                    (shifted_start as i64 - vf.position.start as i64) as usize
-                                                } else {
-                                                    (vf.position.start as i64 - shifted_start as i64) as usize
-                                                };
-                                                // Rotate: for forward strand, each shift moves first base to end
-                                                // For reverse strand, each shift moves last base to front
-                                                let mut rotated = ins_bases.clone();
-                                                let len = rotated.len();
-                                                if len > 0 {
-                                                    let effective_shift = shift_amount % len;
-                                                    match tr.strand {
-                                                        fastvep_core::Strand::Forward => {
-                                                            rotated.rotate_left(effective_shift);
-                                                        }
-                                                        fastvep_core::Strand::Reverse => {
-                                                            rotated.rotate_right(effective_shift);
-                                                        }
-                                                    }
-                                                }
-                                                Allele::Sequence(rotated)
-                                            } else {
-                                                hgvs_alt.clone()
-                                            }
-                                        } else {
-                                            hgvs_alt.clone()
-                                        };
-
-                                        // For insertions, use position before insertion
-                                        // for the primary HGVS coordinate (ins is BETWEEN two bases).
-                                        // On reverse strand, the insertion is between P and P+1 in
-                                        // genomic coords, but P+1 is 5' in transcript order, so we
-                                        // use P+1 as the HGVS start coordinate.
-                                        let is_insertion = matches!((&hgvs_ref, &shifted_hgvs_alt), (Allele::Deletion, Allele::Sequence(_)));
-                                        let hgvs_pos = if is_insertion {
-                                            if tr.strand == fastvep_core::Strand::Reverse {
-                                                shifted_end + 1
-                                            } else {
-                                                shifted_end // base before insertion
-                                            }
-                                        } else {
-                                            shifted_start
-                                        };
-                                        if let Some((cdna_pos, offset)) = fastvep_annotate::intronic_or_exonic_cdna(tr, hgvs_pos) {
-                                            // For multi-base variants, compute end position too
-                                            let (end_cdna, end_offset) = if shifted_start != shifted_end && hgvs_pos == shifted_start {
-                                                fastvep_annotate::intronic_or_exonic_cdna(tr, shifted_end)
-                                                    .map(|(c, o)| (Some(c), Some(o)))
-                                                    .unwrap_or((None, None))
-                                            } else {
-                                                (None, None)
-                                            };
-                                            let mut hgvsc = fastvep_hgvs::hgvsc_intronic_range(
-                                                &versioned_tid,
-                                                cdna_pos,
-                                                offset,
-                                                end_cdna,
-                                                end_offset,
-                                                &hgvs_ref,
-                                                &shifted_hgvs_alt,
-                                                coding_start,
-                                                tr.cdna_coding_end,
-                                            );
-                                            // For intronic insertions, check if it's a dup.
-                                            if let (Some(ref h), Allele::Deletion, Allele::Sequence(_)) =
-                                                (&hgvsc, &hgvs_ref, &hgvs_alt)
-                                            {
-                                                if h.contains("ins") {
-                                                    let orig_ins = match &ac.allele {
-                                                        Allele::Sequence(b) => b.clone(),
-                                                        _ => vec![],
-                                                    };
-                                                    if !orig_ins.is_empty() {
-                                                        if let Some(sp) = seq_provider {
-                                                            let ins_len = orig_ins.len() as u64;
-                                                            // Check dup_before: base(s) before insertion match
-                                                            let check_end = vf.position.end;
-                                                            let check_start = check_end.saturating_sub(ins_len - 1);
-                                                            let dup_before = if let Ok(ref_seq) = sp.fetch_sequence_slice(chrom, check_start, check_end) {
-                                                                ref_seq.len() == orig_ins.len()
-                                                                    && ref_seq.iter().zip(orig_ins.iter())
-                                                                        .all(|(a, b)| a.eq_ignore_ascii_case(b))
-                                                            } else { false };
-                                                            // Check dup_after: base(s) after insertion match
-                                                            let dup_after = if !dup_before {
-                                                                let cs = vf.position.start;
-                                                                let ce = cs + ins_len - 1;
-                                                                if let Ok(ref_seq) = sp.fetch_sequence_slice(chrom, cs, ce) {
-                                                                    ref_seq.len() == orig_ins.len()
-                                                                        && ref_seq.iter().zip(orig_ins.iter())
-                                                                            .all(|(a, b)| a.eq_ignore_ascii_case(b))
-                                                                } else { false }
-                                                            } else { false };
-                                                            if dup_before || dup_after {
-                                                                // For dups, determine the dup base position and 3' shift it
-                                                                let dup_base_pos = if dup_before {
-                                                                    // Dup base is before insertion: position.end
-                                                                    vf.position.end
-                                                                } else {
-                                                                    // Dup base is after insertion: position.start
-                                                                    vf.position.start
-                                                                };
-                                                                // 3' shift the dup position within the intron
-                                                                let shifted_dup = if let Some((istart, iend)) = tr.intron_bounds_at(dup_base_pos) {
-                                                                    let (sd, _) = three_prime_shift_intronic(
-                                                                        sp, chrom,
-                                                                        dup_base_pos, dup_base_pos,
-                                                                        &Allele::Sequence(orig_ins.clone()), &Allele::Deletion,
-                                                                        tr.strand, istart, iend,
-                                                                    );
-                                                                    sd
-                                                                } else {
-                                                                    dup_base_pos
-                                                                };
-                                                                // Use shifted_dup (start of dup region) for offset computation
-                                                                if let Some((dup_cdna, dup_offset)) = tr.genomic_to_intronic_cdna(shifted_dup) {
-                                                                    // `None` means the duplicated block crosses the exon
-                                                                    // boundary and cannot be written from one anchor;
-                                                                    // the insertion notation already there is correct.
-                                                                    hgvsc = convert_ins_to_dup(h, dup_offset, ins_len, dup_cdna, coding_start, tr.cdna_coding_end).or_else(|| hgvsc.clone());
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            ann.hgvsc = hgvsc;
-                                        }
+                                        ann.hgvsc = fastvep_annotate::hgvsc_intronic_shifted(
+                                            seq_provider.map(|sp| sp as &dyn SequenceProvider),
+                                            chrom,
+                                            tr,
+                                            &versioned_tid,
+                                            vf.position.start,
+                                            vf.position.end,
+                                            &vf.ref_allele,
+                                            &ac.allele,
+                                            &hgvs_ref,
+                                            &hgvs_alt,
+                                            Some(coding_start),
+                                            tr.cdna_coding_end,
+                                        );
                                     }
                                 } else {
                                     // Non-coding transcript: use n. notation
@@ -472,125 +327,23 @@ fn annotate_variant(
                                         // one end in an exon and the other in an
                                         // intron has no exonic cDNA pair, and
                                         // `intron_at` reads its first base only.
-                                        // `intronic_or_exonic_cdna` returns
+                                        // `hgvsc_intronic_shifted` returns
                                         // `None` for anything it cannot place,
                                         // which is the real guard.
-                                        // Apply 3' normalization for non-coding intronic indels
-                                        let (nc_shifted_start, nc_shifted_end) = if let Some(sp) = seq_provider {
-                                            let is_indel = matches!((&hgvs_ref, &hgvs_alt),
-                                                (Allele::Sequence(_), Allele::Deletion) |
-                                                (Allele::Deletion, Allele::Sequence(_)));
-                                            if is_indel {
-                                                if let Some((istart, iend)) = tr.intron_bounds_at(vf.position.start) {
-                                                    three_prime_shift_intronic(
-                                                        sp, chrom,
-                                                        vf.position.start, vf.position.end,
-                                                        &vf.ref_allele, &ac.allele,
-                                                        tr.strand, istart, iend,
-                                                    )
-                                                } else {
-                                                    (vf.position.start, vf.position.end)
-                                                }
-                                            } else {
-                                                (vf.position.start, vf.position.end)
-                                            }
-                                        } else {
-                                            (vf.position.start, vf.position.end)
-                                        };
-
-                                        // Rotate insertion bases for non-coding
-                                        let nc_shifted_hgvs_alt = if let (Allele::Deletion, Allele::Sequence(ins_bases)) = (&hgvs_ref, &hgvs_alt) {
-                                            if nc_shifted_start != vf.position.start && !ins_bases.is_empty() {
-                                                let shift_amount = if tr.strand == fastvep_core::Strand::Forward {
-                                                    (nc_shifted_start as i64 - vf.position.start as i64) as usize
-                                                } else {
-                                                    (vf.position.start as i64 - nc_shifted_start as i64) as usize
-                                                };
-                                                let mut rotated = ins_bases.clone();
-                                                let len = rotated.len();
-                                                if len > 0 {
-                                                    let effective_shift = shift_amount % len;
-                                                    match tr.strand {
-                                                        fastvep_core::Strand::Forward => rotated.rotate_left(effective_shift),
-                                                        fastvep_core::Strand::Reverse => rotated.rotate_right(effective_shift),
-                                                    }
-                                                }
-                                                Allele::Sequence(rotated)
-                                            } else {
-                                                hgvs_alt.clone()
-                                            }
-                                        } else {
-                                            hgvs_alt.clone()
-                                        };
-
-                                        if let Some((cdna_pos, offset)) = fastvep_annotate::intronic_or_exonic_cdna(tr, nc_shifted_start) {
-                                            let (end_cdna, end_offset) = if nc_shifted_start != nc_shifted_end {
-                                                fastvep_annotate::intronic_or_exonic_cdna(tr, nc_shifted_end)
-                                                    .map(|(c, o)| (Some(c), Some(o)))
-                                                    .unwrap_or((None, None))
-                                            } else {
-                                                (None, None)
-                                            };
-                                            let mut hgvsc = fastvep_hgvs::hgvsc_noncoding_intronic_range(
-                                                &versioned_tid,
-                                                cdna_pos,
-                                                offset,
-                                                end_cdna,
-                                                end_offset,
-                                                &hgvs_ref,
-                                                &nc_shifted_hgvs_alt,
-                                            );
-                                            // Dup detection for non-coding intronic insertions
-                                            if let (Some(ref h), Allele::Deletion, Allele::Sequence(_)) =
-                                                (&hgvsc, &hgvs_ref, &hgvs_alt)
-                                            {
-                                                if h.contains("ins") {
-                                                    let orig_ins = match &ac.allele {
-                                                        Allele::Sequence(b) => b.clone(),
-                                                        _ => vec![],
-                                                    };
-                                                    if !orig_ins.is_empty() {
-                                                        if let Some(sp) = seq_provider {
-                                                            let ins_len = orig_ins.len() as u64;
-                                                            let check_end = vf.position.end;
-                                                            let check_start = check_end.saturating_sub(ins_len - 1);
-                                                            let dup_before = if let Ok(ref_seq) = sp.fetch_sequence_slice(chrom, check_start, check_end) {
-                                                                ref_seq.len() == orig_ins.len()
-                                                                    && ref_seq.iter().zip(orig_ins.iter())
-                                                                        .all(|(a, b)| a.eq_ignore_ascii_case(b))
-                                                            } else { false };
-                                                            let dup_after = if !dup_before {
-                                                                let cs = vf.position.start;
-                                                                let ce = cs + ins_len - 1;
-                                                                if let Ok(ref_seq) = sp.fetch_sequence_slice(chrom, cs, ce) {
-                                                                    ref_seq.len() == orig_ins.len()
-                                                                        && ref_seq.iter().zip(orig_ins.iter())
-                                                                            .all(|(a, b)| a.eq_ignore_ascii_case(b))
-                                                                } else { false }
-                                                            } else { false };
-                                                            if dup_before || dup_after {
-                                                                let dup_base_pos = if dup_before { vf.position.end } else { vf.position.start };
-                                                                let shifted_dup = if let Some((istart, iend)) = tr.intron_bounds_at(dup_base_pos) {
-                                                                    let (sd, _) = three_prime_shift_intronic(
-                                                                        sp, chrom,
-                                                                        dup_base_pos, dup_base_pos,
-                                                                        &Allele::Sequence(orig_ins.clone()), &Allele::Deletion,
-                                                                        tr.strand, istart, iend,
-                                                                    );
-                                                                    sd
-                                                                } else {
-                                                                    dup_base_pos
-                                                                };
-                                                                if let Some((dup_cdna, dup_offset)) = tr.genomic_to_intronic_cdna(shifted_dup) {
-                                                                    hgvsc = convert_ins_to_dup_noncoding(h, dup_offset, ins_len, dup_cdna).or_else(|| hgvsc.clone());
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            ann.hgvsc = hgvsc;
-                                        }
+                                        ann.hgvsc = fastvep_annotate::hgvsc_intronic_shifted(
+                                            seq_provider.map(|sp| sp as &dyn SequenceProvider),
+                                            chrom,
+                                            tr,
+                                            &versioned_tid,
+                                            vf.position.start,
+                                            vf.position.end,
+                                            &vf.ref_allele,
+                                            &ac.allele,
+                                            &hgvs_ref,
+                                            &hgvs_alt,
+                                            None,
+                                            None,
+                                        );
                                     }
                                 }
                             }

--- a/docs/VEP_DIVERGENCE.md
+++ b/docs/VEP_DIVERGENCE.md
@@ -11,6 +11,11 @@ GRCh38 Ensembl 115 GFF3 and FASTA fastVEP reads, `--hgvs --symbol --canonical`) 
 6,600-variant stratified sample of the ClinVar 2-star+ set: **150,725 matched (variant, allele,
 transcript) rows**, 72,632 of them with a coding consequence.
 
+That sample is stratified to be hard - 54.5 % of its variants are not SNVs, against 7.2 % of the
+ClinVar 2-star+ set it is drawn from - so the rates below are the rates on the shapes that
+disagree, not the rates a typical callset sees. The genome-wide section at the end gives the other
+end of that range.
+
 ## Current agreement
 
 | Field | Scope | Rows disagreeing | Agreement |
@@ -21,7 +26,7 @@ transcript) rows**, 72,632 of them with a coding consequence.
 | Splice terms | all rows | 0 | **100 %** |
 | Whole consequence set | all rows | 117 | 99.92 % |
 | `IMPACT` | all rows | 104 | 99.93 % |
-| `HGVSc` | all rows | 1,774 | 98.82 % |
+| `HGVSc` | all rows | 597 | 99.60 % |
 | `HGVSp` | all rows | 856 | 99.43 % |
 
 Reproduce with `analysis/acmg_benchmark/` for the variant set and the harness described in
@@ -118,14 +123,27 @@ is on the record.
 
 | Gap | Rows | What it looks like |
 |---|---:|---|
-| Intronic 3'-shift off by one, and the anchor side chosen for a duplication deep in a long intron | 1,238 | VEP `c.513+13_513+15dup`, fastVEP `c.513+14_513+16dup`; VEP `c.-65-166_-65-155dup`, fastVEP `c.-65-184_-65-173dup` |
-| A span crossing the exon boundary shifts differently before being named | 243 | VEP `c.2834_2844+13dup`, fastVEP `c.2845_2846insTGAGGG…` |
-| Exonic 3'-shift off by one | 210 | VEP `c.2403_2406del`, fastVEP `c.2404_2407del` |
-| A duplication at an exon edge is written as a boundary insertion | 47 | VEP `c.17430dup`, fastVEP `c.17430_17430+1insT` |
+| The shift crosses the exon boundary and the two tools land on opposite sides of it | 344 | VEP `c.732dup`, fastVEP `c.731-1_731insA`; VEP `n.1134+1del`, fastVEP `n.1135del` |
+| Both ends intronic, but a span reaching the boundary is still placed differently | 151 | VEP `c.956-5_957del`, fastVEP `c.956-6_956del` |
+| Exonic 3'-shift off by one | 66 | VEP `c.2403_2406del`, fastVEP `c.2404_2407del` |
 | fastVEP emits an HGVSc where VEP emits none | 19 | |
 
-These five and divergence 4 account for all 1,774 `HGVSc` mismatches exactly:
-1,238 + 243 + 210 + 47 + 19 + 17.
+These four and divergence 4 account for all 597 `HGVSc` mismatches exactly:
+344 + 151 + 66 + 19 + 17.
+
+495 of the 597 - the first two rows - are the same unfinished piece of work: the 3'-shift is
+bounded by the intron it starts in, so a span that should travel across the splice site stops at
+it. The exonic shift and the intronic shift are each correct within their own territory.
+
+**Fixed since this document was first written.** The largest gap it listed, *"intronic 3'-shift off
+by one, and the anchor side chosen for a duplication deep in a long intron"* (1,238 rows), was
+neither off by one nor about the anchor side. The duplication's position was derived by walking the
+*unshifted* insertion point one base at a time while the next base repeated the current one, which
+slides through a homopolymer and nothing else, so a `TG` insertion in a `TGTG…` repeat never moved
+at all - up to 48 bases from where HGVS puts it, and only 16 % of the disagreements were a single
+base. It also explains a pattern the row counts hid: because that walk stays where the VCF put the
+variant, fastVEP's anchor was the genomically-left one on both strands, so it read as
+under-shifting on forward-strand transcripts and over-shifting on reverse-strand ones.
 
 ### HGVSp
 
@@ -177,6 +195,34 @@ Reproducing the tidier rule instead put a `splice_region_variant` on 63 rows tha
 missense.
 
 ---
+
+## Genome-wide, on an ordinary callset
+
+The table at the top is measured on a sample stratified towards the hard shapes. The same
+comparison over a systematic 1-in-200 sample of the GIAB HG002 WGS callset - 20,241 variants,
+**122,317 matched rows**, real Ensembl VEP 115.1 through the same harness - is the other end of the
+range:
+
+| Field | ClinVar sample | HG002 genome-wide |
+|---|---:|---:|
+| Whole consequence set | 99.92 % | **100.000 %** (0 rows) |
+| `IMPACT` | 99.93 % | **100.000 %** (0 rows) |
+| `HGVSp` | 99.43 % | **99.985 %** (18 rows) |
+| `HGVSc` | 99.60 % | **99.879 %** (148 rows) |
+
+The three fields that carry a clinical call agree completely on a genome-wide callset, because the
+divergences that remain need a coding indel and only 0.5 % of genome-wide transcript rows have a
+coding consequence at all, against 45.2 % in the stratified sample.
+
+`HGVSc` is the exception and does not dilute: before the intronic duplication fix it was **98.74 %**
+genome-wide against 98.82 % on the ClinVar sample, and **87.0 %** on insertion rows, because deep
+intronic repeats are where a WGS callset's indels live and that was exactly the failing case.
+
+Of the 148 rows left, **108 come from multi-allelic VCF records** (`TAA>TA,T`), where the shared
+first base is stripped across all alleles but each allele is not then trimmed on its own, so
+`ACAC>AC` is described as a four-base deletion rather than a two-base one. That is a variant-parsing
+gap rather than an HGVS one, it changes the consequence as well as the name, and it is not fixed
+here.
 
 ## The earlier divergence, still standing
 

--- a/docs/VEP_DIVERGENCE.md
+++ b/docs/VEP_DIVERGENCE.md
@@ -218,11 +218,27 @@ coding consequence at all, against 45.2 % in the stratified sample.
 genome-wide against 98.82 % on the ClinVar sample, and **87.0 %** on insertion rows, because deep
 intronic repeats are where a WGS callset's indels live and that was exactly the failing case.
 
-Of the 148 rows left, **108 come from multi-allelic VCF records** (`TAA>TA,T`), where the shared
-first base is stripped across all alleles but each allele is not then trimmed on its own, so
-`ACAC>AC` is described as a four-base deletion rather than a two-base one. That is a variant-parsing
-gap rather than an HGVS one, it changes the consequence as well as the name, and it is not fixed
-here.
+Most of the 148 rows left come from **multi-allelic VCF records** (`TAA>TA,T`), which are 1.18 % of
+this callset. The shared first base is stripped across all alleles, but each allele is not then
+trimmed against the reference on its own, so `ACAC>AC` stays a four-base replacement where it is a
+two-base deletion.
+
+That is a variant-parsing gap rather than an HGVS one, and it reaches further than the name. Written
+three ways at the same site, the same 5-base deletion comes out:
+
+| VCF | Ensembl VEP 115.1 | fastVEP |
+|---|---|---|
+| `GAAGAA>G` | `-`, `frameshift_variant`, `c.1364_1368del` | `-`, `frameshift_variant`, `c.1365_1369del` |
+| `GAAGAAA>GA` | `-`, `frameshift_variant,splice_region_variant`, `c.1364_1368del` | `A`, `frameshift_variant,splice_region_variant`, `c.1361_1366delinsA` |
+
+VEP trims the shared suffix and reports the allele as a clean deletion; fastVEP carries the extra
+base, which widens the span by one, turns the `del` into a `delins`, and reports `A` where VEP
+reports `-`. A comparison keyed on the allele does not even line those rows up.
+
+Neither dataset here contains a *single*-alt record needing that trim - both are already
+parsimonious - so the gap is reachable only through multi-allelic sites and through callers that
+emit non-minimal records. Fixing it means carrying a position per allele rather than one per site,
+which the variant representation does not do today. It is not fixed here.
 
 ## The earlier divergence, still standing
 


### PR DESCRIPTION
## What this fixes

An intronic insertion inside a repeat can be written at any position the repeat allows and
describes the same variant every time, so every spelling must produce one HGVSc. fastVEP produced
a different one for each spelling.

The duplication's position was derived by re-shifting the **unshifted** insertion point through
`three_prime_shift_intronic` over a single position. That walk steps while the next base repeats
the current one, which is a homopolymer test, not the repeat-period test an insertion needs. A `TG`
insertion in a `TGTG…` repeat therefore never moved at all, and the correctly-shifted position
computed a few lines earlier was discarded.

This also explains a pattern the row counts hid. Because the walk stays where the VCF put the
variant, fastVEP's anchor was the genomically-left one on **both** strands, so it read as
under-shifting on forward-strand transcripts (1,000 rows) and over-shifting on reverse-strand ones
(390 rows), with no exceptions either way.

The fix derives the duplicated block from the shifted insertion point, comparing against the
inserted string **rotated** by the distance travelled - one base per position. That comparison
reads the reference, so its rotation is genomic and therefore strand-dependent: leftward on the
forward strand, rightward on the reverse.

## Measured against real Ensembl VEP 115.1

`ensemblorg/ensembl-vep:release_115.1`, `--gff` mode, the same Ensembl 115 GRCh38 GFF3 and FASTA
fastVEP reads, `--hgvs --symbol --canonical`.

**Genome-wide** - a systematic 1-in-200 sample of the GIAB HG002 WGS callset, 20,241 variants,
122,317 matched (variant, allele, transcript) rows:

| Field | before | after |
|---|---:|---:|
| `HGVSc` | 98.743 % (1,538 rows) | **99.879 %** (148) |
| `HGVSc`, insertion rows | 87.00 % | **99.82 %** |
| consequence set | 100.000 % | 100.000 % |
| `IMPACT` | 100.000 % | 100.000 % |
| `HGVSp` | 99.985 % | 99.985 % |

**ClinVar 2-star+ stratified sample** - 6,600 variants, 150,725 matched rows:

| Field | before | after |
|---|---:|---:|
| `HGVSc` | 98.823 % (1,774 rows) | **99.604 %** (597) |
| consequence set / `IMPACT` / `HGVSp` | 99.922 / 99.931 / 99.432 % | unchanged |

The invariance check that exposed the bug: six variants written at both ends of their repeat,
verified identical at the sequence level. VEP returned one string on all 168 transcript rows;
fastVEP returned two on all 168 before this change and one on all 168 after, matching VEP.

## Three more bugs the unification and review turned up

**The reverse-strand rotation ran the wrong way.**

`hgvs_alt` reaches the shift already in transcript orientation, where the shift always travels 3'
whichever way the transcript runs, so the inserted string always rotates **left**. It was rotating
**right** on the reverse strand, which named the right position with the wrong bases:
`c.21-21_21-20insGTC` for a variant the same transcript calls `insCGT` when the VCF spells it one
base over.

It only shows on a *partial* shift - one that stops mid-period and does not end on a duplication -
which is why 716 of 717 reverse-strand intronic `ins` rows in the HG002 sample agreed with VEP
anyway. A property test over deliberately imperfect repeats found 11 disagreeing configurations
before the fix and none after. The genomic rotation in `intronic_dup_span` stays strand-dependent,
because that function reads the reference rather than the transcript.

**An insertion is written over both bases it sits between, and both are now mapped.** Leaving the
renderer to infer the second coordinate as `offset + 1` breaks across the middle of an intron,
where `+n` counts from one exon and `-m` from the next: an insertion between `c.20+30` and
`c.21-30` came out `c.20+30_20+31ins…`, naming a base past the half the donor-side offsets reach.
The library path had been mapping both ends before this change, so folding the two loops together
on the CLI's behaviour would have regressed it.

**The shift is no longer skipped at an intron edge.** It is bounded by the intron the variant sits
in, found through `intron_bounds_at(var_start)` - but an insertion sits *between* two bases, and
one written against the last intronic base has `var_start` in the exon beyond it. On a
reverse-strand transcript, 3' runs back down into that intron, so the shift was skipped entirely
rather than truncated. It now falls back to `var_end`.

Together these took the ClinVar sample from 684 remaining `HGVSc` rows to 597.

## Two related fixes in the same path

**Both annotation loops now share one implementation.** `fastvep-annotate` - the path the server and
web UI use - had **no intronic 3'-shift at all** and never converted an insertion to `dup`, so the
same variant came out normalised from `fastvep annotate` and unnormalised from the server. Both now
call `hgvsc_intronic_shifted`. The CLI loop loses ~250 lines of duplicated inline logic.

**A dup span may cross the intron's midpoint.** The guard required one shared exon anchor, which
rejected spans Ensembl writes from the exon on either side (`c.5044+27_5045-47dup`). It now requires
the same *intron*, which still blocks the exon-crossing case the original guard existed for - the
one that put PVS1's offset gate at `-2` and called two ClinVar-benign MSH6 and DSP variants likely
pathogenic.

`convert_ins_to_dup` and `convert_ins_to_dup_noncoding` are removed: they were the entry points for
the old path, unreferenced after this change, and carried the superseded single-anchor semantics.

## Tests

`crates/fastvep-annotate/tests/intronic_hgvs_normalization.rs` (7 tests) encodes the property that
broke: every spelling of one insertion must give one HGVSc - across a 60-base perfect repeat on
both strands, across deliberately imperfect repeats that stop the shift mid-period, and for
deletions. It also pins the intron-midpoint coordinate pair. Nine unit tests cover the rotation,
the strand-dependent side the duplicated block sits on, the intron boundary, and reading past the
contig.

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`
(1,012 passing) are clean.

## Performance

The shift walked the reference a base at a time, `fetch_sequence` per step and twice per step for a
deletion, each call returning an owned `Vec`. Crossing 4,000 bases cost ~4,000 allocations, or
~8,000 as a deletion, once per (variant x transcript x allele).

It now reads a **growing** window: 16 bases, doubling to 1,024. The growth is the point - almost
every shift stops within a base or two, so a fixed 256-base block read hundreds of bases to answer
two questions and measured **4.2 s against 3.8 s** over 29,388 real HG002 indels single-threaded.
Growing keeps the common case at one short read (**3.55 s**, best of four, against 3.75 s for the
per-base version) and still collapses a long walk: 32 and 63 allocations across 4,000 bases.

`tests/intronic_shift_allocations.rs` pins that with a counting global allocator, following
`fastvep-sa/tests/query_path_allocations.rs`. Output over both benchmark datasets is md5-identical
before and after.

## Not fixed here

Most of the 148 remaining genome-wide `HGVSc` rows come from **multi-allelic VCF records**, 1.18 %
of that callset. The shared first base is stripped across all alleles, but each allele is not then
trimmed against the reference on its own. Written three ways at one site, the same 5-base deletion
comes out:

| VCF | Ensembl VEP 115.1 | fastVEP |
|---|---|---|
| `GAAGAA>G` | `-`, `frameshift_variant`, `c.1364_1368del` | `-`, `frameshift_variant`, `c.1365_1369del` |
| `GAAGAAA>GA` | `-`, `frameshift_variant,splice_region_variant`, `c.1364_1368del` | `A`, same terms, `c.1361_1366delinsA` |

VEP trims the shared suffix; fastVEP carries the extra base, which widens the span by one, turns
the `del` into a `delins`, and reports `A` where VEP reports `-` - so a comparison keyed on the
allele does not even line those rows up. Neither benchmark dataset contains a *single*-alt record
needing that trim (both are already parsimonious), so it is reachable only through multi-allelic
sites and through callers emitting non-minimal records. Fixing it means carrying a position per
allele rather than one per site, which the variant representation does not do today, so it needs
its own change.

In the ClinVar sample, 495 of the 597 remaining rows are one theme: the shift is bounded by the
intron it starts in, so a span that should travel across the splice site stops at it. The exonic
and intronic shifts are each correct within their own territory.

`HGVS_OFFSET` is still emitted empty. Nothing in the workspace has ever set it, so this is not new,
but now that both loops 3'-shift it is empty on more rows than before. The distance travelled is
already computed as `shift`; populating the field wants its own change and its own check against
what VEP puts there.

## Docs

`docs/VEP_DIVERGENCE.md` and the README concordance table carry the measured numbers, plus a new
genome-wide section. The doc's largest listed gap - *"intronic 3'-shift off by one, and the anchor
side chosen for a duplication deep in a long intron"* - was neither off by one (only 16 % of the
disagreements were a single base; the largest was 48) nor about the anchor side, and is replaced by
what was actually measured. Both now also state that the ClinVar sample is 54.5 % non-SNV by
construction against 7.2 % for the set it is drawn from, so its rates are not read as the rates a
typical callset sees.

## Base

Rebased onto `master` after #103 landed the same annotation work this branch had been carrying
unpushed. The two commits here are the whole PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
