### PR TITLE
fix(consequence): report every coding term that holds, not the first two

### DIFF
--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -585,12 +585,6 @@ impl AnnotationContext {
                                                 // for a change VEP calls `p.Pro154Thr` - and a
                                                 // synonymous two-residue window needs its whole
                                                 // span named.
-                                                // A window wider than one residue also routes here
-                                            // even when the lengths match: `hgvsp()` compares one
-                                            // residue per side, so `EP/ET` reads as unchanged and
-                                            // renders `p.Glu153=` for a change VEP calls
-                                            // `p.Pro154Thr` - and a synonymous two-residue window
-                                            // needs its whole span named.
                                             || aa.0.len() > 1
                                             {
                                                 // In-frame indel / delins (frameshift

--- a/crates/fastvep-annotate/tests/intronic_shift_allocations.rs
+++ b/crates/fastvep-annotate/tests/intronic_shift_allocations.rs
@@ -106,11 +106,11 @@ fn the_shift_reads_the_reference_in_blocks_not_a_base_at_a_time() {
     });
     assert_eq!(deleted.1, 4_000, "the walk should cross the whole repeat");
 
-    // Measured: 32 and 63. A 256-base block centred on the request leaves 128
-    // bases in the direction of travel, so a 4,000-base walk refills about 32
-    // times, and the deletion pays that once per end. Per-base reads cost ~4,000
-    // and ~8,000. The budget is loose enough to survive a block-size change and
-    // tight enough that a return to per-base reads fails it.
+    // The window opens at 16 bases and doubles to 1,024, so a 4,000-base walk
+    // pays a handful of small refills and then a few large ones; the deletion
+    // pays that once per end. Per-base reads cost ~4,000 and ~8,000. The budget
+    // is loose enough to survive a change to the growth curve and tight enough
+    // that a return to per-base reads fails it.
     assert!(
         insertion <= 64,
         "insertion shift allocated {insertion} times crossing 4,000 bases"

--- a/crates/fastvep-cli/src/pipeline/annotate.rs
+++ b/crates/fastvep-cli/src/pipeline/annotate.rs
@@ -956,6 +956,18 @@ fn attach_transcript_sequences(
                 "Built sequences for {} coding transcripts",
                 built.load(Ordering::Relaxed)
             );
+        } else {
+            // Without the CDS there is no way to tell a missense change from a
+            // synonymous one, so `terms_for_window` reports the honest
+            // `coding_sequence_variant` - which is MODIFIER, where a missense
+            // call would be MODERATE. Anything filtering on IMPACT drops those
+            // rows, so say so rather than letting the tier change go unseen.
+            eprintln!(
+                "Warning: no reference sequence (--fasta not given, and the transcript \
+                 source carries none), so coding changes are reported as \
+                 coding_sequence_variant with MODIFIER impact rather than \
+                 missense/synonymous. Pass --fasta for coding consequences."
+            );
         }
     }
     needs_seq_build

--- a/crates/fastvep-consequence/src/predictor.rs
+++ b/crates/fastvep-consequence/src/predictor.rs
@@ -166,17 +166,22 @@ pub type DisplayPair = Option<(String, String)>;
 
 /// What a change inside the CDS resolves to.
 ///
-/// `additional` carries a second SO term for the changes that earn two. Ensembl
-/// evaluates every predicate in `VariationEffect.pm` independently and keeps all
-/// that hold, so one delins can be both `stop_gained` and
-/// `protein_altering_variant` - 164 of the 1,803 coding rows the ClinVar 2-star
-/// in-frame delins produce are exactly that pair. One slot rather than a `Vec`
-/// because this value is built once per (variant x transcript x allele) and a
-/// `Vec` there is an allocation on the hot path; no shape in that set yields
-/// more than two coding terms.
+/// `additional` carries every SO term beyond the first. Ensembl evaluates each
+/// predicate in `VariationEffect.pm` independently and keeps all that hold, so
+/// one delins can be both `stop_gained` and `protein_altering_variant` - 164 of
+/// the 1,803 coding rows the ClinVar 2-star in-frame delins produce are exactly
+/// that pair.
+///
+/// This was one `Option` slot, on the stated grounds that no shape yields more
+/// than two coding terms. Three do: a change that replaces the initiator and
+/// both introduces a stop and shifts the frame fires `stop_gained`,
+/// `frameshift_variant` *and* `start_lost`, and `start_lost` - the lowest-ranked
+/// of the three - was dropped without a diagnostic. The `Vec` costs nothing
+/// extra on the hot path because `terms_for_window` already builds one and this
+/// now takes ownership of it rather than copying out of it.
 pub struct CodingChange {
     pub consequence: Consequence,
-    pub additional: Option<Consequence>,
+    pub additional: Vec<Consequence>,
     pub amino_acids: DisplayPair,
     pub codons: DisplayPair,
 }
