### PR TITLE
fix(annotate): pick the transcript VEP would, not the first one seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,8 @@ objects will be heterogeneous.
 | `--fasta` | Reference FASTA file | -- |
 | `--output-format` | `vcf`, `tab`, or `json` | `vcf` |
 | `--hgvs` | Include HGVS notations | off |
-| `--pick` | Report only the most severe consequence per variant | off |
+| `--pick` | Report one consequence per variant, chosen by `--pick-order` | off |
+| `--pick-order` | Criteria order used by `--pick`, VEP `--pick_order` syntax. Severity (`rank`) is last in the default, so this is not "most severe" -- see [docs/ACMG.md](docs/ACMG.md#which-transcript---pick-reports) | VEP's default |
 | `--symbol` | Include gene symbol in output | off |
 | `--canonical` | Include canonical-transcript flag in output | off |
 | `--everything` | Turn on all common annotation flags | off |

--- a/crates/fastvep-annotate/src/lib.rs
+++ b/crates/fastvep-annotate/src/lib.rs
@@ -8,6 +8,7 @@
 //! the same underlying crates.
 
 mod hgvs_normalize;
+pub mod pick;
 
 pub use hgvs_normalize::{
     convert_ins_to_dup_range, convert_ins_to_dup_range_noncoding, hgvsc_intronic_shifted,
@@ -27,6 +28,7 @@ use fastvep_genome::Transcript;
 use fastvep_io::output;
 use fastvep_io::variant::{AlleleAnnotation, TranscriptVariation, VariationFeature};
 use fastvep_io::vcf::VcfParser;
+use pick::{has_transcripts_to_pick, pick_best_transcript_idx_with, DEFAULT_PICK_ORDER};
 use rayon::prelude::*;
 use std::fs::File;
 use std::path::Path;
@@ -665,31 +667,44 @@ impl AnnotationContext {
                         })
                         .collect();
 
-                    let should_include =
-                        !pick || tc.canonical || vf.transcript_variations.is_empty();
-                    if should_include {
-                        vf.transcript_variations.push(TranscriptVariation {
-                            transcript_id: tc.transcript_id.clone(),
-                            gene_id: tc.gene_id.clone(),
-                            gene_symbol: tc.gene_symbol.clone(),
-                            biotype: tc.biotype.clone(),
-                            allele_annotations,
-                            canonical: tc.canonical,
-                            strand: tc.strand,
-                            source: self.gff3_source.clone(),
-                            protein_id: transcript.and_then(|t| t.protein_id.clone()),
-                            mane_select: transcript.and_then(|t| t.mane_select.clone()),
-                            mane_plus_clinical: transcript
-                                .and_then(|t| t.mane_plus_clinical.clone()),
-                            tsl: transcript.and_then(|t| t.tsl),
-                            appris: transcript.and_then(|t| t.appris.clone()),
-                            ccds: transcript.and_then(|t| t.ccds.clone()),
-                            gencode_primary: transcript.map(|t| t.gencode_primary).unwrap_or(false),
-                            symbol_source: transcript.and_then(|t| t.gene.symbol_source.clone()),
-                            hgnc_id: transcript.and_then(|t| t.gene.hgnc_id.clone()),
-                            flags: transcript.map(|t| t.flags.clone()).unwrap_or_default(),
-                        });
-                    }
+                    // Collect every transcript here; `pick` runs as a single
+                    // post-pass below so it can compare all candidates, the
+                    // same way `fastvep annotate --pick` does.
+                    vf.transcript_variations.push(TranscriptVariation {
+                        transcript_id: tc.transcript_id.clone(),
+                        gene_id: tc.gene_id.clone(),
+                        gene_symbol: tc.gene_symbol.clone(),
+                        biotype: tc.biotype.clone(),
+                        allele_annotations,
+                        canonical: tc.canonical,
+                        strand: tc.strand,
+                        source: self.gff3_source.clone(),
+                        protein_id: transcript.and_then(|t| t.protein_id.clone()),
+                        mane_select: transcript.and_then(|t| t.mane_select.clone()),
+                        mane_plus_clinical: transcript.and_then(|t| t.mane_plus_clinical.clone()),
+                        tsl: transcript.and_then(|t| t.tsl),
+                        appris: transcript.and_then(|t| t.appris.clone()),
+                        ccds: transcript.and_then(|t| t.ccds.clone()),
+                        gencode_primary: transcript.map(|t| t.gencode_primary).unwrap_or(false),
+                        symbol_source: transcript.and_then(|t| t.gene.symbol_source.clone()),
+                        hgnc_id: transcript.and_then(|t| t.gene.hgnc_id.clone()),
+                        flags: transcript.map(|t| t.flags.clone()).unwrap_or_default(),
+                    });
+                }
+            }
+
+            // Apply `pick` before SA/ACMG so those passes only run on the
+            // surviving transcript, and before `compute_most_severe` so the
+            // summary term describes the transcript actually reported.
+            // Shares `pick::` with `fastvep annotate --pick`: this path used to
+            // keep "canonical, or the first transcript seen", which returned a
+            // non-canonical first row next to the canonical one for a
+            // single-gene variant.
+            if pick && has_transcripts_to_pick(&vf.transcript_variations) {
+                if let Some(idx) =
+                    pick_best_transcript_idx_with(&vf.transcript_variations, DEFAULT_PICK_ORDER)
+                {
+                    vf.transcript_variations = vec![vf.transcript_variations.swap_remove(idx)];
                 }
             }
 

