### PR TITLE
docs(api): document the self-hosted REST API, and give it a contract to break

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ fastVEP is inspired by and aims to be compatible with [Ensembl VEP](https://www.
 
 **Try it now:** A hosted web server is available at [fastVEP.org](https://fastVEP.org) — paste VCF data and get annotated results instantly, no installation required. As of July 2026 it has served **2,372 genome analysis sessions** and annotated **19,013 variants**.
 
+The hosted instance is for interactive use in the browser. For programmatic access, run your own server: see the **[REST API guide](docs/API.md)**.
+
 ## Features
 
 - **Variant Consequence Prediction** — Classifies variants using 49 [Sequence Ontology](http://www.sequenceontology.org/) terms (missense, frameshift, splice donor, copy_number_change, transcript_ablation, etc.)
@@ -158,6 +160,20 @@ fastvep-web --gff3 genes.gff3 --fasta ref.fa --sa-dir /path/to/sa_databases/
 Open http://localhost:8080 in your browser. The web interface lets you paste VCF data, switch gene models, and view results in an interactive table.
 
 > **Note:** `fastvep-web` is a separate production-quality binary (axum/tokio, async, multi-connection). The legacy `fastvep web` command still works but is single-threaded.
+
+### REST API (self-hosted)
+
+The same binary serves a JSON API over the same annotation engine, so anything the web interface can do a script can do:
+
+```bash
+curl -s -X POST http://localhost:8080/api/annotate \
+  -H 'Content-Type: application/json' \
+  -d '{"vcf": "17\t43124027\t.\tG\tA\t50\tPASS\t.", "acmg": true}'
+```
+
+It is designed for self-hosting on a workstation or local network, which is also the only supported way to use it: please do not point scripts at fastVEP.org, which is a single small machine sized for interactive browser use. Bulk VCFs belong in `fastvep annotate`, not in an HTTP request.
+
+Full setup, endpoint reference, and response shapes: **[docs/API.md](docs/API.md)**.
 
 ## Local Setup Guide
 

--- a/crates/fastvep-web/fixtures/mini.gff3
+++ b/crates/fastvep-web/fixtures/mini.gff3
@@ -1,0 +1,10 @@
+##gff-version 3
+# Two-exon protein-coding gene used by the API contract tests. Small enough to
+# parse in microseconds, and shaped so a variant can land in coding sequence,
+# in the intron, or upstream of the gene without needing a reference FASTA.
+17	test	gene	1000	3000	.	+	.	ID=gene:GENEA;Name=GENEA;biotype=protein_coding;gene_id=GENEA
+17	test	mRNA	1000	3000	.	+	.	ID=transcript:TXA;Parent=gene:GENEA;Name=GENEA-201;biotype=protein_coding;tag=Ensembl_canonical;transcript_id=TXA
+17	test	exon	1000	1200	.	+	.	ID=exon:TXA-E1;Parent=transcript:TXA;rank=1
+17	test	CDS	1000	1200	.	+	0	ID=CDS:TXA;Parent=transcript:TXA;protein_id=PROTA
+17	test	exon	2800	3000	.	+	.	ID=exon:TXA-E2;Parent=transcript:TXA;rank=2
+17	test	CDS	2800	3000	.	+	0	ID=CDS:TXA;Parent=transcript:TXA;protein_id=PROTA

--- a/crates/fastvep-web/src/lib.rs
+++ b/crates/fastvep-web/src/lib.rs
@@ -1,0 +1,54 @@
+//! Library surface for the fastVEP web server.
+//!
+//! The binary in `main.rs` is a thin wrapper over this: it parses flags, loads
+//! the annotation context, and hands both to [`build_router`]. The routing
+//! table lives here so tests can drive it through `tower::ServiceExt::oneshot`
+//! without binding a socket, which is what lets the JSON contract documented in
+//! `docs/API.md` be asserted rather than described.
+
+pub mod context;
+pub mod errors;
+pub mod handlers;
+
+use axum::extract::DefaultBodyLimit;
+use axum::http::{header, Method};
+use axum::routing::{get, post};
+use axum::Router;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::ServiceBuilder;
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
+
+use crate::handlers::AppState;
+
+/// Build the full application router, including the middleware stack.
+pub fn build_router(state: AppState, max_body_size: usize, max_concurrent: usize) -> Router {
+    Router::new()
+        .route("/", get(handlers::index_html))
+        .route("/index.html", get(handlers::index_html))
+        .route("/assets/logo.png", get(handlers::logo_png))
+        .route("/favicon.ico", get(handlers::logo_png))
+        .route("/apple-touch-icon.png", get(handlers::logo_png))
+        .route("/api/status", get(handlers::status))
+        .route("/api/genomes", get(handlers::list_genomes))
+        .route("/api/load-genome", post(handlers::load_genome))
+        .route("/api/annotate", post(handlers::annotate))
+        .route("/api/upload-gff3", post(handlers::upload_gff3))
+        .with_state(state)
+        .layer(DefaultBodyLimit::max(max_body_size))
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(
+                    // Origin stays open (this is a public annotation API by
+                    // design, per DEPLOYMENT.md), but methods/headers are
+                    // scoped to what the routes above actually use instead
+                    // of blanket `Any` on every axis.
+                    CorsLayer::new()
+                        .allow_origin(Any)
+                        .allow_methods([Method::GET, Method::POST])
+                        .allow_headers([header::CONTENT_TYPE]),
+                )
+                .layer(ConcurrencyLimitLayer::new(max_concurrent)),
+        )
+}

--- a/crates/fastvep-web/src/main.rs
+++ b/crates/fastvep-web/src/main.rs
@@ -1,22 +1,11 @@
-mod context;
-mod errors;
-mod handlers;
-
-use axum::extract::DefaultBodyLimit;
-use axum::http::{header, Method};
-use axum::routing::{get, post};
-use axum::Router;
 use clap::Parser;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
-use tower::limit::ConcurrencyLimitLayer;
-use tower::ServiceBuilder;
-use tower_http::cors::{Any, CorsLayer};
-use tower_http::trace::TraceLayer;
 
-use crate::context::AnnotationContext;
-use crate::handlers::{AppState, SharedState};
+use fastvep_web::build_router;
+use fastvep_web::context::AnnotationContext;
+use fastvep_web::handlers::{AppState, SharedState};
 
 #[derive(Parser)]
 #[command(name = "fastvep-web")]
@@ -117,34 +106,7 @@ async fn main() -> anyhow::Result<()> {
         total_genomes: AtomicU64::new(initial_genomes),
     });
 
-    let app = Router::new()
-        .route("/", get(handlers::index_html))
-        .route("/index.html", get(handlers::index_html))
-        .route("/assets/logo.png", get(handlers::logo_png))
-        .route("/favicon.ico", get(handlers::logo_png))
-        .route("/apple-touch-icon.png", get(handlers::logo_png))
-        .route("/api/status", get(handlers::status))
-        .route("/api/genomes", get(handlers::list_genomes))
-        .route("/api/load-genome", post(handlers::load_genome))
-        .route("/api/annotate", post(handlers::annotate))
-        .route("/api/upload-gff3", post(handlers::upload_gff3))
-        .with_state(state)
-        .layer(DefaultBodyLimit::max(cli.max_body_size))
-        .layer(
-            ServiceBuilder::new()
-                .layer(TraceLayer::new_for_http())
-                .layer(
-                    // Origin stays open (this is a public annotation API by
-                    // design, per DEPLOYMENT.md), but methods/headers are
-                    // scoped to what the routes above actually use instead
-                    // of blanket `Any` on every axis.
-                    CorsLayer::new()
-                        .allow_origin(Any)
-                        .allow_methods([Method::GET, Method::POST])
-                        .allow_headers([header::CONTENT_TYPE]),
-                )
-                .layer(ConcurrencyLimitLayer::new(cli.max_concurrent)),
-        );
+    let app = build_router(state, cli.max_body_size, cli.max_concurrent);
 
     let addr = format!("{}:{}", cli.bind, cli.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/fastvep-web/tests/api.rs
+++ b/crates/fastvep-web/tests/api.rs
@@ -1,0 +1,281 @@
+//! Contract tests for the JSON API documented in `docs/API.md`.
+//!
+//! These drive the real router through `oneshot`, so they cover routing, the
+//! middleware stack, and serialization the way a client meets them. The point
+//! is that the request and response shapes people write clients against are
+//! asserted somewhere, not just described in a document that can drift.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use fastvep_web::context::AnnotationContext;
+use fastvep_web::handlers::{AppState, SharedState};
+use serde_json::{json, Value};
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, RwLock};
+use tower::ServiceExt;
+
+const MINI_GFF3: &str = include_str!("../fixtures/mini.gff3");
+
+/// One transcript, no FASTA, no supplementary annotations. Deliberately the
+/// minimum a caller can stand up, so a failure here is the API's fault rather
+/// than the fixture's.
+fn test_state() -> AppState {
+    let mut ctx = AnnotationContext::new(None, None, None, 5000).expect("build context");
+    ctx.update_gff3_text(MINI_GFF3).expect("load mini gff3");
+    Arc::new(SharedState {
+        ctx: RwLock::new(ctx),
+        data_dir: None,
+        sa_dir: None,
+        // No stats file: these tests must not write to the working directory.
+        stats_file: None,
+        total_variants: AtomicU64::new(0),
+        total_genomes: AtomicU64::new(0),
+    })
+}
+
+fn router(state: &AppState) -> axum::Router {
+    fastvep_web::build_router(Arc::clone(state), 10_485_760, 8)
+}
+
+async fn read_json(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let value = serde_json::from_slice(&bytes).expect("body is JSON");
+    (status, value)
+}
+
+async fn get(state: &AppState, uri: &str) -> (StatusCode, Value) {
+    let resp = router(state)
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    read_json(resp).await
+}
+
+async fn post_json(state: &AppState, uri: &str, body: Value) -> (StatusCode, Value) {
+    let resp = router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    read_json(resp).await
+}
+
+fn vcf_line(pos: u32, id: &str) -> String {
+    format!("17\t{}\t{}\tG\tA\t50\tPASS\t.", pos, id)
+}
+
+#[tokio::test]
+async fn status_reports_what_is_loaded() {
+    let (status, body) = get(&test_state(), "/api/status").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["backend"], true);
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(body["transcripts"], 1);
+    // Callers are told to gate on these two before trusting an annotation, so
+    // they have to be present and honest even when nothing is loaded.
+    assert_eq!(body["has_fasta"], false);
+    assert_eq!(body["sa_sources"], json!([]));
+}
+
+#[tokio::test]
+async fn annotate_returns_one_result_per_record() {
+    let vcf = [
+        vcf_line(1100, "."), // exon 1, inside the CDS
+        vcf_line(2000, "."), // between the two exons
+        vcf_line(500, "."),  // before the gene, within --distance
+    ]
+    .join("\n");
+
+    let (status, body) = post_json(&test_state(), "/api/annotate", json!({ "vcf": vcf })).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], 3);
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results.len(), 3);
+
+    let terms: Vec<&str> = results
+        .iter()
+        .map(|r| r["most_severe_consequence"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        terms,
+        [
+            "coding_sequence_variant",
+            "intron_variant",
+            "upstream_gene_variant"
+        ]
+    );
+
+    // Record order is the caller's order: clients index into `results`
+    // positionally against what they sent.
+    let starts: Vec<u64> = results
+        .iter()
+        .map(|r| r["start"].as_u64().unwrap())
+        .collect();
+    assert_eq!(starts, [1100, 2000, 500]);
+
+    let first = &results[0]["transcript_consequences"][0];
+    assert_eq!(first["transcript_id"], "TXA");
+    assert_eq!(first["gene_symbol"], "GENEA");
+    assert_eq!(first["biotype"], "protein_coding");
+    assert_eq!(
+        first["consequence_terms"],
+        json!(["coding_sequence_variant"])
+    );
+}
+
+#[tokio::test]
+async fn annotate_accepts_a_vcf_header_and_carries_the_id_through() {
+    let vcf = format!(
+        "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n{}",
+        vcf_line(1100, "rs123456")
+    );
+
+    let (status, body) = post_json(&test_state(), "/api/annotate", json!({ "vcf": vcf })).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], 1);
+    // Header lines are skipped rather than parsed as records, and the ID
+    // column round-trips so callers can match responses to their input.
+    assert_eq!(body["results"][0]["id"], "rs123456");
+}
+
+#[tokio::test]
+async fn coding_variant_without_a_fasta_reports_the_generic_term() {
+    // The hazard documented under "Always pass --fasta": with no reference
+    // sequence the server cannot read the codon, so a coding change comes back
+    // as `coding_sequence_variant` with MODIFIER impact instead of the specific
+    // term and its real impact. It does not error, and the response looks
+    // perfectly well-formed, which is what makes it worth pinning here.
+    let (status, body) = post_json(
+        &test_state(),
+        "/api/annotate",
+        json!({ "vcf": vcf_line(1100, ".") }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["results"][0]["most_severe_consequence"],
+        "coding_sequence_variant"
+    );
+    assert_eq!(
+        body["results"][0]["transcript_consequences"][0]["impact"],
+        "MODIFIER"
+    );
+}
+
+#[tokio::test]
+async fn acmg_is_attached_only_when_requested() {
+    let state = test_state();
+    let vcf = vcf_line(1100, ".");
+
+    let (status, off) = post_json(&state, "/api/annotate", json!({ "vcf": vcf })).await;
+    assert_eq!(status, StatusCode::OK);
+    let plain = &off["results"][0]["transcript_consequences"][0];
+    // Assert the consequence itself is really there first: `get` on a missing
+    // path also returns None, which would make the check below pass for the
+    // wrong reason if the response shape ever changed underneath it.
+    assert!(plain.is_object(), "expected a transcript consequence");
+    assert!(
+        plain.get("acmg").is_none(),
+        "acmg must be absent by default so clients do not pay for it unasked"
+    );
+
+    let (status, on) =
+        post_json(&state, "/api/annotate", json!({ "vcf": vcf, "acmg": true })).await;
+    assert_eq!(status, StatusCode::OK);
+    let acmg = &on["results"][0]["transcript_consequences"][0]["acmg"];
+    assert!(acmg.is_object(), "acmg object missing when requested");
+    assert!(
+        acmg["classification"].is_string(),
+        "acmg block must carry a classification"
+    );
+    assert!(
+        acmg["criteria"].is_array(),
+        "acmg block must carry per-criterion verdicts"
+    );
+}
+
+#[tokio::test]
+async fn annotate_rejects_an_empty_vcf() {
+    let state = test_state();
+
+    for body in [json!({ "vcf": "" }), json!({})] {
+        let (status, body) = post_json(&state, "/api/annotate", body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        // 400 messages are caller-facing and documented; 500 messages are not.
+        assert_eq!(body["error"], "No VCF data provided");
+    }
+}
+
+#[tokio::test]
+async fn oversized_body_is_rejected_rather_than_annotated() {
+    // The body cap is the boundary between "small-N queries" and "use the
+    // CLI", so it has to actually stop a large request.
+    let app = fastvep_web::build_router(test_state(), 64, 8);
+    let body = json!({ "vcf": vcf_line(1100, ".").repeat(50) }).to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/annotate")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn genome_endpoints_are_inert_without_a_data_dir() {
+    let state = test_state();
+
+    let (status, body) = get(&state, "/api/genomes").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["genomes"], json!([]));
+
+    let (status, body) = post_json(&state, "/api/load-genome", json!({ "name": "human" })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"], "No data directory configured");
+}
+
+#[tokio::test]
+async fn upload_gff3_replaces_the_active_gene_model() {
+    let state = test_state();
+
+    let resp = router(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/upload-gff3")
+                .body(Body::from(MINI_GFF3))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, body) = read_json(resp).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["genes"], 1);
+    assert_eq!(body["transcripts"], 1);
+
+    // The swap is visible to the next caller, not just to this request.
+    let (_, status_body) = get(&state, "/api/status").await;
+    assert_eq!(status_body["transcripts"], 1);
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,273 @@
+# fastVEP REST API
+
+`fastvep-web` exposes a small JSON HTTP API over the same annotation engine the CLI uses.
+It is meant to be **self-hosted** on your own workstation, lab server, or local network.
+
+## Please self-host
+
+The hosted instance at [fastVEP.org](https://fastVEP.org) is sized for interactive browser use: someone pastes a handful of variants and reads the table.
+It is a single small machine with no rate limiting, so it is not a public API endpoint and there is no API key to request.
+Please do not point scripts, pipelines, or services at it.
+
+Self-hosting is the better option for you regardless:
+
+- Your variant data never leaves your network, which for patient data is usually a requirement rather than a preference.
+- No shared instance to compete with, and no dependency on our uptime.
+- You choose the gene model release and which supplementary databases are loaded, instead of inheriting ours.
+
+## What the API is for
+
+The server loads the gene model, reference FASTA, and supplementary annotation databases once at startup and keeps them resident.
+A full human gene model is over 500,000 transcripts; annotating one variant by invoking the CLI pays that load cost on every call, while the server pays it once.
+
+That makes the API the right tool for **small numbers of variants, queried repeatedly**: a curation interface, a LIMS integration, an internal service, a notebook.
+
+It is the wrong tool for bulk.
+fastVEP's throughput advantage is in whole-genome files, and you do not POST those over HTTP.
+The default request body limit is 10 MiB, and raising it is not the intended path.
+For exome- or genome-scale VCFs use `fastvep annotate` directly.
+
+## Setup
+
+### 1. Install the server
+
+```bash
+cargo install --path crates/fastvep-web
+```
+
+### 2. Get reference data
+
+The API needs the same inputs as the CLI: a GFF3 gene model, and a reference FASTA to resolve coding consequences.
+Follow [Step 1 of the Local Setup Guide](../README.md#step-1-download-reference-data) in the README, then come back here.
+
+### 3. Run the server
+
+For a single user on one machine, bind to loopback so nothing else on the network can reach it:
+
+```bash
+fastvep-web \
+  --bind 127.0.0.1 \
+  --port 8080 \
+  --gff3 data/Homo_sapiens.GRCh38.115.gff3 \
+  --fasta data/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+  --sa-dir data/sa/
+```
+
+To serve a lab or local network, bind to all interfaces (this is the default):
+
+```bash
+fastvep-web --bind 0.0.0.0 --port 8080 --gff3 ... --fasta ...
+```
+
+> **There is no authentication.**
+> `--bind` is the only access control the server has, and it defaults to `0.0.0.0`.
+> On a trusted local network that is fine, which is the deployment this API is designed for.
+> On a machine with a public IP it means the server is open to the internet, so put it behind a reverse proxy with auth, or a firewall rule, before exposing it.
+> [DEPLOYMENT.md](../DEPLOYMENT.md) covers the nginx and TLS setup.
+
+### 4. Verify it is up
+
+```bash
+curl -s http://localhost:8080/api/status | python3 -m json.tool
+```
+
+```json
+{
+    "backend": true,
+    "gff3_source": "Homo_sapiens.GRCh38.115.gff3",
+    "has_fasta": true,
+    "sa_sources": ["ClinVar", "COSMIC", "dbSNP", "gnomAD", "1000 Genomes", "SpliceAI"],
+    "status": "ok",
+    "total_genomes": 0,
+    "total_variants": 0,
+    "transcripts": 509650,
+    "version": "0.3.0"
+}
+```
+
+Check `has_fasta` and `sa_sources` here before you trust any annotation, for the reason in the next section.
+
+## Always pass `--fasta`
+
+`--fasta` is optional to the argument parser and effectively required for correct answers.
+Without reference sequence the server cannot read the codon a variant falls in, so a coding change degrades to a generic term instead of failing.
+Annotating `17:43124027 G>A` against the same gene model, with and without `--fasta`:
+
+| `--fasta` | `most_severe_consequence` |
+| --- | --- |
+| absent | `coding_sequence_variant` |
+| present | `synonymous_variant` |
+
+Neither response is an error, and both look plausible.
+That is the failure mode worth guarding against here, so confirm `"has_fasta": true` in `/api/status` after every deployment and gene-model change.
+
+The same applies to `sa_sources`: an empty list means ClinVar, gnomAD, and the rest were not loaded, and any downstream logic reading those fields silently sees nothing.
+
+One wrinkle when you are testing this: `fastvep-web` writes a sidecar transcript cache next to the GFF3, and a run that had `--fasta` saves the built sequences into it.
+A later run of the same gene model *without* `--fasta` then loads those sequences from the cache and returns correct coding terms while still reporting `"has_fasta": false`.
+So a server that looks right on a machine you have already used a FASTA on can degrade on a fresh deployment, where no such cache exists.
+Judge a deployment by what it returns on the target machine, not by what the same flags produced on yours.
+
+## Endpoints
+
+All request and response bodies are JSON, except `POST /api/upload-gff3`, which takes a raw GFF3 body.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/status` | Server version and what is loaded |
+| `POST` | `/api/annotate` | Annotate VCF records |
+| `GET` | `/api/genomes` | List genomes available under `--data-dir` |
+| `POST` | `/api/load-genome` | Switch the active genome |
+| `POST` | `/api/upload-gff3` | Replace the active gene model with a posted GFF3 |
+
+`GET /` serves the browser interface.
+
+### `POST /api/annotate`
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `vcf` | string | required | VCF text. Header lines are optional; records are tab-separated. |
+| `pick` | bool | `false` | Narrow the reported transcripts (see the caveat below). |
+| `acmg` | bool | `false` | Attach ACMG-AMP classification to each consequence. |
+
+```bash
+curl -s -X POST http://localhost:8080/api/annotate \
+  -H 'Content-Type: application/json' \
+  -d '{"vcf": "17\t43124027\t.\tG\tA\t50\tPASS\t.", "acmg": false}'
+```
+
+Multiple records in one request are annotated in one pass, and an `ID` column is carried through to `id` in the response:
+
+```json
+{
+  "count": 2,
+  "time_ms": 0,
+  "results": [
+    {
+      "seq_region_name": "17",
+      "start": 43124027,
+      "end": 43124027,
+      "allele_string": "G/A",
+      "id": null,
+      "strand": 1,
+      "most_severe_consequence": "synonymous_variant",
+      "transcript_consequences": [
+        {
+          "transcript_id": "ENST00000357654",
+          "gene_id": "ENSG00000012048",
+          "gene_symbol": "BRCA1",
+          "biotype": "protein_coding",
+          "consequence_terms": ["synonymous_variant"],
+          "impact": "LOW",
+          "hgvsc": "ENST00000357654.9:c.70C>T",
+          "hgvsp": "ENSP00000350283.1:p.Cys24=",
+          "hgvsg": "17:g.43124027G>A",
+          "strand": -1,
+          "variant_allele": "A",
+          "canonical": 1
+        }
+      ]
+    },
+    {
+      "seq_region_name": "17",
+      "start": 43104121,
+      "end": 43104121,
+      "allele_string": "G/T",
+      "id": "rs80357064",
+      "strand": 1,
+      "most_severe_consequence": "splice_donor_variant",
+      "transcript_consequences": [
+        {
+          "transcript_id": "ENST00000357654",
+          "gene_id": "ENSG00000012048",
+          "gene_symbol": "BRCA1",
+          "biotype": "protein_coding",
+          "consequence_terms": ["splice_donor_variant"],
+          "impact": "HIGH",
+          "hgvsc": "ENST00000357654.9:c.441+1C>A",
+          "hgvsp": null,
+          "hgvsg": "17:g.43104121G>T",
+          "strand": -1,
+          "variant_allele": "T",
+          "canonical": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+Both `transcript_consequences` arrays are elided above: against a full human gene model those two variants return 58 and 41 entries respectively, one per overlapping transcript.
+Expect responses to be large, and select the transcript you care about rather than assuming the first entry is the interesting one.
+
+The per-variant shape follows Ensembl VEP's JSON output, so clients written against VEP's `transcript_consequences` mostly port over.
+`time_ms` is server-side annotation time, excluding transport.
+
+> **`pick` does not guarantee one consequence per variant.**
+> In this code path a transcript is kept when it is canonical *or* when it is the first one seen for the variant (`crates/fastvep-annotate/src/lib.rs:669`), so a request with `"pick": true` can still return two entries.
+> If you need exactly one row per variant, select it client-side from `most_severe_consequence`, or use the CLI.
+
+Setting `"acmg": true` adds an `acmg` object to each transcript consequence with the classification, the per-criterion verdicts, and the evidence counts.
+Classification quality depends on which supplementary databases are loaded, so read [docs/ACMG_SETUP.md](ACMG_SETUP.md) before relying on it.
+
+### `GET /api/genomes` and `POST /api/load-genome`
+
+Start the server with `--data-dir` pointing at a directory of genome subdirectories (the layout is described under [Multi-organism setup](../README.md#multi-organism-setup) in the README) and the server can switch between them at runtime.
+
+```bash
+curl -s http://localhost:8080/api/genomes
+```
+
+```json
+{"genomes": [{"name": "human_grch38", "has_fasta": true, "has_sa": true}]}
+```
+
+```bash
+curl -s -X POST http://localhost:8080/api/load-genome \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "human_grch38"}'
+```
+
+```json
+{"name": "human_grch38", "transcripts": 509650, "sa_sources": ["ClinVar"], "time_ms": 6}
+```
+
+`name` must be a plain directory name; anything containing a path separator or `..` is rejected with 400.
+Loading a genome swaps the model out from under every client of that server, so treat it as an admin operation rather than something a request handler calls.
+
+## Errors
+
+Failures return the matching HTTP status and a single-field body:
+
+```json
+{"error": "No VCF data provided"}
+```
+
+`400` carries a caller-facing message, as above.
+`500` is always the literal string `Internal server error`; the detail is written to the server log instead, so that paths and parser internals are not returned to clients.
+Check the server's stderr when you get one.
+
+## Options
+
+| Flag | Env | Default | Meaning |
+| --- | --- | --- | --- |
+| `--bind` | `FASTVEP_BIND` | `0.0.0.0` | Interface to listen on |
+| `--port` | `FASTVEP_PORT` | `8080` | Port to listen on |
+| `--gff3` | `FASTVEP_GFF3` | built-in example | Gene model |
+| `--fasta` | `FASTVEP_FASTA` | none | Reference FASTA, needs a `.fai` |
+| `--sa-dir` | `FASTVEP_SA_DIR` | none | Directory of `.osa`/`.osa2`/`.osi`/`.oga` files |
+| `--data-dir` | `FASTVEP_DATA_DIR` | none | Directory of switchable genomes |
+| `--distance` | | `5000` | Upstream/downstream distance in bp |
+| `--max-body-size` | | `10485760` | Request body cap in bytes |
+| `--max-concurrent` | | `64` | Concurrent annotation requests |
+| `--stats-file` | `FASTVEP_STATS_FILE` | `stats.json` | Where the served-variant counters persist |
+
+Two things to know about the defaults.
+`--stats-file` is relative, so a bare `fastvep-web` writes `stats.json` into whatever directory you launched it from; pass an absolute path under a service account's own state directory when running it as a daemon.
+Requests beyond `--max-concurrent` queue rather than fail, which is why raising it is rarely the fix for a slow server.
+
+## Which binary
+
+Use `fastvep-web`, the axum server documented here.
+
+The older `fastvep web` subcommand still works, but it is single-threaded, and it serves only `/api/status`, `/api/annotate`, and `/api/upload-gff3` (no `/api/genomes` or `/api/load-genome`).


### PR DESCRIPTION
Closes #108.

The REST API in `fastvep-web` has shipped since before #108 was filed and has been serving production traffic the whole time. The only place the endpoints were written down was DEPLOYMENT.md, roughly 700 lines into a guide about nginx and Cloudflare, which is not where someone self-hosting for a local network looks. A user had to open an issue to discover a feature that already existed. That is the gap this PR closes: it documents what is there and puts a test suite under it.

## `docs(api)` - the guide

`docs/API.md` is written self-hosting-first. fastVEP.org is one small machine with no rate limiting, sized for someone pasting a handful of variants into the browser, so the guide says plainly that it is not a public API endpoint and there is no key to ask for, and gives the reasons self-hosting is better for the caller anyway. The README now says the same thing where it advertises the hosted instance.

Every command, response body, and figure in the guide was run against a real server rather than read off the source. Three things came out of doing it that way:

**`--fasta` is effectively required.** It is optional to the argument parser, but without reference sequence the server cannot read the codon a variant falls in, so a coding change degrades to a generic term instead of failing. Against the same gene model, `17:43124027 G>A` returns `coding_sequence_variant` without a FASTA and `synonymous_variant` with one. Neither is an error and both look plausible, which is exactly the failure mode this repo cares about.

**That check has a hole**, found by tripping over it while testing. A run with `--fasta` saves built sequences into the sidecar cache, so a later run of the same gene model *without* `--fasta` reads them back and returns correct coding terms while still reporting `"has_fasta": false`. A server that looks right on a machine you have already used a FASTA on can therefore degrade on a fresh deployment. The guide says to judge a deployment by what it returns on the target machine.

**`pick` is documented as observed, not as the README describes it.** In this path a transcript is kept when it is canonical *or* when it is the first one seen (`crates/fastvep-annotate/src/lib.rs:669`), so `"pick": true` can still return more than one consequence per variant. The README's `--pick` row calls it "report only the most severe consequence per variant". Rather than repeat that in a document people will write clients against, the guide states the observed behaviour and cites the line. **The discrepancy itself is left alone here** and is worth a separate look.

## `test(web)` - the contract

`fastvep-web` was bin-only, so nothing exercised the HTTP layer: the tests in `handlers.rs` cover `resolve_genome_paths` and `find_file_with_ext` and stop there. The legacy single-threaded `fastvep web` in `fastvep-cli` has socket-level tests, so the untested server was the production one, and the one #108 now points people at.

Extracting the routing table into `build_router` lets tests drive the real router through `oneshot` (routing, middleware, and serialization included) without binding a socket. `main.rs` keeps flag parsing and context loading and is otherwise unchanged.

The nine tests assert what the guide promises: the status fields callers are told to gate on, one result per record in the caller's order, VCF headers skipped and the ID column carried through, ACMG attached only when asked for, the 400 body on an empty VCF, the body cap actually rejecting, and the genome endpoints staying inert with no `--data-dir`. One of them pins a wrong-looking answer on purpose, so the no-FASTA degradation cannot change quietly in either direction.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`: all clean, **1024 tests passing**.
- The suite was checked for vacuity by changing the 400 message in `handlers.rs`: `annotate_rejects_an_empty_vcf` failed, the other eight passed, revert clean.
- The release binary was smoke-tested after the `main.rs` refactor: `/api/status`, `/api/annotate`, and the HTML index all still serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
