### PR TITLE
fix(pick): read the APPRIS tags, so the APPRIS tier can decide something

### DIFF
--- a/crates/fastvep-annotate/src/pick.rs
+++ b/crates/fastvep-annotate/src/pick.rs
@@ -25,6 +25,14 @@ pub enum PickCriterion {
 /// VEP's default `--pick_order`, which fastVEP matches exactly so that a
 /// default run of each tool picks the same transcript.
 ///
+/// "Matches exactly" is a claim about the tiers *and* about what feeds them.
+/// It was false for two years on the APPRIS tier: `Transcript::appris` came
+/// from the GFF3 parser, which never read the `appris_*` tags, so the tier
+/// scored every candidate the same and the pick fell through to the next one
+/// that could tell them apart. The three unit tests below covered the tier and
+/// passed throughout, because they build `TranscriptVariation` by hand. A tier
+/// added here needs a test that reaches it through the parser.
+///
 /// Note where `Rank` sits: **last**. Transcript status outranks consequence
 /// severity, so at a locus where a MANE transcript of one gene merely
 /// neighbours the variant while a non-MANE transcript of another is disrupted
@@ -137,7 +145,7 @@ fn pick_score(tv: &TranscriptVariation, c: PickCriterion) -> u32 {
         PickCriterion::ManeSelect => tv.mane_select.is_none() as u32,
         PickCriterion::ManePlusClinical => tv.mane_plus_clinical.is_none() as u32,
         PickCriterion::Canonical => !tv.canonical as u32,
-        PickCriterion::Appris => appris_rank(tv.appris.as_deref()) as u32,
+        PickCriterion::Appris => appris_rank(tv.appris.as_deref()),
         PickCriterion::Tsl => tv.tsl.unwrap_or(u8::MAX) as u32,
         PickCriterion::Biotype => u32::from(tv.biotype.as_ref() != "protein_coding"),
         PickCriterion::Ccds => tv.ccds.is_none() as u32,
@@ -173,30 +181,68 @@ fn pick_key_with<'a>(
     (key, tv.transcript_id.as_ref())
 }
 
-/// Map an APPRIS tag (`P1`/`principal1`, ..., `A1`/`alternative1`, ...) to a
-/// rank where lower is better, matching VEP's `--pick_order` APPRIS tier:
-/// principal1 < principal2 < ... < alternative1 < alternative2 < absent.
-fn appris_rank(appris: Option<&str>) -> u8 {
-    let Some(s) = appris else { return u8::MAX };
-    let lower = s.to_ascii_lowercase();
-    let (is_alt, digits) = if let Some(d) = lower.strip_prefix("principal") {
-        (false, d)
-    } else if let Some(d) = lower.strip_prefix("alternative") {
-        (true, d)
-    } else if let Some(d) = lower.strip_prefix('p') {
-        (false, d)
-    } else if let Some(d) = lower.strip_prefix('a') {
-        (true, d)
-    } else {
-        // Present but unrecognised: still better than absent, worse than any
-        // recognised principal/alternative.
-        return u8::MAX - 1;
+/// Every APPRIS spelling reaches here, so the bands are spaced rather than
+/// adjacent: a tier number is added to its band's base, and an un-numbered
+/// call sits at the top of its own band.
+///
+/// APPRIS itself only issues principal 1-5 and alternative 1-2, so the 99
+/// slots per band are slack, not a claim about the vocabulary.
+const APPRIS_PRINCIPAL_BASE: u32 = 0;
+const APPRIS_PRINCIPAL_UNNUMBERED: u32 = 100;
+const APPRIS_ALTERNATIVE_BASE: u32 = 200;
+const APPRIS_ALTERNATIVE_UNNUMBERED: u32 = 300;
+/// Present but in no spelling this understands. Worse than any call it does
+/// understand, better than no call at all - the transcript was annotated.
+const APPRIS_UNRECOGNISED: u32 = u32::MAX - 1;
+/// No APPRIS annotation. Ensembl's own GFF3 carries none for any transcript, so
+/// on that source this is every transcript's rank and the tier decides nothing,
+/// correctly, because there is nothing to decide with. GENCODE's GFF3 does
+/// carry it, and before the parser read those tags this was every transcript's
+/// rank on every source.
+const APPRIS_ABSENT: u32 = u32::MAX;
+
+/// Map an APPRIS tag to a rank where lower is better, matching VEP's
+/// `--pick_order` APPRIS tier:
+/// principal1 < ... < principal5 < principal < alternative1 < alternative2 <
+/// alternative < unrecognised < absent.
+///
+/// Four spellings of the same thing reach this function, because three sources
+/// write it differently and the separator moved between GENCODE releases:
+/// GENCODE's own tag (`appris_principal_1`), the tag with the `appris_` prefix
+/// already stripped (`principal_1`, `principal1`), and VEP's short form (`P1`,
+/// `ALT1`). Handling only some of them is how `appris_principal_1` used to rank
+/// *below* every alternative: it fell through to the bare-`a` arm.
+fn appris_rank(appris: Option<&str>) -> u32 {
+    let Some(s) = appris else {
+        return APPRIS_ABSENT;
     };
-    let n: u8 = digits.parse().unwrap_or(9);
-    if is_alt {
-        5u8.saturating_add(n)
+    let lower = s.trim().to_ascii_lowercase();
+    let body = lower.strip_prefix("appris_").unwrap_or(&lower);
+    // `alt` before the bare `a`, and `alternative` before `alt`: the shorter
+    // prefixes would otherwise swallow the longer spellings' digits.
+    let (base, unnumbered, digits) = if let Some(d) = body.strip_prefix("principal") {
+        (APPRIS_PRINCIPAL_BASE, APPRIS_PRINCIPAL_UNNUMBERED, d)
+    } else if let Some(d) = body.strip_prefix("alternative") {
+        (APPRIS_ALTERNATIVE_BASE, APPRIS_ALTERNATIVE_UNNUMBERED, d)
+    } else if let Some(d) = body.strip_prefix("alt") {
+        (APPRIS_ALTERNATIVE_BASE, APPRIS_ALTERNATIVE_UNNUMBERED, d)
+    } else if let Some(d) = body.strip_prefix('p') {
+        (APPRIS_PRINCIPAL_BASE, APPRIS_PRINCIPAL_UNNUMBERED, d)
+    } else if let Some(d) = body.strip_prefix('a') {
+        (APPRIS_ALTERNATIVE_BASE, APPRIS_ALTERNATIVE_UNNUMBERED, d)
     } else {
-        n
+        return APPRIS_UNRECOGNISED;
+    };
+    let digits = digits.trim_start_matches(['_', '-']);
+    if digits.is_empty() {
+        return unnumbered;
+    }
+    match digits.parse::<u32>() {
+        // Clamped so an out-of-vocabulary tier still sorts inside its own
+        // band rather than past the next one.
+        Ok(n) => base + n.clamp(1, 99),
+        // `P1extra`: the class is legible, the tier is not.
+        Err(_) => unnumbered,
     }
 }
 
@@ -641,6 +687,103 @@ mod pick_tests {
             ),
         ];
         assert_eq!(pick_best_transcript_idx(&tvs), Some(1));
+    }
+
+    #[test]
+    fn appris_orders_alternatives_by_their_tier() {
+        // ALT1 and ALT2 both reach the ranker as the short form the GFF3
+        // parser now writes, and the pre-fix ranker scored them equal: the
+        // bare-`a` arm swallowed the `A`, `lt1` and `lt2` both failed to
+        // parse, and both landed on the same fallback tier.
+        //
+        // The IDs are chosen so that a tie is not silently right. `TX_A`
+        // carries the *worse* call, so the alphabetical transcript-ID
+        // tie-break returns it whenever the APPRIS tier declines to decide -
+        // which is what the equal scores used to produce.
+        let tvs = vec![
+            make_tv(
+                "TX_A",
+                false,
+                "protein_coding",
+                vec![Consequence::MissenseVariant],
+                None,
+                None,
+                Some("ALT2"),
+                None,
+                None,
+            ),
+            make_tv(
+                "TX_Z",
+                false,
+                "protein_coding",
+                vec![Consequence::MissenseVariant],
+                None,
+                None,
+                Some("ALT1"),
+                None,
+                None,
+            ),
+        ];
+        assert_eq!(
+            pick_best_transcript_idx(&tvs),
+            Some(1),
+            "ALT1 should outrank ALT2; index 0 is what the ID tie-break gives"
+        );
+    }
+
+    #[test]
+    fn appris_reads_every_spelling_of_the_same_call() {
+        // Three sources write the same annotation three ways, and the
+        // separator moved between GENCODE releases. All four spellings of
+        // principal 1 have to rank identically, and all of them ahead of
+        // every spelling of alternative 2.
+        for principal in [
+            "P1",
+            "p1",
+            "principal1",
+            "principal_1",
+            "appris_principal_1",
+        ] {
+            for alternative in [
+                "ALT2",
+                "A2",
+                "alternative2",
+                "alternative_2",
+                "appris_alternative_2",
+            ] {
+                assert!(
+                    appris_rank(Some(principal)) < appris_rank(Some(alternative)),
+                    "{principal} ({}) should outrank {alternative} ({})",
+                    appris_rank(Some(principal)),
+                    appris_rank(Some(alternative)),
+                );
+            }
+        }
+        // And the numbered forms agree with each other exactly.
+        let p1 = appris_rank(Some("P1"));
+        for spelling in ["p1", "principal1", "principal_1", "appris_principal_1"] {
+            assert_eq!(appris_rank(Some(spelling)), p1, "{spelling}");
+        }
+    }
+
+    #[test]
+    fn appris_ranks_an_unnumbered_call_at_the_end_of_its_own_class() {
+        // Older GENCODE releases write `appris_principal` with no tier. It is
+        // still a principal call: worse than every numbered principal, better
+        // than any alternative.
+        let (p1, p5) = (appris_rank(Some("P1")), appris_rank(Some("P5")));
+        let (p, alt1) = (appris_rank(Some("P")), appris_rank(Some("ALT1")));
+        let (alt2, alt) = (appris_rank(Some("ALT2")), appris_rank(Some("ALT")));
+        assert!(p1 < p5, "P1 < P5");
+        assert!(p5 < p, "P5 < P");
+        assert!(p < alt1, "P < ALT1");
+        assert!(alt1 < alt2, "ALT1 < ALT2");
+        assert!(alt2 < alt, "ALT2 < ALT");
+        assert!(alt < appris_rank(Some("weird")), "ALT < unrecognised");
+        assert!(
+            appris_rank(Some("weird")) < appris_rank(None),
+            "unrecognised < absent"
+        );
     }
 
     #[test]

--- a/crates/fastvep-cache/src/gff.rs
+++ b/crates/fastvep-cache/src/gff.rs
@@ -291,6 +291,11 @@ fn parse_gff3_lines(lines: impl Iterator<Item = Result<String>>) -> Result<Vec<T
                     .get("transcript_support_level")
                     .and_then(|v| v.split_whitespace().next().and_then(|n| n.parse().ok()));
 
+                // APPRIS rides in the same `tag=` list as MANE and canonical,
+                // spelled `appris_principal_1` / `appris_alternative_2`. VEP
+                // reports the suffix, so that is what is stored.
+                let appris = appris_from_tags(&tag_str);
+
                 transcripts.insert(
                     transcript_id.clone(),
                     GffTranscript {
@@ -307,6 +312,7 @@ fn parse_gff3_lines(lines: impl Iterator<Item = Result<String>>) -> Result<Vec<T
                         gencode_primary,
                         ccds,
                         tsl,
+                        appris,
                         flags,
                         version,
                         provisional: !is_known_transcript_term(feature_type),
@@ -414,6 +420,7 @@ fn parse_gff3_lines(lines: impl Iterator<Item = Result<String>>) -> Result<Vec<T
                         gencode_primary: false,
                         ccds: None,
                         tsl: None,
+                        appris: None,
                         flags: vec![],
                         version: None,
                         // Synthesised from a real CDS, so it is confirmed by
@@ -741,7 +748,7 @@ fn parse_gff3_lines(lines: impl Iterator<Item = Result<String>>) -> Result<Vec<T
                 None
             },
             tsl: gff_tr.tsl,
-            appris: None,
+            appris: gff_tr.appris.clone(),
             ccds: gff_tr.ccds.clone(),
             protein_id: tr_cds.first().map(|c| c.protein_id.clone()),
             protein_version: if !tr_cds.is_empty() { Some(1) } else { None },
@@ -877,6 +884,47 @@ fn parent_is_gene(attrs: &HashMap<String, String>) -> bool {
         .is_some_and(|p| p.starts_with("gene:") || p.starts_with("gene-"))
 }
 
+/// The APPRIS annotation carried in a GENCODE GFF3 `tag=` list, in the short
+/// form VEP reports.
+///
+/// GENCODE spells it `appris_principal_1` .. `appris_principal_5` and
+/// `appris_alternative_1` / `appris_alternative_2`, in the same comma-separated
+/// `tag=` attribute that carries `MANE_Select` and `Ensembl_canonical`. VEP
+/// reports the short form, `P1`..`P5` and `ALT1`/`ALT2`, and that is what goes
+/// in the APPRIS column and into `--pick-order`'s APPRIS tier.
+///
+/// Older GENCODE releases write the un-numbered `appris_principal` /
+/// `appris_alternative`; those become `P` / `ALT`, which `pick`'s APPRIS rank
+/// orders after every numbered principal and alternative respectively.
+///
+/// Ensembl's own GFF3 carries no APPRIS tag at all, so this returns `None`
+/// there and the tier stays inert for that source - which is what it was for
+/// every source before this function existed.
+fn appris_from_tags(tag_str: &str) -> Option<String> {
+    for tag in tag_str.split(',') {
+        let tag = tag.trim().to_ascii_lowercase();
+        let Some(rest) = tag.strip_prefix("appris_") else {
+            continue;
+        };
+        // `principal_1` / `principal1` / `principal`, and the same for
+        // `alternative`. The separator has moved between GENCODE releases.
+        let (short, digits) = if let Some(d) = rest.strip_prefix("principal") {
+            ("P", d)
+        } else if let Some(d) = rest.strip_prefix("alternative") {
+            ("ALT", d)
+        } else {
+            continue;
+        };
+        let digits = digits.trim_start_matches(['_', '-']);
+        return Some(if digits.is_empty() {
+            short.to_string()
+        } else {
+            format!("{}{}", short, digits)
+        });
+    }
+    None
+}
+
 fn parse_attributes(attr_str: &str) -> HashMap<String, String> {
     let mut attrs = HashMap::new();
     for part in attr_str.split(';') {
@@ -935,6 +983,7 @@ struct GffTranscript {
     gencode_primary: bool,
     ccds: Option<String>,
     tsl: Option<u8>,
+    appris: Option<String>,
     flags: Vec<String>,
     version: Option<u32>,
     /// Admitted only because it hangs off a gene, its SO term being unknown.
@@ -1004,6 +1053,63 @@ chr1\tensembl\tCDS\t4000\t4500\t.\t+\t1\tID=CDS:ENSP00000001;Parent=transcript:E
     /// miRNA / snRNA transcript with a synthesised gene carrying no symbol
     /// and biotype "unknown", so SYMBOL came out empty in the CSQ column
     /// while VEP filled it in.
+    /// GENCODE carries APPRIS in the same comma-separated `tag=` list as
+    /// `MANE_Select` and `Ensembl_canonical`, and the parser read every other
+    /// tag in that list and dropped this one. `Transcript::appris` was
+    /// therefore `None` for every transcript from every source, so the APPRIS
+    /// column of the CSQ line was always empty and `--pick`'s APPRIS tier
+    /// scored every candidate identically.
+    #[test]
+    fn test_parse_gff3_reads_the_gencode_appris_tag() {
+        let gff = "##gff-version 3
+1\ttest\tgene\t1000\t2000\t.\t+\t.\tID=gene:ENSG_A;Name=GA;biotype=protein_coding
+1\ttest\tmRNA\t1000\t2000\t.\t+\t.\tID=transcript:ENST_P;Parent=gene:ENSG_A;biotype=protein_coding;tag=gencode_basic,Ensembl_canonical,appris_principal_1
+1\ttest\texon\t1000\t2000\t.\t+\t.\tID=exon:E_P;Parent=transcript:ENST_P;rank=1
+1\ttest\tmRNA\t1000\t2000\t.\t+\t.\tID=transcript:ENST_A;Parent=gene:ENSG_A;biotype=protein_coding;tag=gencode_basic,appris_alternative_2
+1\ttest\texon\t1000\t2000\t.\t+\t.\tID=exon:E_A;Parent=transcript:ENST_A;rank=1
+1\ttest\tmRNA\t1000\t2000\t.\t+\t.\tID=transcript:ENST_N;Parent=gene:ENSG_A;biotype=protein_coding;tag=gencode_basic
+1\ttest\texon\t1000\t2000\t.\t+\t.\tID=exon:E_N;Parent=transcript:ENST_N;rank=1";
+
+        let transcripts = parse_gff3(gff.as_bytes()).unwrap();
+        let appris_of = |id: &str| {
+            transcripts
+                .iter()
+                .find(|t| &*t.stable_id == id)
+                .unwrap_or_else(|| panic!("{id} missing"))
+                .appris
+                .clone()
+        };
+        assert_eq!(appris_of("ENST_P").as_deref(), Some("P1"));
+        assert_eq!(appris_of("ENST_A").as_deref(), Some("ALT2"));
+        // No APPRIS tag is not "unannotated principal": it stays absent, which
+        // is what Ensembl's own GFF3 gives for every transcript.
+        assert_eq!(appris_of("ENST_N"), None);
+    }
+
+    /// Every spelling the tag has had, and the two ways it can be absent.
+    #[test]
+    fn test_appris_from_tags_spellings() {
+        let cases = [
+            ("appris_principal_1", Some("P1")),
+            ("appris_principal1", Some("P1")),
+            ("appris_principal", Some("P")),
+            ("appris_alternative_2", Some("ALT2")),
+            ("appris_alternative2", Some("ALT2")),
+            ("appris_alternative", Some("ALT")),
+            ("gencode_basic,MANE_Select,appris_principal_4", Some("P4")),
+            ("APPRIS_PRINCIPAL_3", Some("P3")),
+            ("gencode_basic,Ensembl_canonical", None),
+            ("", None),
+            // Not APPRIS, and close enough to catch a prefix match that is too
+            // eager: `appris_` is required, and so is a class after it.
+            ("apprisal", None),
+            ("appris_something_else", None),
+        ];
+        for (tags, want) in cases {
+            assert_eq!(appris_from_tags(tags).as_deref(), want, "tag list {tags:?}");
+        }
+    }
+
     #[test]
     fn test_parse_gff3_ncrna_gene_keeps_symbol() {
         let gff = "##gff-version 3

--- a/crates/fastvep-cache/src/transcript_cache.rs
+++ b/crates/fastvep-cache/src/transcript_cache.rs
@@ -13,10 +13,13 @@ use std::time::SystemTime;
 
 /// Magic header for zstd-compressed caches (current format).
 ///
-/// Like V3 before it, V4 differs from its predecessor in nothing but the
-/// guarantee it carries: every V4 cache was written by a build whose GFF3
-/// parser recognises `ncRNA_gene` records (#98). See [`load_cache_zstd`] for
-/// why that has to be a format bump rather than a note in the changelog.
+/// Like V3 and V4 before it, V5 differs from its predecessor in nothing but
+/// the guarantee it carries: every V5 cache was written by a build whose GFF3
+/// parser reads the `appris_*` tags. See [`load_cache_zstd`] for why that has
+/// to be a format bump rather than a note in the changelog.
+const CACHE_MAGIC_V5: &[u8; 8] = b"FSTVEP05";
+/// Magic header for zstd caches written before the APPRIS fix (rejected, see
+/// [`load_cache_zstd`]).
 const CACHE_MAGIC_V4: &[u8; 8] = b"FSTVEP04";
 /// Magic header for zstd caches written before #98 (rejected, see
 /// [`load_cache_zstd`]).
@@ -38,6 +41,22 @@ const DETAIL_PRE_90: &str = "Caches written between 2026-06-10 (the tabix read \
      run - the #87 failure, which reported 47,196 of 47,196 chr17 variants as \
      intergenic at exit code 0. Nothing in the file distinguishes the two, so it \
      is rejected rather than read.";
+
+/// One line naming what is wrong with a pre-APPRIS cache.
+const SUMMARY_PRE_APPRIS: &str = "predates the APPRIS fix and carries no APPRIS \
+     tier for any transcript";
+
+/// The evidence behind [`SUMMARY_PRE_APPRIS`], for the caller that has to stop.
+const DETAIL_PRE_APPRIS: &str = "The GFF3 parser that wrote it dropped the \
+     `appris_principal_*` / `appris_alternative_*` tags GENCODE carries in the \
+     same `tag=` list as MANE_Select, so every transcript in the file has an \
+     empty APPRIS column and `--pick` reaches the APPRIS tier to find every \
+     candidate equal - at a locus where two genes' canonical transcripts \
+     overlap and neither is MANE, the pick then falls through to TSL and \
+     finally to alphabetical transcript ID. Ensembl's own GFF3 has no APPRIS \
+     tag to lose, so a cache built from one is unchanged by the rebuild; \
+     nothing in the file says which source it came from, so it is rejected \
+     rather than read.";
 
 /// One line naming what is wrong with a pre-#98 cache.
 const SUMMARY_PRE_98: &str = "predates the #98 fix and holds unnamed non-coding \
@@ -155,7 +174,7 @@ pub fn save_cache(transcripts: &[Transcript], path: &Path) -> Result<()> {
 
     // Write magic header
     use std::io::Write;
-    zst.write_all(CACHE_MAGIC_V4)?;
+    zst.write_all(CACHE_MAGIC_V5)?;
 
     // Serialize with bincode
     bincode::serialize_into(&mut zst, transcripts)
@@ -244,6 +263,14 @@ pub fn load_cache(path: &Path) -> Result<Vec<Transcript>> {
 /// that nothing downstream can detect. Same trade as #88's decision to error
 /// rather than annotate against an empty transcript set.
 ///
+/// `FSTVEP04` is rejected on the same grounds as `FSTVEP03`: the parser that
+/// wrote it could not see GENCODE's `appris_*` tags, and the sidecar path
+/// reuses a cache whenever it is newer than its GFF3, so without a bump the
+/// APPRIS column stays empty and `--pick`'s APPRIS tier stays inert after the
+/// upgrade. A V4 cache loads cleanly; it just has no APPRIS call for any
+/// transcript, which is indistinguishable from an Ensembl source that never
+/// carried one.
+///
 /// `FSTVEP03` is rejected for the same reason at one remove. #98 fixed the GFF3
 /// parser, not the caches it had already written, and the sidecar path reuses a
 /// cache whenever it is newer than its GFF3 - so without a bump the user who
@@ -274,8 +301,16 @@ fn load_cache_zstd<R: std::io::Read>(reader: R) -> Result<Vec<Transcript>> {
         }
         .into());
     }
-    if &magic != CACHE_MAGIC_V4 {
-        anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP04)");
+    if &magic == CACHE_MAGIC_V4 {
+        return Err(StaleCacheFormat {
+            found: "FSTVEP04",
+            summary: SUMMARY_PRE_APPRIS,
+            detail: DETAIL_PRE_APPRIS,
+        }
+        .into());
+    }
+    if &magic != CACHE_MAGIC_V5 {
+        anyhow::bail!("Invalid cache file (wrong magic header, expected FSTVEP05)");
     }
 
     let transcripts: Vec<Transcript> = bincode::deserialize_from(&mut zst)
@@ -732,7 +767,7 @@ mod tests {
     }
 
     #[test]
-    fn the_published_magic_is_v4() {
+    fn the_published_magic_is_v5() {
         // Pin the on-disk byte, so a future change to the writer that forgets
         // the reader shows up here rather than in someone's annotation.
         use std::io::Read;
@@ -742,6 +777,6 @@ mod tests {
         let mut zst = zstd::Decoder::new(BufReader::new(File::open(tmp.path()).unwrap())).unwrap();
         let mut magic = [0u8; 8];
         zst.read_exact(&mut magic).unwrap();
-        assert_eq!(&magic, CACHE_MAGIC_V4, "published magic drifted from V4");
+        assert_eq!(&magic, CACHE_MAGIC_V5, "published magic drifted from V5");
     }
 }

--- a/crates/fastvep-cli/tests/appris_pick_tier.rs
+++ b/crates/fastvep-cli/tests/appris_pick_tier.rs
@@ -1,0 +1,198 @@
+//! `--pick`'s APPRIS tier has to be able to decide something.
+//!
+//! `pick.rs` scores eight tiers in VEP's `--pick_order`, and three unit tests
+//! covered the APPRIS one. All three passed, and the tier had never decided a
+//! pick in production: they built `TranscriptVariation` by hand, and the GFF3
+//! parser wrote `appris: None` on every transcript it had ever produced. The
+//! criterion returned the same constant for every candidate, so it could only
+//! ever be a no-op, and the APPRIS column of every CSQ line was empty.
+//!
+//! The tier matters exactly where two genes overlap: each gene has its own
+//! canonical transcript, so `canonical` cannot separate them, and if neither is
+//! MANE the next tier that can is APPRIS. That is the case this file builds -
+//! two overlapping protein-coding genes, both canonical, neither MANE, equal
+//! TSL, equal biotype, equal consequence - so every tier above and below APPRIS
+//! is tied and the pick is decided by APPRIS or by nothing.
+//!
+//! Driven through `run_annotate` rather than `pick_best_transcript_idx` on
+//! purpose: the defect was in the parser, and a test that builds the struct
+//! itself cannot see it. That is what the three unit tests were.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use fastvep_cli::pipeline::{run_annotate, AnnotateConfig};
+use tempfile::TempDir;
+
+/// Two overlapping protein-coding genes with GENCODE's APPRIS tags.
+///
+/// `ENST_ALT` sorts before `ENST_PRIN` alphabetically, which is `pick`'s final
+/// tie-break, so with the APPRIS tier inert the wrong one wins. Reversing the
+/// two IDs would make this test pass against the broken code.
+fn write_gff3(dir: &Path) -> PathBuf {
+    let path = dir.join("ann.gff3");
+    std::fs::write(
+        &path,
+        "1\ttest\tgene\t1001\t1200\t.\t+\t.\tID=gene:ENSG_A;Name=GENEA;biotype=protein_coding\n\
+         1\ttest\tmRNA\t1001\t1200\t.\t+\t.\tID=transcript:ENST_PRIN;Parent=gene:ENSG_A;biotype=protein_coding;tag=gencode_basic,Ensembl_canonical,appris_principal_1;transcript_support_level=1\n\
+         1\ttest\texon\t1001\t1200\t.\t+\t.\tID=exon:E_PRIN;Parent=transcript:ENST_PRIN;rank=1\n\
+         1\ttest\tCDS\t1001\t1200\t.\t+\t0\tID=CDS:P_PRIN;Parent=transcript:ENST_PRIN\n\
+         1\ttest\tgene\t1001\t1200\t.\t+\t.\tID=gene:ENSG_B;Name=GENEB;biotype=protein_coding\n\
+         1\ttest\tmRNA\t1001\t1200\t.\t+\t.\tID=transcript:ENST_ALT;Parent=gene:ENSG_B;biotype=protein_coding;tag=gencode_basic,Ensembl_canonical,appris_alternative_2;transcript_support_level=1\n\
+         1\ttest\texon\t1001\t1200\t.\t+\t.\tID=exon:E_ALT;Parent=transcript:ENST_ALT;rank=1\n\
+         1\ttest\tCDS\t1001\t1200\t.\t+\t0\tID=CDS:P_ALT;Parent=transcript:ENST_ALT\n",
+    )
+    .unwrap();
+    path
+}
+
+fn write_fasta(dir: &Path) -> PathBuf {
+    let mut seq = vec![b'N'; 1_300];
+    // 200 coding bases starting at 1-based 1001, opening with ATG.
+    seq[1000..1003].copy_from_slice(b"ATG");
+    let path = dir.join("ref.fa");
+    let mut f = File::create(&path).unwrap();
+    writeln!(f, ">1").unwrap();
+    for chunk in seq.chunks(60) {
+        f.write_all(chunk).unwrap();
+        f.write_all(b"\n").unwrap();
+    }
+    path
+}
+
+fn write_vcf(dir: &Path) -> PathBuf {
+    let path = dir.join("in.vcf");
+    let mut f = File::create(&path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(f, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO").unwrap();
+    writeln!(f, "1\t1100\t.\tN\tA\t.\t.\t.").unwrap();
+    path
+}
+
+fn config(input: &Path, out: &Path) -> AnnotateConfig {
+    AnnotateConfig {
+        input: input.to_string_lossy().into(),
+        output: out.to_string_lossy().into(),
+        gff3: vec![],
+        fasta: None,
+        output_format: "vcf".into(),
+        pick: false,
+        hgvs: false,
+        distance: 5000,
+        cache_dir: None,
+        transcript_cache: None,
+        sa_dir: None,
+        sa_only: false,
+        acmg: false,
+        acmg_config: None,
+        pick_order: None,
+        functional_evidence: None,
+        proband: None,
+        mother: None,
+        father: None,
+        gene_list: None,
+        explicit_alleles: false,
+        qc_rules: None,
+        show_progress: false,
+    }
+}
+
+fn csq_entries(annotated: &str) -> Vec<Vec<String>> {
+    let line = annotated
+        .lines()
+        .find(|l| !l.starts_with('#'))
+        .unwrap_or_else(|| panic!("no annotated record in:\n{annotated}"));
+    let info = line.split('\t').nth(7).expect("INFO column");
+    let csq = info
+        .split(';')
+        .find_map(|kv| kv.strip_prefix("CSQ="))
+        .unwrap_or_else(|| panic!("no CSQ on:\n{line}"));
+    csq.split(',')
+        .map(|e| e.split('|').map(str::to_string).collect())
+        .collect()
+}
+
+fn field_idx(name: &str) -> usize {
+    fastvep_io::output::DEFAULT_CSQ_FIELDS
+        .iter()
+        .position(|f| *f == name)
+        .unwrap_or_else(|| panic!("{name} is a default CSQ field"))
+}
+
+fn annotate(dir: &Path, pick: bool, pick_order: Option<&str>) -> String {
+    let gff3 = write_gff3(dir);
+    let fasta = write_fasta(dir);
+    let vcf = write_vcf(dir);
+    let out = dir.join(format!(
+        "out-{}-{}.vcf",
+        pick,
+        pick_order.unwrap_or("default")
+    ));
+    run_annotate(AnnotateConfig {
+        gff3: vec![gff3.to_string_lossy().into()],
+        fasta: Some(fasta.to_string_lossy().into()),
+        pick,
+        pick_order: pick_order.map(str::to_string),
+        ..config(&vcf, &out)
+    })
+    .expect("annotation should succeed");
+    std::fs::read_to_string(&out).unwrap()
+}
+
+#[test]
+fn a_gencode_appris_tag_reaches_the_csq_column() {
+    let dir = TempDir::new().unwrap();
+    let annotated = annotate(dir.path(), false, None);
+
+    let (feature, appris) = (field_idx("Feature"), field_idx("APPRIS"));
+    let entries = csq_entries(&annotated);
+
+    let of = |tx: &str| {
+        entries
+            .iter()
+            .find(|f| f.get(feature).map(String::as_str) == Some(tx))
+            .unwrap_or_else(|| panic!("no CSQ entry for {tx} in:\n{annotated}"))
+            .get(appris)
+            .cloned()
+            .unwrap_or_default()
+    };
+
+    // Empty for both before the parser read `tag=appris_*`.
+    assert_eq!(of("ENST_PRIN"), "P1", "in:\n{annotated}");
+    assert_eq!(of("ENST_ALT"), "ALT2", "in:\n{annotated}");
+}
+
+#[test]
+fn pick_prefers_the_appris_principal_transcript() {
+    let dir = TempDir::new().unwrap();
+    let annotated = annotate(dir.path(), true, None);
+
+    let feature = field_idx("Feature");
+    let entries = csq_entries(&annotated);
+    assert_eq!(entries.len(), 1, "--pick kept more than one: {entries:?}");
+    assert_eq!(
+        entries[0].get(feature).map(String::as_str),
+        Some("ENST_PRIN"),
+        "the APPRIS tier did not decide the pick; `ENST_ALT` is what the \
+         alphabetical transcript-ID tie-break returns, in:\n{annotated}"
+    );
+}
+
+#[test]
+fn an_explicit_appris_first_pick_order_is_honoured() {
+    let dir = TempDir::new().unwrap();
+    // APPRIS ahead of everything. Before the parser populated the field this
+    // was accepted and silently changed nothing, which is the behaviour
+    // `parse_pick_order` refuses to allow for `length`.
+    let annotated = annotate(dir.path(), true, Some("appris,mane_select,canonical,rank"));
+
+    let feature = field_idx("Feature");
+    let entries = csq_entries(&annotated);
+    assert_eq!(entries.len(), 1, "--pick kept more than one: {entries:?}");
+    assert_eq!(
+        entries[0].get(feature).map(String::as_str),
+        Some("ENST_PRIN"),
+        "`--pick-order appris,...` did not change the pick, in:\n{annotated}"
+    );
+}

--- a/crates/fastvep-cli/tests/transcript_cache_integrity.rs
+++ b/crates/fastvep-cli/tests/transcript_cache_integrity.rs
@@ -257,7 +257,7 @@ fn a_pre_90_sidecar_cache_is_rebuilt_rather_than_trusted() {
             .unwrap();
     }
     assert_eq!(
-        &magic, b"FSTVEP04",
+        &magic, b"FSTVEP05",
         "rebuild should publish the current format"
     );
 }
@@ -303,6 +303,50 @@ fn a_pre_98_sidecar_cache_is_rebuilt_rather_than_trusted() {
     assert!(
         annotated.contains("missense_variant"),
         "the run trusted a pre-#98 cache and lost the annotation; got:\n{annotated}"
+    );
+}
+
+/// Write a well-formed cache in the pre-APPRIS FSTVEP04 format. Whole-file,
+/// every gene named - the only thing wrong with it is that the parser which
+/// filled it did not read GENCODE's `appris_*` tags, so no transcript in it
+/// carries an APPRIS call and `--pick`'s APPRIS tier has nothing to compare.
+fn write_v4_cache(path: &Path, transcripts: &[fastvep_genome::Transcript]) {
+    use std::io::{BufWriter, Write};
+    let file = File::create(path).unwrap();
+    let mut zst = zstd::Encoder::new(BufWriter::new(file), 1).unwrap();
+    zst.write_all(b"FSTVEP04").unwrap();
+    bincode::serialize_into(&mut zst, transcripts).unwrap();
+    zst.finish().unwrap().flush().unwrap();
+}
+
+#[test]
+fn a_pre_appris_sidecar_cache_is_rebuilt_rather_than_trusted() {
+    // Third instance of the same gap: the sidecar is newer than its GFF3, so a
+    // user who upgrades and re-runs the identical command never re-parses the
+    // file, and the APPRIS column stays empty and the pick stays wrong. The
+    // cache loads cleanly; nothing in it distinguishes "GENCODE model whose
+    // APPRIS tags were dropped" from "Ensembl model that never had any".
+    let dir = TempDir::new().unwrap();
+    let gff3 = write_gff3(dir.path());
+    let fasta = write_fasta(dir.path());
+    let vcf = write_vcf(dir.path());
+
+    let sidecar = dir.path().join("ann.gff3.fastvep.cache");
+    write_v4_cache(&sidecar, &[]);
+    make_fresh(&sidecar);
+
+    let out = dir.path().join("out.vcf");
+    run_annotate(AnnotateConfig {
+        gff3: vec![gff3.to_string_lossy().into()],
+        fasta: Some(fasta.to_string_lossy().into()),
+        ..config(&vcf, &out)
+    })
+    .expect("a pre-APPRIS sidecar should be rebuilt from the GFF3, not fatal");
+
+    let annotated = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        annotated.contains("missense_variant"),
+        "the run trusted a pre-APPRIS cache and lost the annotation; got:\n{annotated}"
     );
 }
 

--- a/docs/ACMG.md
+++ b/docs/ACMG.md
@@ -597,6 +597,14 @@ clinical reporting, and the round-2 review caught it: CYP21A2 variants were repo
 the neighbouring gene's MANE transcript outranked the disrupted non-MANE one.
 Stock VEP makes the same choice; this is not a fastVEP deviation.
 
+The `appris` tier is only as good as the gene model.
+APPRIS reaches fastVEP through GENCODE's `tag=appris_principal_1` / `tag=appris_alternative_2`
+attributes; **Ensembl's own GFF3 carries no APPRIS tag at all**, so on an Ensembl model every
+transcript scores the same at that tier and the pick falls through to `tsl`.
+That is the same answer VEP gives from the same file, but it is worth knowing which tier is
+actually deciding: at a locus where two genes' canonical transcripts overlap and neither is MANE,
+an Ensembl model decides the pick on TSL, and a GENCODE model decides it on APPRIS.
+
 For clinical reporting, put `rank` first:
 
 ```bash


### PR DESCRIPTION
`--pick` scores VEP's eight `--pick_order` tiers. One of them has never been able to separate two transcripts.

`Transcript::appris` is filled by the GFF3 parser, and the parser had `appris: None` written in as a literal ([`gff.rs`](https://github.com/Huang-lab/fastVEP/blob/e3d4c35/crates/fastvep-cache/src/gff.rs#L744)). So `PickCriterion::Appris` returned the same constant for every candidate on every run, and the `APPRIS` column of every CSQ line came out empty.

## Showing it

Two overlapping protein-coding genes, each with its own canonical transcript, neither MANE, equal TSL, equal biotype, equal consequence. The only thing that differs is the APPRIS call, so APPRIS is the only tier that can decide.

```console
$ grep -o 'appris_[a-z_0-9]*' appris.gff3
appris_principal_1      # ENST00000000002, GENEA
appris_alternative_2    # ENST00000000001, GENEB

$ fastvep annotate -i appris.vcf --gff3 appris.gff3 --output-format json --pick --symbol
```

| | transcript picked | `appris` in the output |
|---|---|---|
| before | `ENST00000000001` (GENEB, **alternative_2**) | *(field absent)* |
| after | `ENST00000000002` (GENEA, **principal_1**) | `P1` |

`ENST00000000001` is what the *alphabetical transcript-ID tie-break* returns, which is the last thing `pick` tries. Every tier from APPRIS down was tied, so the pick was decided by the sort order of the accession.

And putting APPRIS first changed nothing, which is how you can tell the tier was absent rather than out of position:

```console
$ fastvep annotate ... --pick --pick-order appris,mane_select,canonical
ENST00000000001   GENEB    # unchanged
```

That is exactly the failure `parse_pick_order` already refuses to allow for `length`:

> `'length' is not supported; ... honouring it would mean silently doing nothing - worse than saying so.`

## Why it matters, and where

The tier only decides at a locus where two genes overlap: each gene has its own `Ensembl_canonical`, so `canonical` cannot separate them, and if neither is MANE the next tier that can is APPRIS.

That locus is not exotic - it is the shape `docs/ACMG.md` already measures. CYP21A2 variants reported on **C4B**, STRC-region variants on **TIMM9**: 43 of 300 and 32 of 300 respectively. Those are gene-overlap loci resolved by tiers below `canonical`, and APPRIS is the first of them.

## Why three passing unit tests did not catch it

`pick.rs` has three APPRIS tests. All three passed throughout:

```
pick_prefers_lower_appris_principal          ok
pick_prefers_principal_over_alternative_appris   ok
pick_accepts_long_form_appris_tags           ok
```

They build `TranscriptVariation` by hand, with `appris: Some("P1")` supplied directly. Nothing in the suite went through the parser, which is the component that was wrong. One of them even carries the comment *"Ensembl GFF3 sometimes uses `principal1` / `alternative2`"* - Ensembl's GFF3 carries no APPRIS tag at all, and GENCODE spells it `appris_principal_1`. The tests pinned a vocabulary the code never met.

The new integration test drives `run_annotate` over a GFF3 instead. That is the only shape that could have caught this, and it is the general lesson: **a tier fed by a parser needs one test that reaches it through the parser.**

## What changed

**`gff.rs` reads the tag.** `appris_principal_*` / `appris_alternative_*` come out of the same comma-separated `tag=` attribute the parser already reads `MANE_Select`, `Ensembl_canonical`, `gencode_primary` and the `cds_*_NF` flags from. Stored as VEP's short form (`P1`, `ALT2`).

Ensembl's own GFF3 has no APPRIS tag, so it stays `None` there and the tier stays inert for that source - correctly, because there is nothing to decide with. GENCODE's GFF3 has it. `docs/ACMG.md` now says which source feeds the tier, since "the pick is decided on TSL" and "the pick is decided on APPRIS" are different runs and the file you passed decides which.

**`appris_rank` learns the spellings that now reach it.** It understood `P1` and `principal1`. It did not understand:

- `ALT1` / `ALT2` - both fell through to the bare-`a` arm, `lt1` and `lt2` both failed to parse, and both landed on the same fallback tier. Two alternatives could not be ordered against each other.
- the raw `appris_principal_1` - same arm, so a *principal* call scored below every alternative.
- a bare `appris_principal` (older GENCODE) - landed in the middle of the numbered alternatives rather than at the end of the principals.

The bands are now spaced and named, so each class has room for its tiers and an un-numbered call sits at the end of its own class:

```
P1 < … < P5 < P < ALT1 < ALT2 < ALT < unrecognised < absent
```

**Cache format `FSTVEP04` → `FSTVEP05`.** Same grounds as the V3→V4 bump for #98, and it is the part worth arguing with if you are going to argue with any of it. A V4 cache loads cleanly and has no APPRIS call for any transcript, which is indistinguishable from an Ensembl source that never had one. The sidecar path reuses a cache whenever it is newer than its GFF3, so without the bump an upgrade leaves the tier inert: same command, same wrong answer, nothing to indicate why. Rebuilding an Ensembl-sourced cache changes nothing in it - the cost is one rebuild, and it falls on Ensembl users who gain nothing from the fix. I think that is the right trade for the same reason #98 was, but it is a real cost.

## Tests

9 new.

| | |
|---|---|
| `crates/fastvep-cli/tests/appris_pick_tier.rs` | 3, through `run_annotate` over a GENCODE-style GFF3: the tag reaches the CSQ column, the default order picks the principal, `--pick-order appris,…` is honoured |
| `gff.rs` | 2: the parser fills `Transcript::appris`; every spelling of the tag, and two near-misses that must *not* match (`apprisal`, `appris_something_else`) |
| `pick.rs` | 3: alternatives ordered by tier, all four spellings of principal-1 ranked identically and ahead of every spelling of alternative-2, un-numbered calls at the end of their class |
| `transcript_cache_integrity.rs` | 1: a pre-APPRIS sidecar is rebuilt rather than trusted |

**Mutation-checked.** Restoring `appris: None` fails all four parser-facing tests; restoring the old `appris_rank` fails all three ranker tests.

One of them failed the mutation check on the first draft and had to be rewritten: `appris_orders_alternatives_by_their_tier` originally named the transcripts `TX_ALT1` / `TX_ALT2`, so when the ranker tied them the alphabetical tie-break returned the right one anyway and the test passed against the broken code. The IDs are now `TX_Z` (better call) and `TX_A` (worse call), so a tie returns the wrong one.

Workspace: **1038 passed, 0 failed**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.

## Not in here

- Whether `ALT1`/`ALT2` is exactly the string Ensembl VEP prints for an alternative, or whether it prints `A1`/`A2`. `vep_compat.rs` pins `P1` and `P3` and has no alternative case, and I did not have a VEP install to check against. It affects the CSQ column's text only - `appris_rank` handles both spellings identically, so the pick is unaffected either way. Worth one `vep --appris` run on a locus with an `appris_alternative_*` transcript to settle it.
- RefSeq GFF3, which carries no APPRIS tag either. Unchanged.

*Filed from the 2026-09-02 Huang Lab code review.*