--- a/crates/fastvep-annotate/src/pick.rs
+++ b/crates/fastvep-annotate/src/pick.rs
@@ -1,4 +1,10 @@
 //! `--pick`: choosing one consequence per variant, in VEP's order.
+//!
+//! This lives in `fastvep-annotate` rather than in the CLI because both
+//! drivers need it and they had already drifted: the CLI ran this hierarchy
+//! while `annotate_vcf_text` (the web server's path) kept "canonical, or the
+//! first transcript seen", which returns two rows for a single-gene variant
+//! and puts a non-canonical one first. One implementation, one behaviour.
 
 use anyhow::Result;
 use fastvep_io::variant::TranscriptVariation;
@@ -84,13 +90,29 @@ pub fn parse_pick_order(spec: &str) -> Result<Vec<PickCriterion>> {
     Ok(out)
 }
 
+/// Whether `--pick` has competing transcripts to choose between.
+///
+/// The placeholder rows `annotate_intergenic` and `annotate_sa_only_scaffold`
+/// emit carry `transcript_id` `-`, and they are built one per *alt allele*
+/// rather than one per transcript. Running the hierarchy over those keeps a
+/// single row and silently drops every other alt from the output - no error,
+/// just a missing allele. There is no transcript to pick at such a site, so
+/// pick does not apply there.
+///
+/// A mix cannot currently occur, because those scaffolds run only when nothing
+/// overlaps the variant; `any` is the deliberate reading if one ever does, so
+/// that a real transcript still gets picked.
+pub fn has_transcripts_to_pick(tvs: &[TranscriptVariation]) -> bool {
+    tvs.len() > 1 && tvs.iter().any(|tv| tv.transcript_id.as_ref() != "-")
+}
+
 /// Index of the best transcript variation under the given `--pick-order`
 /// hierarchy, with transcript_id alphabetical order as a final deterministic
 /// tie-breaker.
 ///
 /// Criteria omitted from `order` are not consulted at all, which is what lets
 /// a caller drop a tier rather than only reorder it.