@@ -226,7 +231,7 @@ impl CodingChange {
     fn single(consequence: Consequence, amino_acids: DisplayPair, codons: DisplayPair) -> Self {
         Self {
             consequence,
-            additional: None,
+            additional: Vec::new(),
             amino_acids,
             codons,
         }
@@ -523,9 +528,7 @@ impl ConsequencePredictor {
                 );
                 if let Some(change) = coding_conseq {
                     consequences.push(change.consequence);
-                    if let Some(extra) = change.additional {
-                        consequences.push(extra);
-                    }
+                    consequences.extend(change.additional);
                     amino_acids = change.amino_acids;
                     codons = change.codons;
                 } else {
@@ -675,7 +678,7 @@ impl ConsequencePredictor {
                 });
             return partial_codon.then_some(CodingChange {
                 consequence: Consequence::CodingSequenceVariant,
-                additional: Some(Consequence::IncompleteTerminalCodonVariant),
+                additional: vec![Consequence::IncompleteTerminalCodonVariant],
                 amino_acids: None,
                 codons: None,
             });
@@ -911,16 +914,17 @@ impl ConsequencePredictor {
         };
         let amino_acids = Some((shown(&w.ref_aas), shown(&w.alt_aas)));
         let codons = Some((w.ref_codons.clone(), w.alt_codons.clone()));
-        match terms.first() {
-            Some(&first) => CodingChange {
-                consequence: first,
-                additional: terms.get(1).copied(),
-                amino_acids,
-                codons,
-            },
+        if terms.is_empty() {
             // Nothing held: a length change whose peptides Ensembl cannot
             // classify is `coding_sequence_variant`, which the caller supplies.
-            None => CodingChange::single(Consequence::CodingSequenceVariant, amino_acids, codons),
+            return CodingChange::single(Consequence::CodingSequenceVariant, amino_acids, codons);
+        }
+        let first = terms.remove(0);
+        CodingChange {
+            consequence: first,
+            additional: terms,
+            amino_acids,
+            codons,
         }
     }
 
@@ -1587,6 +1591,40 @@ mod tests {
             gencode_primary: false,
             flags: vec![],
             codon_table_start_phase: 0,
+        }
+    }
+
+    /// Nine predicates run over the codon window and every one that holds is a
+    /// term Ensembl would report. Keeping two dropped the third silently.
+    ///
+    /// A change that replaces the initiator, introduces a stop and shifts the
+    /// frame holds `stop_gained`, `frameshift_variant` and `start_lost` at once.
+    /// `start_lost` ranks below the other two, so it was the one lost.
+    ///
+    /// PVS1 happens to be unaffected here - `NonsenseOrFrameshift` outranks
+    /// `StartLost` when both are present, so the criterion takes the same branch
+    /// either way - but the reported consequence set was still short a term
+    /// Ensembl's model holds.
+    #[test]
+    fn every_coding_term_that_holds_is_reported() {
+        let predictor = ConsequencePredictor::default();
+        let tr = make_coding_transcript();
+        // CDS 1-3 is the initiator.
+        let pos = GenomicPosition::new("chr1", 1050, 1052, Strand::Forward);
+        let result = predictor.predict(
+            &pos,
+            &Allele::from_str("ATG"),
+            &[Allele::from_str("TAAA")],
+            &[&tr],
+            None,
+        );
+        let got = &result.transcript_consequences[0].allele_consequences[0].consequences;
+        for term in [
+            Consequence::StopGained,
+            Consequence::FrameshiftVariant,
+            Consequence::StartLost,
+        ] {
+            assert!(got.contains(&term), "{term:?} missing from {got:?}");
         }
     }
 

--- a/crates/fastvep-consequence/src/splice.rs
+++ b/crates/fastvep-consequence/src/splice.rs
@@ -325,6 +325,24 @@ where
     // adjacent entries bound one intron whichever way the transcript runs.
     // Reading the pair through `min`/`max` rather than sorting a copy keeps this
     // free of the per-(variant x transcript) allocation a `Vec` would cost.
+    // The pairing is order-agnostic between ascending and descending, but not
+    // against an unsorted list: two non-adjacent exons would bound an intron
+    // that does not exist, and the result is a wrong splice term rather than an
+    // error. Every other transcript accessor calls `sorted_exons()`; this one
+    // cannot without paying that allocation per (variant x transcript), so the
+    // invariant is asserted instead.
+    debug_assert!(
+        transcript
+            .exons
+            .windows(2)
+            .all(|p| p[0].start <= p[1].start)
+            || transcript
+                .exons
+                .windows(2)
+                .all(|p| p[0].start >= p[1].start),
+        "exons of {} are neither ascending nor descending",
+        transcript.stable_id
+    );
     for pair in transcript.exons.windows(2) {
         let (intron_start, intron_end) = (
             pair[0].end.min(pair[1].end) + 1,

--- a/crates/fastvep-hgvs/src/coding.rs
+++ b/crates/fastvep-hgvs/src/coding.rs
@@ -205,6 +205,13 @@ fn describe(
         (Allele::Deletion, Allele::Sequence(alt_bases)) => {
             let (mut before, mut after) = (cdna_lo, cdna_hi);
             let len = alt_bases.len();
+            // An insertion of nothing describes no change, and every index below
+            // is taken modulo this length. `Allele::from_str("")` yields an empty
+            // `Sequence`, so the pair is constructible even though the VCF reader
+            // maps a fully consumed allele to `-` and never produces it.
+            if len == 0 {
+                return None;
+            }
             let mut rotation = 0usize;
             if let Some(seq) = spliced_seq {
                 let seq_bytes = seq.as_bytes();


### PR DESCRIPTION
Findings from a review of the merged #103/#104 work, verified before acting on each.

## A third coding term was silently dropped

`terms_for_window` evaluates nine predicates over the codon window and keeps each that holds, but
`CodingChange` had one slot for a second term and discarded the rest with no diagnostic. Its comment
justified the single slot on the grounds that no shape yields more than two coding terms.

Three do. A change that replaces the initiator, introduces a stop and shifts the frame holds
`stop_gained`, `frameshift_variant` **and** `start_lost` at once, and `start_lost` - the
lowest-ranked of the three - was the one lost. Reproduced against the existing fixture:
`[StopGained, FrameshiftVariant]`.

**PVS1 is not affected**, and it is worth being precise about that rather than overselling the
finding: `NullKind::NonsenseOrFrameshift` has severity rank 2 against `StartLost`'s 1, so the
criterion picks the same branch whether or not `start_lost` is present. Neither the 20,241-variant
HG002 sample nor the 6,600-variant ClinVar sample contains the shape, and both come out
md5-identical. What was wrong is the reported set, which was short a term Ensembl's model holds.

The `Vec` costs nothing extra on the hot path: `terms_for_window` already builds one, and
`CodingChange` now takes ownership of it rather than copying two values out.

## Three smaller ones

**A divide-by-zero abort.** `describe`'s insertion arm indexes `alt_bases[shift % len]` without
checking `len`. `Allele::from_str("")` yields an empty `Sequence`, so the pair is constructible. The
VCF reader never produces one - it maps a fully consumed allele to `-` - but the arm is reachable
and was total before. Guarded.

**An invariant that had become implicit.** `for_each_intron` pairs adjacent exons without sorting.
That is correct for `gff.rs`, the only production source, and silently wrong for any other: two
non-adjacent exons bound an intron that does not exist, and the result is a wrong splice term rather
than an error. It cannot call `sorted_exons()` without the per-(variant × transcript) allocation it
exists to avoid, so the invariant is now a `debug_assert!`.

**A silent impact-tier change.** Running without `--fasta`, and without a transcript source carrying
sequences, reports coding changes as `coding_sequence_variant` at MODIFIER where a missense call
would be MODERATE. Verified: `[CodingSequenceVariant] impact=Modifier` for a plain coding SNV with
`translateable_seq = None`. That is the honest answer - without a CDS there is no way to tell
missense from synonymous - but anything filtering on IMPACT drops those rows, so it now says so at
startup rather than letting the tier change go unseen.

## Two comment corrections

A block #103 left duplicated in `lib.rs`, and the block size named in the allocation budget's
comment: the window opens at 16 bases and doubles to 1,024, not a flat 256. That comment was mine,
written when the block was fixed and not updated when I made it grow.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
(1,015 passing). Output over the 20,241-variant HG002 sample and the 6,600-variant ClinVar sample is
md5-identical, and the ClinVar concordance is unchanged at 99.922 % / 99.604 % / 99.432 % / 99.931 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