-pub(crate) fn pick_best_transcript_idx_with(
+pub fn pick_best_transcript_idx_with(
     tvs: &[TranscriptVariation],
     order: &[PickCriterion],
 ) -> Option<usize> {
@@ -242,6 +264,60 @@ mod pick_tests {
             hgnc_id: None,
             flags: Vec::new(),
         }
+    }
+
+    #[test]
+    fn intergenic_placeholders_are_not_pickable() {
+        // Regression test: a multi-allelic intergenic site arrives as one
+        // placeholder row per alt allele. Picking among them drops alleles.
+        let rows: Vec<TranscriptVariation> = ["-", "-"]
+            .iter()
+            .map(|id| {
+                make_tv(
+                    id,
+                    false,
+                    "-",
+                    vec![Consequence::IntergenicVariant],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .collect();
+        assert!(!has_transcripts_to_pick(&rows));
+    }
+
+    #[test]
+    fn real_transcripts_are_pickable() {
+        let rows = vec![
+            make_tv(
+                "ENST1",
+                false,
+                "protein_coding",
+                vec![Consequence::MissenseVariant],
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            make_tv(
+                "ENST2",
+                true,
+                "protein_coding",
+                vec![Consequence::MissenseVariant],
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        ];
+        assert!(has_transcripts_to_pick(&rows));
+        // One transcript is not a choice either.
+        assert!(!has_transcripts_to_pick(&rows[..1]));
     }
 
     #[test]

--- a/crates/fastvep-cli/src/main.rs
+++ b/crates/fastvep-cli/src/main.rs
@@ -57,7 +57,8 @@ enum Commands {
         #[arg(long, default_value_t = 5000)]
         buffer_size: usize,
 
-        /// Pick one consequence per variant (most severe)
+        /// Pick one consequence per variant, by `--pick-order` (not by severity:
+        /// severity is that order's last tie-break, as in VEP)
         #[arg(long)]
         pick: bool,
 

--- a/crates/fastvep-cli/src/pipeline/annotate.rs
+++ b/crates/fastvep-cli/src/pipeline/annotate.rs
@@ -2,10 +2,11 @@
 
 use super::cache_build::{load_one_gff3, parse_gff3_arg, Gff3Spec};
 use super::open_vcf_input_reader;
-use super::pick::{
-    parse_pick_order, pick_best_transcript_idx_with, PickCriterion, DEFAULT_PICK_ORDER,
-};
 use anyhow::{Context, Result};
+use fastvep_annotate::pick::{
+    has_transcripts_to_pick, parse_pick_order, pick_best_transcript_idx_with, PickCriterion,
+    DEFAULT_PICK_ORDER,
+};
 use fastvep_cache::annotation::{AnnotationProvider, AnnotationValue, GeneAnnotationProvider};
 use fastvep_cache::fasta::FastaReader;
 use fastvep_cache::info::CacheInfo;
@@ -495,7 +496,7 @@ fn annotate_variant(
     // single surviving transcript. Running pick after them would still
     // produce correct output but would waste the most expensive work
     // (ACMG classification) on transcripts that get thrown away.
-    if config.pick && !sa_only && vf.transcript_variations.len() > 1 {
+    if config.pick && !sa_only && has_transcripts_to_pick(&vf.transcript_variations) {
         if let Some(idx) = pick_best_transcript_idx_with(&vf.transcript_variations, pick_order) {
             vf.transcript_variations = vec![vf.transcript_variations.swap_remove(idx)];
         }

--- a/crates/fastvep-cli/src/pipeline/mod.rs
+++ b/crates/fastvep-cli/src/pipeline/mod.rs
@@ -13,14 +13,16 @@ pub mod annotate;
 pub mod cache_build;
 pub mod custom;
 pub mod filter;
-pub mod pick;
 pub mod sa_build;
 
 pub use annotate::{run_annotate, AnnotateConfig};
 pub use cache_build::{parse_gff3_arg, run_cache_build, Gff3Spec};
 pub use custom::run_oga_build;
 pub use filter::run_filter;
-pub use pick::{parse_pick_order, PickCriterion, DEFAULT_PICK_ORDER};
+// `pick` moved into `fastvep-annotate` so the CLI and the web server
+// share one implementation; re-exported here so callers of
+// `pipeline::` keep the path they had.
+pub use fastvep_annotate::pick::{parse_pick_order, PickCriterion, DEFAULT_PICK_ORDER};
 pub use sa_build::{
     run_sa_build, run_sa_build_format, run_sa_build_v2, run_sa_convert, source_from_json_key,
     source_has_decomposed_osa2, source_supports_osa2, OSA2_DECOMPOSED_SOURCES,

--- a/crates/fastvep-web/fixtures/pick.gff3
+++ b/crates/fastvep-web/fixtures/pick.gff3
@@ -1,0 +1,13 @@
+##gff-version 3
+# Two transcripts of one gene, for the `pick` contract test. TXB starts earlier
+# so it is the first one the annotator sees, and it is not canonical: that is
+# the shape the old "canonical, or the first transcript seen" filter got wrong,
+# returning both rows with the non-canonical one first.
+17	test	gene	900	3000	.	+	.	ID=gene:GENEA;Name=GENEA;biotype=protein_coding;gene_id=GENEA
+17	test	mRNA	900	3000	.	+	.	ID=transcript:TXB;Parent=gene:GENEA;Name=GENEA-202;biotype=protein_coding;transcript_id=TXB
+17	test	exon	900	1200	.	+	.	ID=exon:TXB-E1;Parent=transcript:TXB;rank=1
+17	test	mRNA	1000	3000	.	+	.	ID=transcript:TXA;Parent=gene:GENEA;Name=GENEA-201;biotype=protein_coding;tag=Ensembl_canonical;transcript_id=TXA
+17	test	exon	1000	1200	.	+	.	ID=exon:TXA-E1;Parent=transcript:TXA;rank=1
+17	test	CDS	1000	1200	.	+	0	ID=CDS:TXA;Parent=transcript:TXA;protein_id=PROTA
+17	test	exon	2800	3000	.	+	.	ID=exon:TXA-E2;Parent=transcript:TXA;rank=2
+17	test	CDS	2800	3000	.	+	0	ID=CDS:TXA;Parent=transcript:TXA;protein_id=PROTA

--- a/crates/fastvep-web/tests/api.rs
+++ b/crates/fastvep-web/tests/api.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, RwLock};
 use tower::ServiceExt;
 
 const MINI_GFF3: &str = include_str!("../fixtures/mini.gff3");
+const PICK_GFF3: &str = include_str!("../fixtures/pick.gff3");
 
 /// One transcript, no FASTA, no supplementary annotations. Deliberately the
 /// minimum a caller can stand up, so a failure here is the API's fault rather
@@ -27,6 +28,22 @@ fn test_state() -> AppState {
         data_dir: None,
         sa_dir: None,
         // No stats file: these tests must not write to the working directory.
+        stats_file: None,
+        total_variants: AtomicU64::new(0),
+        total_genomes: AtomicU64::new(0),
+    })
+}
+
+/// Two overlapping transcripts of one gene, the first-seen one non-canonical.
+/// Kept separate from [`test_state`] so the single-transcript counts the other
+/// tests assert stay meaningful.
+fn pick_state() -> AppState {
+    let mut ctx = AnnotationContext::new(None, None, None, 5000).expect("build context");
+    ctx.update_gff3_text(PICK_GFF3).expect("load pick gff3");
+    Arc::new(SharedState {
+        ctx: RwLock::new(ctx),
+        data_dir: None,
+        sa_dir: None,
         stats_file: None,
         total_variants: AtomicU64::new(0),
         total_genomes: AtomicU64::new(0),
@@ -206,6 +223,94 @@ async fn acmg_is_attached_only_when_requested() {
         acmg["criteria"].is_array(),
         "acmg block must carry per-criterion verdicts"
     );
+}
+
+#[tokio::test]
+async fn pick_returns_exactly_one_transcript_and_it_is_the_canonical_one() {
+    // Regression test for the drift between the two annotation drivers. The
+    // CLI ran VEP's `--pick_order` hierarchy; this path kept a transcript when
+    // it was canonical *or* the first one seen, which returned both rows here
+    // with the non-canonical TXB first. A client reading
+    // `transcript_consequences[0]` therefore got the wrong transcript from a
+    // request that had explicitly asked for one answer.
+    let state = pick_state();
+    let vcf = vcf_line(1100, "pick");
+
+    let (status, all) = post_json(&state, "/api/annotate", json!({ "vcf": &vcf })).await;
+    assert_eq!(status, StatusCode::OK);
+    let unpicked = all["results"][0]["transcript_consequences"]
+        .as_array()
+        .expect("transcript consequences");
+    // Both transcripts really do overlap the variant, so the pick below is
+    // making a choice rather than describing a set that only had one member.
+    let ids: Vec<&str> = unpicked
+        .iter()
+        .map(|t| t["transcript_id"].as_str().unwrap_or_default())
+        .collect();
+    assert!(ids.contains(&"TXA") && ids.contains(&"TXB"), "got {ids:?}");
+
+    let (status, picked) = post_json(
+        &state,
+        "/api/annotate",
+        json!({ "vcf": &vcf, "pick": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let kept = picked["results"][0]["transcript_consequences"]
+        .as_array()
+        .expect("transcript consequences");
+    assert_eq!(kept.len(), 1, "pick must reduce to one row, got {kept:?}");
+    assert_eq!(
+        kept[0]["transcript_id"], "TXA",
+        "pick must keep the canonical transcript, not the first one seen"
+    );
+}
+
+#[tokio::test]
+async fn pick_does_not_drop_alleles_at_a_site_with_no_transcripts() {
+    // An intergenic site is scaffolded one row per *alt allele*, not one row
+    // per transcript, so running the pick hierarchy over those rows keeps one
+    // and silently loses the other alt. There is no transcript to pick here,
+    // so `pick` must leave the site alone.
+    let state = pick_state();
+    let vcf = "17\t900000\t.\tG\tA,T\t50\tPASS\t.";
+
+    for pick in [false, true] {
+        let (status, body) =
+            post_json(&state, "/api/annotate", json!({ "vcf": vcf, "pick": pick })).await;
+        assert_eq!(status, StatusCode::OK);
+        let alleles: Vec<&str> = body["results"][0]["transcript_consequences"]
+            .as_array()
+            .expect("transcript consequences")
+            .iter()
+            .map(|t| t["variant_allele"].as_str().unwrap_or_default())
+            .collect();
+        assert_eq!(alleles, ["A", "T"], "pick={pick} lost an alt allele");
+    }
+}
+
+#[tokio::test]
+async fn pick_keeps_every_allele_of_the_transcript_it_picks() {
+    // `pick` reduces to one transcript, not to one row: the JSON carries one
+    // entry per (transcript, allele), so a biallelic site keeps two.
+    let state = pick_state();
+    let vcf = "17\t1100\t.\tG\tA,T\t50\tPASS\t.";
+
+    let (status, body) =
+        post_json(&state, "/api/annotate", json!({ "vcf": vcf, "pick": true })).await;
+    assert_eq!(status, StatusCode::OK);
+    let kept: Vec<(&str, &str)> = body["results"][0]["transcript_consequences"]
+        .as_array()
+        .expect("transcript consequences")
+        .iter()
+        .map(|t| {
+            (
+                t["transcript_id"].as_str().unwrap_or_default(),
+                t["variant_allele"].as_str().unwrap_or_default(),
+            )
+        })
+        .collect();
+    assert_eq!(kept, [("TXA", "A"), ("TXA", "T")]);
 }
 
 #[tokio::test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,7 +85,8 @@ curl -s http://localhost:8080/api/status | python3 -m json.tool
 }
 ```
 
-Check `has_fasta` and `sa_sources` here before you trust any annotation, for the reason in the next section.
+Check `transcripts`, `has_fasta`, and `sa_sources` here before you trust any annotation.
+Each of the three can be missing without the server saying so: a zero transcript count makes every variant `intergenic_variant`, and the other two are the subject of the next section.
 
 ## Always pass `--fasta`
 
@@ -127,7 +128,7 @@ All request and response bodies are JSON, except `POST /api/upload-gff3`, which 
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `vcf` | string | required | VCF text. Header lines are optional; records are tab-separated. |
-| `pick` | bool | `false` | Narrow the reported transcripts (see the caveat below). |
+| `pick` | bool | `false` | Reduce each variant to one transcript consequence (see below). |
 | `acmg` | bool | `false` | Attach ACMG-AMP classification to each consequence. |
 
 ```bash
@@ -203,9 +204,16 @@ Expect responses to be large, and select the transcript you care about rather th
 The per-variant shape follows Ensembl VEP's JSON output, so clients written against VEP's `transcript_consequences` mostly port over.
 `time_ms` is server-side annotation time, excluding transport.
 
-> **`pick` does not guarantee one consequence per variant.**
-> In this code path a transcript is kept when it is canonical *or* when it is the first one seen for the variant (`crates/fastvep-annotate/src/lib.rs:669`), so a request with `"pick": true` can still return two entries.
-> If you need exactly one row per variant, select it client-side from `most_severe_consequence`, or use the CLI.
+`"pick": true` reduces each variant to one transcript, chosen by the same hierarchy as `fastvep annotate --pick`: MANE Select, then MANE Plus Clinical, canonical, APPRIS, TSL, biotype, CCDS, and only then consequence severity.
+That is Ensembl VEP's default `--pick_order`, so a default run of either tool picks the same transcript.
+It reduces to one *transcript*, not to one entry: `transcript_consequences` carries one entry per (transcript, allele), so a biallelic site still returns two.
+A variant that overlaps no transcript at all is left untouched, because there its entries are one per alt allele rather than competing transcripts.
+
+> **`pick` does not mean "most severe".**
+> Severity is the *last* tie-break in that order, so where genes overlap, a neighbouring gene's MANE transcript outranks a non-MANE transcript the variant actually disrupts, and the reported consequence can be `upstream_gene_variant` on the neighbour rather than the damaging term on the real target.
+> Stock VEP behaves the same way; it is still the wrong answer for clinical reporting.
+> The server does not expose `--pick-order`, so if severity must come first, use the CLI with `--pick-order rank,mane_select,...` -- [docs/ACMG.md](ACMG.md#which-transcript---pick-reports) has the measured effect.
+> `most_severe_consequence` is computed from the transcripts actually reported, so with `"pick": true` it describes the picked transcript, not the whole locus.
 
 Setting `"acmg": true` adds an `acmg` object to each transcript consequence with the classification, the per-criterion verdicts, and the evidence counts.
 Classification quality depends on which supplementary databases are loaded, so read [docs/ACMG_SETUP.md](ACMG_SETUP.md) before relying on it.
@@ -253,7 +261,7 @@ Check the server's stderr when you get one.
 | --- | --- | --- | --- |
 | `--bind` | `FASTVEP_BIND` | `0.0.0.0` | Interface to listen on |
 | `--port` | `FASTVEP_PORT` | `8080` | Port to listen on |
-| `--gff3` | `FASTVEP_GFF3` | built-in example | Gene model |
+| `--gff3` | `FASTVEP_GFF3` | none | Gene model |
 | `--fasta` | `FASTVEP_FASTA` | none | Reference FASTA, needs a `.fai` |
 | `--sa-dir` | `FASTVEP_SA_DIR` | none | Directory of `.osa`/`.osa2`/`.osi`/`.oga` files |
 | `--data-dir` | `FASTVEP_DATA_DIR` | none | Directory of switchable genomes |
@@ -262,7 +270,8 @@ Check the server's stderr when you get one.
 | `--max-concurrent` | | `64` | Concurrent annotation requests |
 | `--stats-file` | `FASTVEP_STATS_FILE` | `stats.json` | Where the served-variant counters persist |
 
-Two things to know about the defaults.
+Three things to know about the defaults.
+`--gff3` has none, and a server started without one does not refuse to start: it comes up with `"status": "ok"`, reports `"transcripts": 0`, and answers every request with `intergenic_variant` at HTTP 200.
 `--stats-file` is relative, so a bare `fastvep-web` writes `stats.json` into whatever directory you launched it from; pass an absolute path under a service account's own state directory when running it as a daemon.
 Requests beyond `--max-concurrent` queue rather than fail, which is why raising it is rarely the fix for a slow server.
 


### PR DESCRIPTION
Follow-up to #110, which documented the `pick` discrepancy rather than fixing it.

## The two drivers had drifted

`fastvep annotate` ran VEP's `--pick_order` hierarchy. `annotate_vcf_text` - the path behind `fastvep-web`'s `/api/annotate` and the legacy `fastvep web` - filtered inline instead, keeping a transcript when it was canonical **or** when it was the first one seen.

Against the BRCA1 model in `tests/test.gff3`, `{"pick": true}` on `17:43124090 A>G`:

```
entry[0]  ENST00000921914  canonical=None  non_coding_transcript_variant
entry[1]  ENST00000357654  canonical=1     coding_sequence_variant
```

Two rows from a request that asked for one, and the first is a transcript that wins only by starting earliest. A client reading `transcript_consequences[0]` got a coding BRCA1 variant reported as non-coding, at HTTP 200. The CLI returned the single canonical row on the same input.

`pick.rs` moves down into `fastvep-annotate` - which both drivers already depend on, and which is below where it needs to be for either - and the shared path calls it as the same post-pass the CLI runs: after the transcript loop, before SA/ACMG, before `compute_most_severe`. It needs only `fastvep_io::TranscriptVariation` and `fastvep_core::Consequence`, so no new dependency edge. The CLI re-exports it so `pipeline::` callers keep their path. All 18 pick unit tests moved intact.

## Reviewing that fix turned up a bug the CLI already had

`annotate_intergenic` and `annotate_sa_only_scaffold` emit one placeholder row per **alt allele**, not one per transcript, and the pick hierarchy cannot tell those from competing transcripts. On `master` today:

```
fastvep annotate --pick   multi-allelic intergenic  ->  ['A']
fastvep annotate          multi-allelic intergenic  ->  ['A', 'T']
```

`--pick` silently drops the second alt. Not a regression from this PR - it reproduces on `master` - but sharing the CLI's post-pass would have carried it into the web path too, so `has_transcripts_to_pick` now guards both call sites. A site with no transcripts has no transcript to pick. Both drivers now return `['A', 'T']` with and without pick.

## Docs that did not match the code

- **`--pick` is not "most severe."** The README options table and the CLI's `--help` both said it was. `DEFAULT_PICK_ORDER` puts `rank` **last**, behind MANE/canonical/APPRIS/TSL/biotype/CCDS. `docs/ACMG.md` has said so all along with measured numbers (43 of 300 CYP21A2-region variants land on the neighbouring C4B). Fixed both, and added the `--pick-order` row the README was missing.
- **`docs/API.md` gave `--gff3`'s default as "built-in example."** There is none. Started `fastvep-web` without it: comes up `"status": "ok"`, `"transcripts": 0`, and answers every request `intergenic_variant` at HTTP 200. Same failure shape as the documented `--fasta` hazard, now flagged in the same two places.
- **The `pick` caveat described the bug this PR fixes.** Rewritten to state the hierarchy and what `pick` does and does not promise.

## Verification

- CLI `--pick` and the web API agree on the picked transcript and `most_severe_consequence` for all 8 records of `tests/test.vcf`.
- Both new E2E tests were checked against the code they pin - the transcript one fails `left: 2, right: 1` under the old predicate, the allele one fails `pick=true lost an alt allele` without the guard.
- Every doc claim added here was confirmed against a running server, not read off the source.
- `cargo fmt` / `clippy -D warnings` / **1029 tests**, all green.

## Behaviour change worth calling out

Callers of `/api/annotate` with `"pick": true` now get one transcript instead of two. That is the fix, but it is user-visible. The web API still has no `pick_order` field, so `rank`-first ordering remains CLI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
